### PR TITLE
Merging changes made by Coverdell to remove the use of filestreams

### DIFF
--- a/LitleSdkForNet/LitleSdkForNet/Communications.cs
+++ b/LitleSdkForNet/LitleSdkForNet/Communications.cs
@@ -1,22 +1,16 @@
 ﻿using System;
-using System.IO;
-using System.Xml;
-using System.Xml.Serialization;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Text;
-using System.Xml.XPath;
+using System.IO;
 using System.Net;
-using Tamir.SharpSsh.jsch;
-using Tamir.SharpSsh;
-using System.Timers;
-using System.Net.Sockets;
 using System.Net.Security;
+using System.Net.Sockets;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
-using System.Reflection;
-using System.Runtime.CompilerServices;
+using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
+using Tamir.SharpSsh.jsch;
 
 namespace Litle.Sdk
 {
@@ -32,17 +26,14 @@ namespace Litle.Sdk
 
         public StringBuilder this[string key]
         {
-            get
-            {
-                return _cache[key];
-            }
+            get { return _cache[key]; }
         }
 
         public static bool ValidateServerCertificate(
-             object sender,
-             X509Certificate certificate,
-             X509Chain chain,
-             SslPolicyErrors sslPolicyErrors)
+            object sender,
+            X509Certificate certificate,
+            X509Chain chain,
+            SslPolicyErrors sslPolicyErrors)
         {
             if (sslPolicyErrors == SslPolicyErrors.None)
                 return true;
@@ -55,17 +46,16 @@ namespace Litle.Sdk
 
         public void neuterXML(ref string inputXml)
         {
+            var pattern1 = "(?i)<number>.*?</number>";
+            var pattern2 = "(?i)<accNum>.*?</accNum>";
 
-            string pattern1 = "(?i)<number>.*?</number>";
-            string pattern2 = "(?i)<accNum>.*?</accNum>";
-
-            Regex rgx1 = new Regex(pattern1);
-            Regex rgx2 = new Regex(pattern2);
+            var rgx1 = new Regex(pattern1);
+            var rgx2 = new Regex(pattern2);
             inputXml = rgx1.Replace(inputXml, "<number>xxxxxxxxxxxxxxxx</number>");
             inputXml = rgx2.Replace(inputXml, "<accNum>xxxxxxxxxx</accNum>");
         }
-        
-        public void log(String logMessage, String logFile, bool neuter)
+
+        public void log(string logMessage, string logFile, bool neuter)
         {
             lock (_synLock)
             {
@@ -73,40 +63,43 @@ namespace Litle.Sdk
                 {
                     neuterXML(ref logMessage);
                 }
-                StreamWriter logWriter = new StreamWriter(logFile, true);
-                DateTime time = DateTime.Now;
+                var logWriter = new StreamWriter(logFile, true);
+                var time = DateTime.Now;
                 logWriter.WriteLine(time.ToString());
                 logWriter.WriteLine(logMessage + "\r\n");
                 logWriter.Close();
             }
         }
 
-        virtual public string HttpPost(string xmlRequest, Dictionary<String, String> config)
+        public virtual string HttpPost(string xmlRequest, Dictionary<string, string> config)
         {
             string logFile = null;
             if (config.ContainsKey("logFile"))
             {
                 logFile = config["logFile"];
             }
-            
-            string uri = config["url"];
-            System.Net.ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls; 
-            System.Net.HttpWebRequest req = (System.Net.HttpWebRequest)System.Net.WebRequest.Create(uri);
-            
-            bool neuter = false;
+
+            var uri = config["url"];
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 |
+                                                   SecurityProtocolType.Tls;
+            var req = (HttpWebRequest) WebRequest.Create(uri);
+
+            var neuter = false;
             if (config.ContainsKey("neuterAccountNums"))
             {
                 neuter = ("true".Equals(config["neuterAccountNums"]));
             }
 
-            bool printxml = false;
+            var printxml = false;
             if (config.ContainsKey("printxml"))
             {
-                if("true".Equals(config["printxml"])) {
+                if ("true".Equals(config["printxml"]))
+                {
                     printxml = true;
                 }
             }
-            if(printxml) {
+            if (printxml)
+            {
                 Console.WriteLine(xmlRequest);
                 Console.WriteLine(logFile);
             }
@@ -114,7 +107,7 @@ namespace Litle.Sdk
             //log request
             if (logFile != null)
             {
-                log(xmlRequest,logFile, neuter);
+                log(xmlRequest, logFile, neuter);
             }
 
             req.ContentType = "text/xml";
@@ -123,7 +116,7 @@ namespace Litle.Sdk
             req.ServicePoint.Expect100Continue = false;
             if (isProxyOn(config))
             {
-                WebProxy myproxy = new WebProxy(config["proxyHost"], int.Parse(config["proxyPort"]));
+                var myproxy = new WebProxy(config["proxyHost"], int.Parse(config["proxyPort"]));
                 myproxy.BypassProxyOnLocal = true;
                 req.Proxy = myproxy;
             }
@@ -135,15 +128,14 @@ namespace Litle.Sdk
             }
 
 
-
             // read response
-            System.Net.WebResponse resp = req.GetResponse();
+            var resp = req.GetResponse();
             if (resp == null)
             {
                 return null;
             }
             string xmlResponse;
-            using (var reader = new System.IO.StreamReader(resp.GetResponseStream()))
+            using (var reader = new StreamReader(resp.GetResponseStream()))
             {
                 xmlResponse = reader.ReadToEnd().Trim();
             }
@@ -155,27 +147,30 @@ namespace Litle.Sdk
             //log response
             if (logFile != null)
             {
-                log(xmlResponse,logFile,neuter);
+                log(xmlResponse, logFile, neuter);
             }
 
             return xmlResponse;
         }
 
-        public bool isProxyOn(Dictionary<String,String> config) {
-            return config.ContainsKey("proxyHost") && config["proxyHost"] != null && config["proxyHost"].Length > 0 && config.ContainsKey("proxyPort") && config["proxyPort"] != null && config["proxyPort"].Length > 0;
+        public bool isProxyOn(Dictionary<string, string> config)
+        {
+            return config.ContainsKey("proxyHost") && config["proxyHost"] != null && config["proxyHost"].Length > 0 &&
+                   config.ContainsKey("proxyPort") && config["proxyPort"] != null && config["proxyPort"].Length > 0;
         }
 
-        virtual public string socketStream(string xmlRequestFilePath, string xmlResponseDestinationDirectory, Dictionary<String, String> config)
+        public virtual string socketStream(string xmlRequestFilePath, string xmlResponseDestinationDirectory,
+            Dictionary<string, string> config)
         {
-            string url = config["onlineBatchUrl"];
-            int port = Int32.Parse(config["onlineBatchPort"]);
+            var url = config["onlineBatchUrl"];
+            var port = int.Parse(config["onlineBatchPort"]);
             TcpClient tcpClient = null;
             SslStream sslStream = null;
 
             try
             {
                 tcpClient = new TcpClient(url, port);
-                sslStream = new SslStream(tcpClient.GetStream(), false, new RemoteCertificateValidationCallback(ValidateServerCertificate), null);
+                sslStream = new SslStream(tcpClient.GetStream(), false, ValidateServerCertificate, null);
             }
             catch (SocketException e)
             {
@@ -202,15 +197,15 @@ namespace Litle.Sdk
             sslStream.Write(buffer);
             sslStream.Flush();
 
-            string batchName = Path.GetFileName(xmlRequestFilePath);
+            var batchName = Path.GetFileName(xmlRequestFilePath);
             if ("true".Equals(config["printxml"]))
             {
                 Console.WriteLine("Writing to XML File: " + xmlResponseDestinationDirectory + batchName);
             }
 
-            byte[] byteBuffer = new byte[2048];
-            StringBuilder messageData = new StringBuilder();
-            int bytes = -1;
+            var byteBuffer = new byte[2048];
+            var messageData = new StringBuilder();
+            var bytes = -1;
             do
             {
                 // Read the client's test message.
@@ -223,7 +218,7 @@ namespace Litle.Sdk
                 decoder.GetChars(byteBuffer, 0, bytes, chars, 0);
                 messageData.Append(chars);
             } while (bytes != 0);
-            
+
             _cache.Add(xmlResponseDestinationDirectory + batchName, messageData);
 
             tcpClient.Close();
@@ -232,18 +227,18 @@ namespace Litle.Sdk
             return xmlResponseDestinationDirectory + batchName;
         }
 
-        virtual public void FtpDropOff(string fileDirectory, string fileName, Dictionary<String, String> config)
+        public virtual void FtpDropOff(string fileDirectory, string fileName, Dictionary<string, string> config)
         {
             ChannelSftp channelSftp = null;
             Channel channel;
 
-            string url = config["sftpUrl"];
-            string username = config["sftpUsername"];
-            string password = config["sftpPassword"];
-            string knownHostsFile = config["knownHostsFile"];
-            string filePath = fileDirectory + fileName;
+            var url = config["sftpUrl"];
+            var username = config["sftpUsername"];
+            var password = config["sftpPassword"];
+            var knownHostsFile = config["knownHostsFile"];
+            var filePath = fileDirectory + fileName;
 
-            bool printxml = config["printxml"] == "true";
+            var printxml = config["printxml"] == "true";
             if (printxml)
             {
                 Console.WriteLine("Sftp Url: " + url);
@@ -252,10 +247,10 @@ namespace Litle.Sdk
                 Console.WriteLine("Known hosts file path: " + knownHostsFile);
             }
 
-            JSch jsch = new JSch();
+            var jsch = new JSch();
             jsch.setKnownHosts(knownHostsFile);
 
-            Session session = jsch.getSession(username, url);
+            var session = jsch.getSession(username, url);
             session.setPassword(password);
 
             try
@@ -264,11 +259,11 @@ namespace Litle.Sdk
 
                 channel = session.openChannel("sftp");
                 channel.connect();
-                channelSftp = (ChannelSftp)channel;
+                channelSftp = (ChannelSftp) channel;
             }
             catch (SftpException e)
             {
-                throw new LitleOnlineException("Error occured while attempting to establish an SFTP connection",e);
+                throw new LitleOnlineException("Error occured while attempting to establish an SFTP connection", e);
             }
             catch (JSchException e)
             {
@@ -284,7 +279,8 @@ namespace Litle.Sdk
                 channelSftp.put(filePath, "inbound/" + fileName + ".prg", ChannelSftp.OVERWRITE);
                 if (printxml)
                 {
-                    Console.WriteLine("File copied - renaming from inbound/" + fileName + ".prg to inbound/" + fileName + ".asc");
+                    Console.WriteLine("File copied - renaming from inbound/" + fileName + ".prg to inbound/" + fileName +
+                                      ".asc");
                 }
                 channelSftp.rename("inbound/" + fileName + ".prg", "inbound/" + fileName + ".asc");
             }
@@ -298,26 +294,27 @@ namespace Litle.Sdk
             session.disconnect();
         }
 
-        virtual public void FtpPoll(string fileName, int timeout, Dictionary<string, string> config)
+        public virtual void FtpPoll(string fileName, int timeout, Dictionary<string, string> config)
         {
             fileName = fileName + ".asc";
-            bool printxml = config["printxml"] == "true";
+            var printxml = config["printxml"] == "true";
             if (printxml)
             {
-                Console.WriteLine("Polling for outbound result file.  Timeout set to " + timeout + "ms. File to wait for is " + fileName);
+                Console.WriteLine("Polling for outbound result file.  Timeout set to " + timeout +
+                                  "ms. File to wait for is " + fileName);
             }
             ChannelSftp channelSftp = null;
             Channel channel;
 
-            string url = config["sftpUrl"];
-            string username = config["sftpUsername"];
-            string password = config["sftpPassword"];
-            string knownHostsFile = config["knownHostsFile"];
+            var url = config["sftpUrl"];
+            var username = config["sftpUsername"];
+            var password = config["sftpPassword"];
+            var knownHostsFile = config["knownHostsFile"];
 
-            JSch jsch = new JSch();
+            var jsch = new JSch();
             jsch.setKnownHosts(knownHostsFile);
 
-            Session session = jsch.getSession(username, url);
+            var session = jsch.getSession(username, url);
             session.setPassword(password);
 
             try
@@ -326,7 +323,7 @@ namespace Litle.Sdk
 
                 channel = session.openChannel("sftp");
                 channel.connect();
-                channelSftp = (ChannelSftp)channel;
+                channelSftp = (ChannelSftp) channel;
             }
             catch (SftpException e)
             {
@@ -335,7 +332,7 @@ namespace Litle.Sdk
 
             //check if file exists
             SftpATTRS sftpATTRS = null;
-            Stopwatch stopWatch = new Stopwatch();
+            var stopWatch = new Stopwatch();
             stopWatch.Start();
             do
             {
@@ -348,7 +345,7 @@ namespace Litle.Sdk
                     sftpATTRS = channelSftp.lstat("outbound/" + fileName);
                     if (printxml)
                     {
-                        Console.WriteLine("Attrs of file are: " + sftpATTRS.ToString());
+                        Console.WriteLine("Attrs of file are: " + sftpATTRS);
                     }
                 }
                 catch (SftpException e)
@@ -357,27 +354,27 @@ namespace Litle.Sdk
                     {
                         Console.WriteLine(e.message);
                     }
-                    System.Threading.Thread.Sleep(30000);
+                    Thread.Sleep(30000);
                 }
             } while (sftpATTRS == null && stopWatch.Elapsed.TotalMilliseconds <= timeout);
         }
 
-        virtual public void FtpPickUp(string destinationFilePath, Dictionary<String, String> config, string fileName)
+        public virtual void FtpPickUp(string destinationFilePath, Dictionary<string, string> config, string fileName)
         {
             ChannelSftp channelSftp = null;
             Channel channel;
 
-            bool printxml = config["printxml"] == "true";
+            var printxml = config["printxml"] == "true";
 
-            string url = config["sftpUrl"];
-            string username = config["sftpUsername"];
-            string password = config["sftpPassword"];
-            string knownHostsFile = config["knownHostsFile"];
+            var url = config["sftpUrl"];
+            var username = config["sftpUsername"];
+            var password = config["sftpPassword"];
+            var knownHostsFile = config["knownHostsFile"];
 
-            JSch jsch = new JSch();
+            var jsch = new JSch();
             jsch.setKnownHosts(knownHostsFile);
 
-            Session session = jsch.getSession(username, url);
+            var session = jsch.getSession(username, url);
             session.setPassword(password);
 
             try
@@ -386,7 +383,7 @@ namespace Litle.Sdk
 
                 channel = session.openChannel("sftp");
                 channel.connect();
-                channelSftp = (ChannelSftp)channel;
+                channelSftp = (ChannelSftp) channel;
             }
             catch (SftpException e)
             {
@@ -409,16 +406,16 @@ namespace Litle.Sdk
             }
             catch (SftpException e)
             {
-                throw new LitleOnlineException("Error occured while attempting to retrieve and save the file from SFTP", e);
+                throw new LitleOnlineException(
+                    "Error occured while attempting to retrieve and save the file from SFTP", e);
             }
 
             channelSftp.quit();
 
             session.disconnect();
-
         }
 
-      
+
         public struct SshConnectionInfo
         {
             public string Host;

--- a/LitleSdkForNet/LitleSdkForNet/Communications.cs
+++ b/LitleSdkForNet/LitleSdkForNet/Communications.cs
@@ -24,11 +24,6 @@ namespace Litle.Sdk
             _cache = cache;
         }
 
-        public StringBuilder this[string key]
-        {
-            get { return _cache[key]; }
-        }
-
         public static bool ValidateServerCertificate(
             object sender,
             X509Certificate certificate,
@@ -192,8 +187,8 @@ namespace Litle.Sdk
                 Console.WriteLine("Using XML File: " + xmlRequestFilePath);
             }
 
-            var memoryStream = this[xmlRequestFilePath];
-            var buffer = Encoding.UTF8.GetBytes(memoryStream.ToString());
+            var stringBuilder = _cache[xmlRequestFilePath];
+            var buffer = Encoding.UTF8.GetBytes(stringBuilder.ToString());
             sslStream.Write(buffer);
             sslStream.Flush();
 

--- a/LitleSdkForNet/LitleSdkForNet/Communications.cs
+++ b/LitleSdkForNet/LitleSdkForNet/Communications.cs
@@ -184,7 +184,7 @@ namespace Litle.Sdk
 
             try
             {
-                sslStream.AuthenticateAsClient(url);
+                sslStream.AuthenticateAsClient(url, new X509Certificate2Collection(), SslProtocols.Tls12, false);
             }
             catch (AuthenticationException e)
             {
@@ -198,7 +198,8 @@ namespace Litle.Sdk
             }
 
             var memoryStream = this[xmlRequestFilePath];
-            var buffer = Encoding.UTF8.GetBytes(memoryStream.ToString());
+            var value = memoryStream.ToString();
+            var buffer = Encoding.UTF8.GetBytes(value);
             sslStream.Write(buffer);
             sslStream.Flush();
 
@@ -208,16 +209,12 @@ namespace Litle.Sdk
                 Console.WriteLine("Writing to XML File: " + xmlResponseDestinationDirectory + batchName);
             }
 
-            byte[] byteBuffer = new byte[2048];
+            byte[] byteBuffer = new byte[tcpClient.ReceiveBufferSize];
             StringBuilder messageData = new StringBuilder();
             int bytes = -1;
             do
             {
-                // Read the client's test message.
                 bytes = sslStream.Read(byteBuffer, 0, byteBuffer.Length);
-
-                // Use Decoder class to convert from bytes to UTF8
-                // in case a character spans two buffers.
                 var decoder = Encoding.UTF8.GetDecoder();
                 var chars = new char[decoder.GetCharCount(byteBuffer, 0, bytes)];
                 decoder.GetChars(byteBuffer, 0, bytes, chars, 0);

--- a/LitleSdkForNet/LitleSdkForNet/Communications.cs
+++ b/LitleSdkForNet/LitleSdkForNet/Communications.cs
@@ -184,7 +184,7 @@ namespace Litle.Sdk
 
             try
             {
-                sslStream.AuthenticateAsClient(url, new X509Certificate2Collection(), SslProtocols.Tls12, false);
+                sslStream.AuthenticateAsClient(url);
             }
             catch (AuthenticationException e)
             {
@@ -198,8 +198,7 @@ namespace Litle.Sdk
             }
 
             var memoryStream = this[xmlRequestFilePath];
-            var value = memoryStream.ToString();
-            var buffer = Encoding.UTF8.GetBytes(value);
+            var buffer = Encoding.UTF8.GetBytes(memoryStream.ToString());
             sslStream.Write(buffer);
             sslStream.Flush();
 
@@ -209,12 +208,16 @@ namespace Litle.Sdk
                 Console.WriteLine("Writing to XML File: " + xmlResponseDestinationDirectory + batchName);
             }
 
-            byte[] byteBuffer = new byte[tcpClient.ReceiveBufferSize];
+            byte[] byteBuffer = new byte[2048];
             StringBuilder messageData = new StringBuilder();
             int bytes = -1;
             do
             {
+                // Read the client's test message.
                 bytes = sslStream.Read(byteBuffer, 0, byteBuffer.Length);
+
+                // Use Decoder class to convert from bytes to UTF8
+                // in case a character spans two buffers.
                 var decoder = Encoding.UTF8.GetDecoder();
                 var chars = new char[decoder.GetCharCount(byteBuffer, 0, bytes)];
                 decoder.GetChars(byteBuffer, 0, bytes, chars, 0);

--- a/LitleSdkForNet/LitleSdkForNet/LitleBatch.cs
+++ b/LitleSdkForNet/LitleSdkForNet/LitleBatch.cs
@@ -1,24 +1,23 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
-using System.Xml;
-using System.Xml.Serialization;
 using System.IO;
 using System.Security.Cryptography;
+using System.Text;
+using Litle.Sdk.Properties;
 
 namespace Litle.Sdk
 {
     public class litleRequest
     {
-        private IDictionary<string, StringBuilder> _memoryStreams; 
+        private readonly IDictionary<string, StringBuilder> _memoryStreams;
         private authentication authentication;
-        private Dictionary<String, String> config;
+        private readonly Dictionary<string, string> config;
         private Communications communication;
         private litleXmlSerializer litleXmlSerializer;
-        private int numOfLitleBatchRequest = 0;
-        private int numOfRFRRequest = 0;
-        public string finalFilePath = null;
-        private string batchFilePath = null;
+        private int numOfLitleBatchRequest;
+        private int numOfRFRRequest;
+        public string finalFilePath;
+        private string batchFilePath;
         private string requestDirectory;
         private string responseDirectory;
         private litleTime litleTime;
@@ -27,28 +26,29 @@ namespace Litle.Sdk
         /**
          * Construct a Litle online using the configuration specified in LitleSdkForNet.dll.config
          */
+
         public litleRequest(IDictionary<string, StringBuilder> memoryStreams)
         {
             _memoryStreams = memoryStreams;
             config = new Dictionary<string, string>();
 
-            config["url"] = Properties.Settings.Default.url;
-            config["reportGroup"] = Properties.Settings.Default.reportGroup;
-            config["username"] = Properties.Settings.Default.username;
-            config["printxml"] = Properties.Settings.Default.printxml;
-            config["timeout"] = Properties.Settings.Default.timeout;
-            config["proxyHost"] = Properties.Settings.Default.proxyHost;
-            config["merchantId"] = Properties.Settings.Default.merchantId;
-            config["password"] = Properties.Settings.Default.password;
-            config["proxyPort"] = Properties.Settings.Default.proxyPort;
-            config["sftpUrl"] = Properties.Settings.Default.sftpUrl;
-            config["sftpUsername"] = Properties.Settings.Default.sftpUsername;
-            config["sftpPassword"] = Properties.Settings.Default.sftpPassword;
-            config["knownHostsFile"] = Properties.Settings.Default.knownHostsFile;
-            config["onlineBatchUrl"] = Properties.Settings.Default.onlineBatchUrl;
-            config["onlineBatchPort"] = Properties.Settings.Default.onlineBatchPort;
-            config["requestDirectory"] = Properties.Settings.Default.requestDirectory;
-            config["responseDirectory"] = Properties.Settings.Default.responseDirectory;
+            config["url"] = Settings.Default.url;
+            config["reportGroup"] = Settings.Default.reportGroup;
+            config["username"] = Settings.Default.username;
+            config["printxml"] = Settings.Default.printxml;
+            config["timeout"] = Settings.Default.timeout;
+            config["proxyHost"] = Settings.Default.proxyHost;
+            config["merchantId"] = Settings.Default.merchantId;
+            config["password"] = Settings.Default.password;
+            config["proxyPort"] = Settings.Default.proxyPort;
+            config["sftpUrl"] = Settings.Default.sftpUrl;
+            config["sftpUsername"] = Settings.Default.sftpUsername;
+            config["sftpPassword"] = Settings.Default.sftpPassword;
+            config["knownHostsFile"] = Settings.Default.knownHostsFile;
+            config["onlineBatchUrl"] = Settings.Default.onlineBatchUrl;
+            config["onlineBatchPort"] = Settings.Default.onlineBatchPort;
+            config["requestDirectory"] = Settings.Default.requestDirectory;
+            config["responseDirectory"] = Settings.Default.responseDirectory;
 
             initializeRequest();
         }
@@ -77,7 +77,8 @@ namespace Litle.Sdk
          * requestDirectory
          * responseDirectory
          */
-        public litleRequest(IDictionary<string, StringBuilder> memoryStreams, Dictionary<String, String> config)
+
+        public litleRequest(IDictionary<string, StringBuilder> memoryStreams, Dictionary<string, string> config)
         {
             _memoryStreams = memoryStreams;
             this.config = config;
@@ -103,17 +104,17 @@ namespace Litle.Sdk
 
         public authentication getAuthenication()
         {
-            return this.authentication;
+            return authentication;
         }
 
         public string getRequestDirectory()
         {
-            return this.requestDirectory;
+            return requestDirectory;
         }
 
         public string getResponseDirectory()
         {
-            return this.responseDirectory;
+            return responseDirectory;
         }
 
         public void setCommunication(Communications communication)
@@ -123,7 +124,7 @@ namespace Litle.Sdk
 
         public Communications getCommunication()
         {
-            return this.communication;
+            return communication;
         }
 
         public void setLitleXmlSerializer(litleXmlSerializer litleXmlSerializer)
@@ -133,7 +134,7 @@ namespace Litle.Sdk
 
         public litleXmlSerializer getLitleXmlSerializer()
         {
-            return this.litleXmlSerializer;
+            return litleXmlSerializer;
         }
 
         public void setLitleTime(litleTime litleTime)
@@ -143,7 +144,7 @@ namespace Litle.Sdk
 
         public litleTime getLitleTime()
         {
-            return this.litleTime;
+            return litleTime;
         }
 
         public void setLitleFile(litleFile litleFile)
@@ -153,7 +154,7 @@ namespace Litle.Sdk
 
         public litleFile getLitleFile()
         {
-            return this.litleFile;
+            return litleFile;
         }
 
         public void addBatch(batchRequest litleBatchRequest)
@@ -175,7 +176,7 @@ namespace Litle.Sdk
             {
                 throw new LitleOnlineException("Can not add an RFRRequest to a batch with requests!");
             }
-            else if (numOfRFRRequest >= 1)
+            if (numOfRFRRequest >= 1)
             {
                 throw new LitleOnlineException("Can not add more than one RFRRequest to a batch!");
             }
@@ -186,18 +187,18 @@ namespace Litle.Sdk
 
         public litleResponse sendToLitleWithStream()
         {
-            string requestFilePath = this.Serialize();
-            string batchName = Path.GetFileName(requestFilePath);
+            var requestFilePath = Serialize();
+            var batchName = Path.GetFileName(requestFilePath);
 
-            string responseFilePath = communication.socketStream(requestFilePath, responseDirectory, config);
-            
-            litleResponse litleResponse = (litleResponse)litleXmlSerializer.DeserializeObjectFromFile(communication, responseFilePath);
+            var responseFilePath = communication.socketStream(requestFilePath, responseDirectory, config);
+
+            var litleResponse = litleXmlSerializer.DeserializeObjectFromFile(communication, responseFilePath);
             return litleResponse;
         }
 
         public string sendToLitle()
         {
-            string requestFilePath = this.Serialize();
+            var requestFilePath = Serialize();
 
             communication.FtpDropOff(requestDirectory, Path.GetFileName(requestFilePath), config);
             return Path.GetFileName(requestFilePath);
@@ -213,15 +214,16 @@ namespace Litle.Sdk
         {
             communication.FtpPickUp(responseDirectory + batchFileName, config, batchFileName);
 
-            litleResponse litleResponse = (litleResponse)litleXmlSerializer.DeserializeObjectFromFile(communication, responseDirectory + batchFileName);
+            var litleResponse = litleXmlSerializer.DeserializeObjectFromFile(communication,
+                responseDirectory + batchFileName);
             return litleResponse;
         }
 
         public string SerializeBatchRequestToFile(batchRequest litleBatchRequest, string filePath)
         {
-
-            filePath = litleFile.createRandomFile(requestDirectory, Path.GetFileName(filePath), "_temp_litleRequest.xml", litleTime);
-            string tempFilePath = litleBatchRequest.Serialize();
+            filePath = litleFile.createRandomFile(requestDirectory, Path.GetFileName(filePath), "_temp_litleRequest.xml",
+                litleTime);
+            var tempFilePath = litleBatchRequest.Serialize();
 
             litleFile.AppendFileToFile(filePath, tempFilePath);
 
@@ -230,8 +232,9 @@ namespace Litle.Sdk
 
         public string SerializeRFRRequestToFile(RFRRequest rfrRequest, string filePath)
         {
-            filePath = litleFile.createRandomFile(requestDirectory, Path.GetFileName(filePath), "_temp_litleRequest.xml", litleTime);
-            string tempFilePath = rfrRequest.Serialize();
+            filePath = litleFile.createRandomFile(requestDirectory, Path.GetFileName(filePath), "_temp_litleRequest.xml",
+                litleTime);
+            var tempFilePath = rfrRequest.Serialize();
 
             litleFile.AppendFileToFile(filePath, tempFilePath);
 
@@ -240,15 +243,16 @@ namespace Litle.Sdk
 
         public string Serialize()
         {
-            string xmlHeader = "<?xml version='1.0' encoding='utf-8'?>\r\n<litleRequest version=\"9.3\"" +
-             " xmlns=\"http://www.litle.com/schema\" " +
-             "numBatchRequests=\"" + numOfLitleBatchRequest + "\">";
+            var xmlHeader = "<?xml version='1.0' encoding='utf-8'?>\r\n<litleRequest version=\"9.3\"" +
+                            " xmlns=\"http://www.litle.com/schema\" " +
+                            "numBatchRequests=\"" + numOfLitleBatchRequest + "\">";
 
-            string xmlFooter = "\r\n</litleRequest>";
+            var xmlFooter = "\r\n</litleRequest>";
 
             string filePath;
 
-            finalFilePath = litleFile.createRandomFile(requestDirectory, Path.GetFileName(finalFilePath), ".xml", litleTime);
+            finalFilePath = litleFile.createRandomFile(requestDirectory, Path.GetFileName(finalFilePath), ".xml",
+                litleTime);
             filePath = finalFilePath;
 
             litleFile.AppendLineToFile(finalFilePath, xmlHeader);
@@ -280,7 +284,6 @@ namespace Litle.Sdk
                 litleBatchRequest.reportGroup = config["reportGroup"];
             }
         }
-
     }
 
     public class litleFile
@@ -292,11 +295,16 @@ namespace Litle.Sdk
             _cache = cache;
         }
 
-        public StringBuilder this[string name] { get { return _cache[name]; } } 
-        public virtual string createRandomFile(string fileDirectory, string fileName, string fileExtension, litleTime litleTime)
+        public StringBuilder this[string name]
+        {
+            get { return _cache[name]; }
+        }
+
+        public virtual string createRandomFile(string fileDirectory, string fileName, string fileExtension,
+            litleTime litleTime)
         {
             string filePath = null;
-            if (fileName == null || fileName == String.Empty)
+            if (fileName == null || fileName == string.Empty)
             {
                 fileName = litleTime.getCurrentTime("MM-dd-yyyy_HH-mm-ss-ffff_") + RandomGen.NextString(8);
                 filePath = fileDirectory + fileName + fileExtension;
@@ -318,10 +326,11 @@ namespace Litle.Sdk
 
         public virtual string AppendLineToFile(string filePath, string lineToAppend)
         {
-            StringBuilder ms = _cache[filePath];
+            var ms = _cache[filePath];
             ms.Append(lineToAppend);
             return filePath;
         }
+
         public virtual string ReadPosition(string filepath)
         {
             var s = _cache[filepath];
@@ -344,14 +353,15 @@ namespace Litle.Sdk
 
     public static class RandomGen
     {
-        private static RNGCryptoServiceProvider _global = new RNGCryptoServiceProvider();
+        private static readonly RNGCryptoServiceProvider _global = new RNGCryptoServiceProvider();
         private static Random _local;
+
         public static int NextInt()
         {
-            Random inst = _local;
+            var inst = _local;
             if (inst == null)
             {
-                byte[] buffer = new byte[8];
+                var buffer = new byte[8];
                 _global.GetBytes(buffer);
                 _local = inst = new Random(BitConverter.ToInt32(buffer, 0));
             }
@@ -361,11 +371,11 @@ namespace Litle.Sdk
 
         public static string NextString(int length)
         {
-            string result = "";
+            var result = "";
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
-                result += Convert.ToChar(NextInt() % ('Z' - 'A') + 'A');
+                result += Convert.ToChar(NextInt()%('Z' - 'A') + 'A');
             }
 
             return result;
@@ -374,10 +384,9 @@ namespace Litle.Sdk
 
     public class litleTime
     {
-        public virtual String getCurrentTime(String format)
+        public virtual string getCurrentTime(string format)
         {
             return DateTime.Now.ToString(format);
         }
     }
-
 }

--- a/LitleSdkForNet/LitleSdkForNet/LitleBatchRequest.cs
+++ b/LitleSdkForNet/LitleSdkForNet/LitleBatchRequest.cs
@@ -13,7 +13,7 @@ namespace Litle.Sdk
         public string reportGroup;
 
         public Dictionary<string, string> config;
-        private readonly IDictionary<string, StringBuilder> _memoryStreams;
+        private readonly IDictionary<string, StringBuilder> _cache;
 
         public string batchFilePath;
         private string tempBatchFilePath;
@@ -84,9 +84,9 @@ namespace Litle.Sdk
 
         private const string accountUpdateErrorMessage = "Account Updates need to exist in their own batch request!";
 
-        public batchRequest(IDictionary<string, StringBuilder> memoryStreams)
+        public batchRequest(IDictionary<string, StringBuilder> cache)
         {
-            _memoryStreams = memoryStreams;
+            _cache = cache;
             config = new Dictionary<string, string>();
 
             config["url"] = Settings.Default.url;
@@ -108,9 +108,9 @@ namespace Litle.Sdk
             initializeRequest();
         }
 
-        public batchRequest(IDictionary<string, StringBuilder> memoryStreams, Dictionary<string, string> config)
+        public batchRequest(IDictionary<string, StringBuilder> cache, Dictionary<string, string> config)
         {
-            _memoryStreams = memoryStreams;
+            _cache = cache;
             this.config = config;
 
             initializeRequest();
@@ -121,7 +121,7 @@ namespace Litle.Sdk
             requestDirectory = config["requestDirectory"] + "\\Requests\\";
             responseDirectory = config["responseDirectory"] + "\\Responses\\";
 
-            litleFile = new litleFile(_memoryStreams);
+            litleFile = new litleFile(_cache);
             litleTime = new litleTime();
 
             numAuthorization = 0;
@@ -686,7 +686,7 @@ namespace Litle.Sdk
             }
         }
 
-        public string addEcheckPreNoteCredit(echeckPreNoteCredit echeckPreNoteCredit)
+        public void addEcheckPreNoteCredit(echeckPreNoteCredit echeckPreNoteCredit)
         {
             if (numAccountUpdates == 0)
             {
@@ -698,7 +698,6 @@ namespace Litle.Sdk
             {
                 throw new LitleOnlineException(accountUpdateErrorMessage);
             }
-            return tempBatchFilePath;
         }
 
         public void addUpdateCardValidationNumOnToken(updateCardValidationNumOnToken updateCardValidationNumOnToken)
@@ -1303,11 +1302,11 @@ namespace Litle.Sdk
         private string responseDirectory;
 
         private Dictionary<string, string> config;
-        private readonly IDictionary<string, StringBuilder> _memoryStreams;
+        private readonly IDictionary<string, StringBuilder> _cache;
 
-        public RFRRequest(IDictionary<string, StringBuilder> memoryStreams)
+        public RFRRequest(IDictionary<string, StringBuilder> cache)
         {
-            _memoryStreams = memoryStreams;
+            _cache = cache;
             config = new Dictionary<string, string>();
 
             config["url"] = Settings.Default.url;
@@ -1327,15 +1326,15 @@ namespace Litle.Sdk
             config["responseDirectory"] = Settings.Default.responseDirectory;
 
             litleTime = new litleTime();
-            litleFile = new litleFile(_memoryStreams);
+            litleFile = new litleFile(_cache);
 
             requestDirectory = config["requestDirectory"] + "\\Requests\\";
             responseDirectory = config["responseDirectory"] + "\\Responses\\";
         }
 
-        public RFRRequest(IDictionary<string, StringBuilder> memoryStreams, Dictionary<string, string> config)
+        public RFRRequest(IDictionary<string, StringBuilder> cache, Dictionary<string, string> config)
         {
-            _memoryStreams = memoryStreams;
+            _cache = cache;
             this.config = config;
 
             initializeRequest();
@@ -1346,7 +1345,7 @@ namespace Litle.Sdk
             requestDirectory = config["requestDirectory"] + "\\Requests\\";
             responseDirectory = config["responseDirectory"] + "\\Responses\\";
 
-            litleFile = new litleFile(_memoryStreams);
+            litleFile = new litleFile(_cache);
             litleTime = new litleTime();
         }
 

--- a/LitleSdkForNet/LitleSdkForNet/LitleBatchRequest.cs
+++ b/LitleSdkForNet/LitleSdkForNet/LitleBatchRequest.cs
@@ -1,19 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Security;
+using System.Text;
+using Litle.Sdk.Properties;
 
 namespace Litle.Sdk
 {
-    public partial class batchRequest
+    public class batchRequest
     {
         public string id;
         public string merchantId;
         public string reportGroup;
 
-        public Dictionary<String, String> config;
-        private IDictionary<string, StringBuilder> _memoryStreams; 
+        public Dictionary<string, string> config;
+        private readonly IDictionary<string, StringBuilder> _memoryStreams;
 
         public string batchFilePath;
         private string tempBatchFilePath;
@@ -87,28 +87,28 @@ namespace Litle.Sdk
         public batchRequest(IDictionary<string, StringBuilder> memoryStreams)
         {
             _memoryStreams = memoryStreams;
-            config = new Dictionary<String, String>();
+            config = new Dictionary<string, string>();
 
-            config["url"] = Properties.Settings.Default.url;
-            config["reportGroup"] = Properties.Settings.Default.reportGroup;
-            config["username"] = Properties.Settings.Default.username;
-            config["printxml"] = Properties.Settings.Default.printxml;
-            config["timeout"] = Properties.Settings.Default.timeout;
-            config["proxyHost"] = Properties.Settings.Default.proxyHost;
-            config["merchantId"] = Properties.Settings.Default.merchantId;
-            config["password"] = Properties.Settings.Default.password;
-            config["proxyPort"] = Properties.Settings.Default.proxyPort;
-            config["sftpUrl"] = Properties.Settings.Default.sftpUrl;
-            config["sftpUsername"] = Properties.Settings.Default.sftpUsername;
-            config["sftpPassword"] = Properties.Settings.Default.sftpPassword;
-            config["knownHostsFile"] = Properties.Settings.Default.knownHostsFile;
-            config["requestDirectory"] = Properties.Settings.Default.requestDirectory;
-            config["responseDirectory"] = Properties.Settings.Default.responseDirectory;
+            config["url"] = Settings.Default.url;
+            config["reportGroup"] = Settings.Default.reportGroup;
+            config["username"] = Settings.Default.username;
+            config["printxml"] = Settings.Default.printxml;
+            config["timeout"] = Settings.Default.timeout;
+            config["proxyHost"] = Settings.Default.proxyHost;
+            config["merchantId"] = Settings.Default.merchantId;
+            config["password"] = Settings.Default.password;
+            config["proxyPort"] = Settings.Default.proxyPort;
+            config["sftpUrl"] = Settings.Default.sftpUrl;
+            config["sftpUsername"] = Settings.Default.sftpUsername;
+            config["sftpPassword"] = Settings.Default.sftpPassword;
+            config["knownHostsFile"] = Settings.Default.knownHostsFile;
+            config["requestDirectory"] = Settings.Default.requestDirectory;
+            config["responseDirectory"] = Settings.Default.responseDirectory;
 
             initializeRequest();
         }
 
-        public batchRequest(IDictionary<string, StringBuilder> memoryStreams, Dictionary<String, String> config)
+        public batchRequest(IDictionary<string, StringBuilder> memoryStreams, Dictionary<string, string> config)
         {
             _memoryStreams = memoryStreams;
             this.config = config;
@@ -120,7 +120,7 @@ namespace Litle.Sdk
         {
             requestDirectory = config["requestDirectory"] + "\\Requests\\";
             responseDirectory = config["responseDirectory"] + "\\Responses\\";
-            
+
             litleFile = new litleFile(_memoryStreams);
             litleTime = new litleTime();
 
@@ -176,12 +176,12 @@ namespace Litle.Sdk
 
         public string getResponseDirectory()
         {
-            return this.responseDirectory;
+            return responseDirectory;
         }
 
         public string getRequestDirectory()
         {
-            return this.requestDirectory;
+            return requestDirectory;
         }
 
         public void setLitleFile(litleFile litleFile)
@@ -191,7 +191,7 @@ namespace Litle.Sdk
 
         public litleFile getLitleFile()
         {
-            return this.litleFile;
+            return litleFile;
         }
 
         public void setLitleTime(litleTime litleTime)
@@ -201,7 +201,7 @@ namespace Litle.Sdk
 
         public litleTime getLitleTime()
         {
-            return this.litleTime;
+            return litleTime;
         }
 
         public int getNumAuthorization()
@@ -854,7 +854,7 @@ namespace Litle.Sdk
             if (numAccountUpdates == 0)
             {
                 numSubmerchantCredit++;
-                submerchantCreditAmount += (long)submerchantCredit.amount;
+                submerchantCreditAmount += (long) submerchantCredit.amount;
                 fillInReportGroup(submerchantCredit);
                 tempBatchFilePath = saveElement(litleFile, litleTime, tempBatchFilePath, submerchantCredit);
             }
@@ -869,7 +869,7 @@ namespace Litle.Sdk
             if (numAccountUpdates == 0)
             {
                 numPayFacCredit++;
-                payFacCreditAmount += (long)payFacCredit.amount;
+                payFacCreditAmount += (long) payFacCredit.amount;
                 fillInReportGroup(payFacCredit);
                 tempBatchFilePath = saveElement(litleFile, litleTime, tempBatchFilePath, payFacCredit);
             }
@@ -884,7 +884,7 @@ namespace Litle.Sdk
             if (numAccountUpdates == 0)
             {
                 numReserveCredit++;
-                reserveCreditAmount += (long)reserveCredit.amount;
+                reserveCreditAmount += (long) reserveCredit.amount;
                 fillInReportGroup(reserveCredit);
                 tempBatchFilePath = saveElement(litleFile, litleTime, tempBatchFilePath, reserveCredit);
             }
@@ -899,7 +899,7 @@ namespace Litle.Sdk
             if (numAccountUpdates == 0)
             {
                 numVendorCredit++;
-                vendorCreditAmount += (long)vendorCredit.amount;
+                vendorCreditAmount += (long) vendorCredit.amount;
                 fillInReportGroup(vendorCredit);
                 tempBatchFilePath = saveElement(litleFile, litleTime, tempBatchFilePath, vendorCredit);
             }
@@ -914,7 +914,7 @@ namespace Litle.Sdk
             if (numAccountUpdates == 0)
             {
                 numPhysicalCheckCredit++;
-                physicalCheckCreditAmount += (long)physicalCheckCredit.amount;
+                physicalCheckCreditAmount += (long) physicalCheckCredit.amount;
                 fillInReportGroup(physicalCheckCredit);
                 tempBatchFilePath = saveElement(litleFile, litleTime, tempBatchFilePath, physicalCheckCredit);
             }
@@ -929,7 +929,7 @@ namespace Litle.Sdk
             if (numAccountUpdates == 0)
             {
                 numSubmerchantDebit++;
-                submerchantDebitAmount += (long)submerchantDebit.amount;
+                submerchantDebitAmount += (long) submerchantDebit.amount;
                 fillInReportGroup(submerchantDebit);
                 tempBatchFilePath = saveElement(litleFile, litleTime, tempBatchFilePath, submerchantDebit);
             }
@@ -944,7 +944,7 @@ namespace Litle.Sdk
             if (numAccountUpdates == 0)
             {
                 numPayFacDebit++;
-                payFacDebitAmount += (long)payFacDebit.amount;
+                payFacDebitAmount += (long) payFacDebit.amount;
                 fillInReportGroup(payFacDebit);
                 tempBatchFilePath = saveElement(litleFile, litleTime, tempBatchFilePath, payFacDebit);
             }
@@ -959,7 +959,7 @@ namespace Litle.Sdk
             if (numAccountUpdates == 0)
             {
                 numReserveDebit++;
-                reserveDebitAmount += (long)reserveDebit.amount;
+                reserveDebitAmount += (long) reserveDebit.amount;
                 fillInReportGroup(reserveDebit);
                 tempBatchFilePath = saveElement(litleFile, litleTime, tempBatchFilePath, reserveDebit);
             }
@@ -974,7 +974,7 @@ namespace Litle.Sdk
             if (numAccountUpdates == 0)
             {
                 numVendorDebit++;
-                vendorDebitAmount += (long)vendorDebit.amount;
+                vendorDebitAmount += (long) vendorDebit.amount;
                 fillInReportGroup(vendorDebit);
                 tempBatchFilePath = saveElement(litleFile, litleTime, tempBatchFilePath, vendorDebit);
             }
@@ -989,7 +989,7 @@ namespace Litle.Sdk
             if (numAccountUpdates == 0)
             {
                 numPhysicalCheckDebit++;
-                physicalCheckDebitAmount += (long)physicalCheckDebit.amount;
+                physicalCheckDebitAmount += (long) physicalCheckDebit.amount;
                 fillInReportGroup(physicalCheckDebit);
                 tempBatchFilePath = saveElement(litleFile, litleTime, tempBatchFilePath, physicalCheckDebit);
             }
@@ -999,26 +999,26 @@ namespace Litle.Sdk
             }
         }
 
-        public String Serialize()
+        public string Serialize()
         {
-            string xmlHeader = generateXmlHeader();
+            var xmlHeader = generateXmlHeader();
 
-            string xmlFooter = "</batchRequest>\r\n";
+            var xmlFooter = "</batchRequest>\r\n";
 
             batchFilePath = litleFile.createRandomFile(requestDirectory, null, "_batchRequest.xml", litleTime);
 
             litleFile.AppendLineToFile(batchFilePath, xmlHeader);
             litleFile.AppendFileToFile(batchFilePath, tempBatchFilePath);
             litleFile.AppendLineToFile(batchFilePath, xmlFooter);
-            
+
             //tempBatchFilePath = null;
 
             return batchFilePath;
         }
-        
+
         public string generateXmlHeader()
         {
-            string xmlHeader = "\r\n<batchRequest id=\"" + id + "\"\r\n";
+            var xmlHeader = "\r\n<batchRequest id=\"" + id + "\"\r\n";
 
             if (numAuthorization != 0)
             {
@@ -1040,49 +1040,42 @@ namespace Litle.Sdk
 
             if (numCredit != 0)
             {
-
                 xmlHeader += "numCredits=\"" + numCredit + "\"\r\n";
                 xmlHeader += "creditAmount=\"" + sumOfCredit + "\"\r\n";
             }
 
             if (numForceCapture != 0)
             {
-
                 xmlHeader += "numForceCaptures=\"" + numForceCapture + "\"\r\n";
                 xmlHeader += "forceCaptureAmount=\"" + sumOfForceCapture + "\"\r\n";
             }
 
             if (numSale != 0)
             {
-
                 xmlHeader += "numSales=\"" + numSale + "\"\r\n";
                 xmlHeader += "saleAmount=\"" + sumOfSale + "\"\r\n";
             }
 
             if (numCaptureGivenAuth != 0)
             {
-
                 xmlHeader += "numCaptureGivenAuths=\"" + numCaptureGivenAuth + "\"\r\n";
                 xmlHeader += "captureGivenAuthAmount=\"" + sumOfCaptureGivenAuth + "\"\r\n";
             }
 
             if (numEcheckSale != 0)
             {
-
                 xmlHeader += "numEcheckSales=\"" + numEcheckSale + "\"\r\n";
                 xmlHeader += "echeckSalesAmount=\"" + sumOfEcheckSale + "\"\r\n";
             }
 
             if (numEcheckCredit != 0)
             {
-
                 xmlHeader += "numEcheckCredit=\"" + numEcheckCredit + "\"\r\n";
                 xmlHeader += "echeckCreditAmount=\"" + sumOfEcheckCredit + "\"\r\n";
             }
 
             if (numEcheckVerification != 0)
             {
-
                 xmlHeader += "numEcheckVerification=\"" + numEcheckVerification + "\"\r\n";
                 xmlHeader += "echeckVerificationAmount=\"" + sumOfEcheckVerification + "\"\r\n";
             }
@@ -1167,70 +1160,60 @@ namespace Litle.Sdk
 
             if (numPayFacCredit != 0)
             {
-
                 xmlHeader += "numPayFacCredit=\"" + numPayFacCredit + "\"\r\n";
                 xmlHeader += "payFacCreditAmount=\"" + payFacCreditAmount + "\"\r\n";
             }
 
             if (numSubmerchantCredit != 0)
             {
-
                 xmlHeader += "numSubmerchantCredit=\"" + numSubmerchantCredit + "\"\r\n";
                 xmlHeader += "submerchantCreditAmount=\"" + submerchantCreditAmount + "\"\r\n";
             }
 
             if (numReserveCredit != 0)
             {
-
                 xmlHeader += "numReserveCredit=\"" + numReserveCredit + "\"\r\n";
                 xmlHeader += "reserveCreditAmount=\"" + reserveCreditAmount + "\"\r\n";
             }
 
             if (numVendorCredit != 0)
             {
-
                 xmlHeader += "numVendorCredit=\"" + numVendorCredit + "\"\r\n";
                 xmlHeader += "vendorCreditAmount=\"" + vendorCreditAmount + "\"\r\n";
             }
 
             if (numPhysicalCheckCredit != 0)
             {
-
                 xmlHeader += "numPhysicalCheckCredit=\"" + numPhysicalCheckCredit + "\"\r\n";
                 xmlHeader += "physicalCheckCreditAmount=\"" + physicalCheckCreditAmount + "\"\r\n";
             }
 
             if (numPayFacDebit != 0)
             {
-
                 xmlHeader += "numPayFacDebit=\"" + numPayFacDebit + "\"\r\n";
                 xmlHeader += "payFacDebitAmount=\"" + payFacDebitAmount + "\"\r\n";
             }
 
             if (numSubmerchantDebit != 0)
             {
-
                 xmlHeader += "numSubmerchantDebit=\"" + numSubmerchantDebit + "\"\r\n";
                 xmlHeader += "submerchantDebitAmount=\"" + submerchantDebitAmount + "\"\r\n";
             }
 
             if (numReserveDebit != 0)
             {
-
                 xmlHeader += "numReserveDebit=\"" + numReserveDebit + "\"\r\n";
                 xmlHeader += "reserveDebitAmount=\"" + reserveDebitAmount + "\"\r\n";
             }
 
             if (numVendorDebit != 0)
             {
-
                 xmlHeader += "numVendorDebit=\"" + numVendorDebit + "\"\r\n";
                 xmlHeader += "vendorDebitAmount=\"" + vendorDebitAmount + "\"\r\n";
             }
 
             if (numPhysicalCheckDebit != 0)
             {
-
                 xmlHeader += "numPhysicalCheckDebit=\"" + numPhysicalCheckDebit + "\"\r\n";
                 xmlHeader += "physicalCheckDebitAmount=\"" + physicalCheckDebitAmount + "\"\r\n";
             }
@@ -1244,7 +1227,8 @@ namespace Litle.Sdk
         private string saveElement(litleFile litleFile, litleTime litleTime, string filePath, transactionRequest element)
         {
             string fPath;
-            fPath = litleFile.createRandomFile(requestDirectory, Path.GetFileName(filePath), "_temp_batchRequest.xml", litleTime);
+            fPath = litleFile.createRandomFile(requestDirectory, Path.GetFileName(filePath), "_temp_batchRequest.xml",
+                litleTime);
 
             litleFile.AppendLineToFile(fPath, element.Serialize());
 
@@ -1269,40 +1253,40 @@ namespace Litle.Sdk
 
         private bool isOnlyAccountUpdates()
         {
-            bool result = numAuthorization == 0
-                && numCapture == 0
-                && numCredit == 0
-                && numSale == 0
-                && numAuthReversal == 0
-                && numEcheckCredit == 0
-                && numEcheckVerification == 0
-                && numEcheckSale == 0
-                && numRegisterTokenRequest == 0
-                && numForceCapture == 0
-                && numCaptureGivenAuth == 0
-                && numEcheckRedeposit == 0
-                && numEcheckPreNoteSale == 0
-                && numEcheckPreNoteCredit == 0
-                && numUpdateCardValidationNumOnToken == 0
-                && numUpdateSubscriptions == 0
-                && numCancelSubscriptions == 0
-                && numCreatePlans == 0
-                && numUpdatePlans == 0
-                && numActivates == 0
-                && numDeactivates == 0
-                && numLoads == 0
-                && numUnloads == 0
-                && numBalanceInquiries == 0
-                && numPayFacCredit == 0
-                && numSubmerchantCredit == 0
-                && numReserveCredit == 0
-                && numVendorCredit == 0
-                && numPhysicalCheckCredit == 0
-                && numPayFacDebit == 0
-                && numSubmerchantDebit == 0
-                && numReserveDebit == 0
-                && numVendorDebit == 0
-                && numPhysicalCheckDebit == 0;
+            var result = numAuthorization == 0
+                         && numCapture == 0
+                         && numCredit == 0
+                         && numSale == 0
+                         && numAuthReversal == 0
+                         && numEcheckCredit == 0
+                         && numEcheckVerification == 0
+                         && numEcheckSale == 0
+                         && numRegisterTokenRequest == 0
+                         && numForceCapture == 0
+                         && numCaptureGivenAuth == 0
+                         && numEcheckRedeposit == 0
+                         && numEcheckPreNoteSale == 0
+                         && numEcheckPreNoteCredit == 0
+                         && numUpdateCardValidationNumOnToken == 0
+                         && numUpdateSubscriptions == 0
+                         && numCancelSubscriptions == 0
+                         && numCreatePlans == 0
+                         && numUpdatePlans == 0
+                         && numActivates == 0
+                         && numDeactivates == 0
+                         && numLoads == 0
+                         && numUnloads == 0
+                         && numBalanceInquiries == 0
+                         && numPayFacCredit == 0
+                         && numSubmerchantCredit == 0
+                         && numReserveCredit == 0
+                         && numVendorCredit == 0
+                         && numPhysicalCheckCredit == 0
+                         && numPayFacDebit == 0
+                         && numSubmerchantDebit == 0
+                         && numReserveDebit == 0
+                         && numVendorDebit == 0
+                         && numPhysicalCheckDebit == 0;
 
             return result;
         }
@@ -1318,29 +1302,29 @@ namespace Litle.Sdk
         private string requestDirectory;
         private string responseDirectory;
 
-        private Dictionary<String, String> config;
-        private IDictionary<string, StringBuilder> _memoryStreams;
+        private Dictionary<string, string> config;
+        private readonly IDictionary<string, StringBuilder> _memoryStreams;
 
         public RFRRequest(IDictionary<string, StringBuilder> memoryStreams)
         {
             _memoryStreams = memoryStreams;
-            config = new Dictionary<String, String>();
+            config = new Dictionary<string, string>();
 
-            config["url"] = Properties.Settings.Default.url;
-            config["reportGroup"] = Properties.Settings.Default.reportGroup;
-            config["username"] = Properties.Settings.Default.username;
-            config["printxml"] = Properties.Settings.Default.printxml;
-            config["timeout"] = Properties.Settings.Default.timeout;
-            config["proxyHost"] = Properties.Settings.Default.proxyHost;
-            config["merchantId"] = Properties.Settings.Default.merchantId;
-            config["password"] = Properties.Settings.Default.password;
-            config["proxyPort"] = Properties.Settings.Default.proxyPort;
-            config["sftpUrl"] = Properties.Settings.Default.sftpUrl;
-            config["sftpUsername"] = Properties.Settings.Default.sftpUsername;
-            config["sftpPassword"] = Properties.Settings.Default.sftpPassword;
-            config["knownHostsFile"] = Properties.Settings.Default.knownHostsFile;
-            config["requestDirectory"] = Properties.Settings.Default.requestDirectory;
-            config["responseDirectory"] = Properties.Settings.Default.responseDirectory;
+            config["url"] = Settings.Default.url;
+            config["reportGroup"] = Settings.Default.reportGroup;
+            config["username"] = Settings.Default.username;
+            config["printxml"] = Settings.Default.printxml;
+            config["timeout"] = Settings.Default.timeout;
+            config["proxyHost"] = Settings.Default.proxyHost;
+            config["merchantId"] = Settings.Default.merchantId;
+            config["password"] = Settings.Default.password;
+            config["proxyPort"] = Settings.Default.proxyPort;
+            config["sftpUrl"] = Settings.Default.sftpUrl;
+            config["sftpUsername"] = Settings.Default.sftpUsername;
+            config["sftpPassword"] = Settings.Default.sftpPassword;
+            config["knownHostsFile"] = Settings.Default.knownHostsFile;
+            config["requestDirectory"] = Settings.Default.requestDirectory;
+            config["responseDirectory"] = Settings.Default.responseDirectory;
 
             litleTime = new litleTime();
             litleFile = new litleFile(_memoryStreams);
@@ -1349,7 +1333,7 @@ namespace Litle.Sdk
             responseDirectory = config["responseDirectory"] + "\\Responses\\";
         }
 
-        public RFRRequest(IDictionary<string, StringBuilder> memoryStreams, Dictionary<String, String> config)
+        public RFRRequest(IDictionary<string, StringBuilder> memoryStreams, Dictionary<string, string> config)
         {
             _memoryStreams = memoryStreams;
             this.config = config;
@@ -1361,22 +1345,22 @@ namespace Litle.Sdk
         {
             requestDirectory = config["requestDirectory"] + "\\Requests\\";
             responseDirectory = config["responseDirectory"] + "\\Responses\\";
-            
+
             litleFile = new litleFile(_memoryStreams);
             litleTime = new litleTime();
         }
 
         public string getRequestDirectory()
         {
-            return this.requestDirectory;
+            return requestDirectory;
         }
 
         public string getResponseDirectory()
         {
-            return this.responseDirectory;
+            return responseDirectory;
         }
 
-        public void setConfig(Dictionary<String, String> config)
+        public void setConfig(Dictionary<string, string> config)
         {
             this.config = config;
         }
@@ -1388,7 +1372,7 @@ namespace Litle.Sdk
 
         public litleFile getLitleFile()
         {
-            return this.litleFile;
+            return litleFile;
         }
 
         public void setLitleTime(litleTime litleTime)
@@ -1398,17 +1382,17 @@ namespace Litle.Sdk
 
         public litleTime getLitleTime()
         {
-            return this.litleTime;
+            return litleTime;
         }
 
         public string Serialize()
         {
-            string xmlHeader = "\r\n<RFRRequest xmlns=\"http://www.litle.com/schema\">";
-            string xmlFooter = "\r\n</RFRRequest>";
+            var xmlHeader = "\r\n<RFRRequest xmlns=\"http://www.litle.com/schema\">";
+            var xmlFooter = "\r\n</RFRRequest>";
 
-            string filePath = litleFile.createRandomFile(requestDirectory, null, "_RFRRequest.xml", litleTime);
+            var filePath = litleFile.createRandomFile(requestDirectory, null, "_RFRRequest.xml", litleTime);
 
-            string xmlBody = "";
+            var xmlBody = "";
 
             if (accountUpdateFileRequestData != null)
             {
@@ -1428,87 +1412,26 @@ namespace Litle.Sdk
         }
     }
 
-    public partial class echeckPreNoteCredit : transactionTypeWithReportGroup
+    public class echeckPreNoteCredit : transactionTypeWithReportGroup
     {
+        /// <remarks />
+        public string orderId { get; set; }
 
-        private string orderIdField;
+        /// <remarks />
+        public orderSourceType orderSource { get; set; }
 
-        private orderSourceType orderSourceField;
+        /// <remarks />
+        public contact billToAddress { get; set; }
 
-        private contact billToAddressField;
+        /// <remarks />
+        public echeckType echeck { get; set; }
 
-        private echeckType echeckField;
-
-        private merchantDataType merchantDataField;
-
-        /// <remarks/>
-        public string orderId
-        {
-            get
-            {
-                return this.orderIdField;
-            }
-            set
-            {
-                this.orderIdField = value;
-            }
-        }
-
-        /// <remarks/>
-        public orderSourceType orderSource
-        {
-            get
-            {
-                return this.orderSourceField;
-            }
-            set
-            {
-                this.orderSourceField = value;
-            }
-        }
-
-        /// <remarks/>
-        public contact billToAddress
-        {
-            get
-            {
-                return this.billToAddressField;
-            }
-            set
-            {
-                this.billToAddressField = value;
-            }
-        }
-
-        /// <remarks/>
-        public echeckType echeck
-        {
-            get
-            {
-                return this.echeckField;
-            }
-            set
-            {
-                this.echeckField = value;
-            }
-        }
-
-        /// <remarks/>
-        public merchantDataType merchantData
-        {
-            get
-            {
-                return this.merchantDataField;
-            }
-            set
-            {
-                this.merchantDataField = value;
-            }
-        }
+        /// <remarks />
+        public merchantDataType merchantData { get; set; }
 
         public override string Serialize()
         {
-            string xml = "\r\n<echeckPreNoteCredit ";
+            var xml = "\r\n<echeckPreNoteCredit ";
 
             if (id != null)
             {
@@ -1555,87 +1478,26 @@ namespace Litle.Sdk
         }
     }
 
-    public partial class echeckPreNoteSale : transactionTypeWithReportGroup
+    public class echeckPreNoteSale : transactionTypeWithReportGroup
     {
+        /// <remarks />
+        public string orderId { get; set; }
 
-        private string orderIdField;
+        /// <remarks />
+        public orderSourceType orderSource { get; set; }
 
-        private orderSourceType orderSourceField;
+        /// <remarks />
+        public contact billToAddress { get; set; }
 
-        private contact billToAddressField;
+        /// <remarks />
+        public echeckType echeck { get; set; }
 
-        private echeckType echeckField;
-
-        private merchantDataType merchantDataField;
-
-        /// <remarks/>
-        public string orderId
-        {
-            get
-            {
-                return this.orderIdField;
-            }
-            set
-            {
-                this.orderIdField = value;
-            }
-        }
-
-        /// <remarks/>
-        public orderSourceType orderSource
-        {
-            get
-            {
-                return this.orderSourceField;
-            }
-            set
-            {
-                this.orderSourceField = value;
-            }
-        }
-
-        /// <remarks/>
-        public contact billToAddress
-        {
-            get
-            {
-                return this.billToAddressField;
-            }
-            set
-            {
-                this.billToAddressField = value;
-            }
-        }
-
-        /// <remarks/>
-        public echeckType echeck
-        {
-            get
-            {
-                return this.echeckField;
-            }
-            set
-            {
-                this.echeckField = value;
-            }
-        }
-
-        /// <remarks/>
-        public merchantDataType merchantData
-        {
-            get
-            {
-                return this.merchantDataField;
-            }
-            set
-            {
-                this.merchantDataField = value;
-            }
-        }
+        /// <remarks />
+        public merchantDataType merchantData { get; set; }
 
         public override string Serialize()
         {
-            string xml = "\r\n<echeckPreNoteSale ";
+            var xml = "\r\n<echeckPreNoteSale ";
 
             if (id != null)
             {
@@ -1682,9 +1544,8 @@ namespace Litle.Sdk
         }
     }
 
-    public partial class submerchantCredit : transactionTypeWithReportGroup
+    public class submerchantCredit : transactionTypeWithReportGroup
     {
-
         public string fundingSubmerchantId { get; set; }
 
         public string submerchantName { get; set; }
@@ -1697,7 +1558,7 @@ namespace Litle.Sdk
 
         public override string Serialize()
         {
-            string xml = "\r\n<submerchantCredit ";
+            var xml = "\r\n<submerchantCredit ";
 
             if (id != null)
                 xml += "id=\"" + SecurityElement.Escape(id) + "\" ";
@@ -1705,7 +1566,8 @@ namespace Litle.Sdk
                 xml += "customerId=\"" + SecurityElement.Escape(customerId) + "\" ";
             xml += "reportGroup=\"" + SecurityElement.Escape(reportGroup) + "\">";
             if (fundingSubmerchantId != null)
-                xml += "\r\n<fundingSubmerchantId>" + SecurityElement.Escape(fundingSubmerchantId) + "</fundingSubmerchantId>";
+                xml += "\r\n<fundingSubmerchantId>" + SecurityElement.Escape(fundingSubmerchantId) +
+                       "</fundingSubmerchantId>";
             if (submerchantName != null)
                 xml += "\r\n<submerchantName>" + SecurityElement.Escape(submerchantName) + "</submerchantName>";
             if (fundsTransferId != null)
@@ -1726,9 +1588,8 @@ namespace Litle.Sdk
         }
     }
 
-    public partial class payFacCredit : transactionTypeWithReportGroup
+    public class payFacCredit : transactionTypeWithReportGroup
     {
-
         public string fundingSubmerchantId { get; set; }
 
         public string fundsTransferId { get; set; }
@@ -1737,7 +1598,7 @@ namespace Litle.Sdk
 
         public override string Serialize()
         {
-            string xml = "\r\n<payFacCredit ";
+            var xml = "\r\n<payFacCredit ";
 
             if (id != null)
                 xml += "id=\"" + SecurityElement.Escape(id) + "\" ";
@@ -1745,7 +1606,8 @@ namespace Litle.Sdk
                 xml += "customerId=\"" + SecurityElement.Escape(customerId) + "\" ";
             xml += "reportGroup=\"" + SecurityElement.Escape(reportGroup) + "\">";
             if (fundingSubmerchantId != null)
-                xml += "\r\n<fundingSubmerchantId>" + SecurityElement.Escape(fundingSubmerchantId) + "</fundingSubmerchantId>";
+                xml += "\r\n<fundingSubmerchantId>" + SecurityElement.Escape(fundingSubmerchantId) +
+                       "</fundingSubmerchantId>";
             if (fundsTransferId != null)
                 xml += "\r\n<fundsTransferId>" + SecurityElement.Escape(fundsTransferId) + "</fundsTransferId>";
             if (amount != null)
@@ -1757,9 +1619,8 @@ namespace Litle.Sdk
         }
     }
 
-    public partial class reserveCredit : transactionTypeWithReportGroup
+    public class reserveCredit : transactionTypeWithReportGroup
     {
-
         public string fundingSubmerchantId { get; set; }
 
         public string fundsTransferId { get; set; }
@@ -1768,7 +1629,7 @@ namespace Litle.Sdk
 
         public override string Serialize()
         {
-            string xml = "\r\n<reserveCredit ";
+            var xml = "\r\n<reserveCredit ";
 
             if (id != null)
                 xml += "id=\"" + SecurityElement.Escape(id) + "\" ";
@@ -1776,7 +1637,8 @@ namespace Litle.Sdk
                 xml += "customerId=\"" + SecurityElement.Escape(customerId) + "\" ";
             xml += "reportGroup=\"" + SecurityElement.Escape(reportGroup) + "\">";
             if (fundingSubmerchantId != null)
-                xml += "\r\n<fundingSubmerchantId>" + SecurityElement.Escape(fundingSubmerchantId) + "</fundingSubmerchantId>";
+                xml += "\r\n<fundingSubmerchantId>" + SecurityElement.Escape(fundingSubmerchantId) +
+                       "</fundingSubmerchantId>";
             if (fundsTransferId != null)
                 xml += "\r\n<fundsTransferId>" + SecurityElement.Escape(fundsTransferId) + "</fundsTransferId>";
             if (amount != null)
@@ -1788,9 +1650,8 @@ namespace Litle.Sdk
         }
     }
 
-    public partial class vendorCredit : transactionTypeWithReportGroup
+    public class vendorCredit : transactionTypeWithReportGroup
     {
-
         public string fundingSubmerchantId { get; set; }
 
         public string vendorName { get; set; }
@@ -1803,7 +1664,7 @@ namespace Litle.Sdk
 
         public override string Serialize()
         {
-            string xml = "\r\n<vendorCredit ";
+            var xml = "\r\n<vendorCredit ";
 
             if (id != null)
                 xml += "id=\"" + SecurityElement.Escape(id) + "\" ";
@@ -1811,7 +1672,8 @@ namespace Litle.Sdk
                 xml += "customerId=\"" + SecurityElement.Escape(customerId) + "\" ";
             xml += "reportGroup=\"" + SecurityElement.Escape(reportGroup) + "\">";
             if (fundingSubmerchantId != null)
-                xml += "\r\n<fundingSubmerchantId>" + SecurityElement.Escape(fundingSubmerchantId) + "</fundingSubmerchantId>";
+                xml += "\r\n<fundingSubmerchantId>" + SecurityElement.Escape(fundingSubmerchantId) +
+                       "</fundingSubmerchantId>";
             if (vendorName != null)
                 xml += "\r\n<vendorName>" + SecurityElement.Escape(vendorName) + "</vendorName>";
             if (fundsTransferId != null)
@@ -1832,9 +1694,8 @@ namespace Litle.Sdk
         }
     }
 
-    public partial class physicalCheckCredit : transactionTypeWithReportGroup
+    public class physicalCheckCredit : transactionTypeWithReportGroup
     {
-
         public string fundingSubmerchantId { get; set; }
 
         public string fundsTransferId { get; set; }
@@ -1843,7 +1704,7 @@ namespace Litle.Sdk
 
         public override string Serialize()
         {
-            string xml = "\r\n<physicalCheckCredit ";
+            var xml = "\r\n<physicalCheckCredit ";
 
             if (id != null)
                 xml += "id=\"" + SecurityElement.Escape(id) + "\" ";
@@ -1851,7 +1712,8 @@ namespace Litle.Sdk
                 xml += "customerId=\"" + SecurityElement.Escape(customerId) + "\" ";
             xml += "reportGroup=\"" + SecurityElement.Escape(reportGroup) + "\">";
             if (fundingSubmerchantId != null)
-                xml += "\r\n<fundingSubmerchantId>" + SecurityElement.Escape(fundingSubmerchantId) + "</fundingSubmerchantId>";
+                xml += "\r\n<fundingSubmerchantId>" + SecurityElement.Escape(fundingSubmerchantId) +
+                       "</fundingSubmerchantId>";
             if (fundsTransferId != null)
                 xml += "\r\n<fundsTransferId>" + SecurityElement.Escape(fundsTransferId) + "</fundsTransferId>";
             if (amount != null)
@@ -1863,9 +1725,8 @@ namespace Litle.Sdk
         }
     }
 
-    public partial class submerchantDebit : transactionTypeWithReportGroup
+    public class submerchantDebit : transactionTypeWithReportGroup
     {
-
         public string fundingSubmerchantId { get; set; }
 
         public string submerchantName { get; set; }
@@ -1878,7 +1739,7 @@ namespace Litle.Sdk
 
         public override string Serialize()
         {
-            string xml = "\r\n<submerchantDebit ";
+            var xml = "\r\n<submerchantDebit ";
 
             if (id != null)
                 xml += "id=\"" + SecurityElement.Escape(id) + "\" ";
@@ -1886,7 +1747,8 @@ namespace Litle.Sdk
                 xml += "customerId=\"" + SecurityElement.Escape(customerId) + "\" ";
             xml += "reportGroup=\"" + SecurityElement.Escape(reportGroup) + "\">";
             if (fundingSubmerchantId != null)
-                xml += "\r\n<fundingSubmerchantId>" + SecurityElement.Escape(fundingSubmerchantId) + "</fundingSubmerchantId>";
+                xml += "\r\n<fundingSubmerchantId>" + SecurityElement.Escape(fundingSubmerchantId) +
+                       "</fundingSubmerchantId>";
             if (submerchantName != null)
                 xml += "\r\n<submerchantName>" + SecurityElement.Escape(submerchantName) + "</submerchantName>";
             if (fundsTransferId != null)
@@ -1907,9 +1769,8 @@ namespace Litle.Sdk
         }
     }
 
-    public partial class payFacDebit : transactionTypeWithReportGroup
+    public class payFacDebit : transactionTypeWithReportGroup
     {
-
         public string fundingSubmerchantId { get; set; }
 
         public string fundsTransferId { get; set; }
@@ -1918,7 +1779,7 @@ namespace Litle.Sdk
 
         public override string Serialize()
         {
-            string xml = "\r\n<payFacDebit ";
+            var xml = "\r\n<payFacDebit ";
 
             if (id != null)
                 xml += "id=\"" + SecurityElement.Escape(id) + "\" ";
@@ -1926,7 +1787,8 @@ namespace Litle.Sdk
                 xml += "customerId=\"" + SecurityElement.Escape(customerId) + "\" ";
             xml += "reportGroup=\"" + SecurityElement.Escape(reportGroup) + "\">";
             if (fundingSubmerchantId != null)
-                xml += "\r\n<fundingSubmerchantId>" + SecurityElement.Escape(fundingSubmerchantId) + "</fundingSubmerchantId>";
+                xml += "\r\n<fundingSubmerchantId>" + SecurityElement.Escape(fundingSubmerchantId) +
+                       "</fundingSubmerchantId>";
             if (fundsTransferId != null)
                 xml += "\r\n<fundsTransferId>" + SecurityElement.Escape(fundsTransferId) + "</fundsTransferId>";
             if (amount != null)
@@ -1938,9 +1800,8 @@ namespace Litle.Sdk
         }
     }
 
-    public partial class reserveDebit : transactionTypeWithReportGroup
+    public class reserveDebit : transactionTypeWithReportGroup
     {
-
         public string fundingSubmerchantId { get; set; }
 
         public string fundsTransferId { get; set; }
@@ -1949,7 +1810,7 @@ namespace Litle.Sdk
 
         public override string Serialize()
         {
-            string xml = "\r\n<reserveDebit ";
+            var xml = "\r\n<reserveDebit ";
 
             if (id != null)
                 xml += "id=\"" + SecurityElement.Escape(id) + "\" ";
@@ -1957,7 +1818,8 @@ namespace Litle.Sdk
                 xml += "customerId=\"" + SecurityElement.Escape(customerId) + "\" ";
             xml += "reportGroup=\"" + SecurityElement.Escape(reportGroup) + "\">";
             if (fundingSubmerchantId != null)
-                xml += "\r\n<fundingSubmerchantId>" + SecurityElement.Escape(fundingSubmerchantId) + "</fundingSubmerchantId>";
+                xml += "\r\n<fundingSubmerchantId>" + SecurityElement.Escape(fundingSubmerchantId) +
+                       "</fundingSubmerchantId>";
             if (fundsTransferId != null)
                 xml += "\r\n<fundsTransferId>" + SecurityElement.Escape(fundsTransferId) + "</fundsTransferId>";
             if (amount != null)
@@ -1969,9 +1831,8 @@ namespace Litle.Sdk
         }
     }
 
-    public partial class vendorDebit : transactionTypeWithReportGroup
+    public class vendorDebit : transactionTypeWithReportGroup
     {
-
         public string fundingSubmerchantId { get; set; }
 
         public string vendorName { get; set; }
@@ -1984,7 +1845,7 @@ namespace Litle.Sdk
 
         public override string Serialize()
         {
-            string xml = "\r\n<vendorDebit ";
+            var xml = "\r\n<vendorDebit ";
 
             if (id != null)
                 xml += "id=\"" + SecurityElement.Escape(id) + "\" ";
@@ -1992,7 +1853,8 @@ namespace Litle.Sdk
                 xml += "customerId=\"" + SecurityElement.Escape(customerId) + "\" ";
             xml += "reportGroup=\"" + SecurityElement.Escape(reportGroup) + "\">";
             if (fundingSubmerchantId != null)
-                xml += "\r\n<fundingSubmerchantId>" + SecurityElement.Escape(fundingSubmerchantId) + "</fundingSubmerchantId>";
+                xml += "\r\n<fundingSubmerchantId>" + SecurityElement.Escape(fundingSubmerchantId) +
+                       "</fundingSubmerchantId>";
             if (vendorName != null)
                 xml += "\r\n<vendorName>" + SecurityElement.Escape(vendorName) + "</vendorName>";
             if (fundsTransferId != null)
@@ -2013,9 +1875,8 @@ namespace Litle.Sdk
         }
     }
 
-    public partial class physicalCheckDebit : transactionTypeWithReportGroup
+    public class physicalCheckDebit : transactionTypeWithReportGroup
     {
-
         public string fundingSubmerchantId { get; set; }
 
         public string fundsTransferId { get; set; }
@@ -2024,7 +1885,7 @@ namespace Litle.Sdk
 
         public override string Serialize()
         {
-            string xml = "\r\n<physicalCheckDebit ";
+            var xml = "\r\n<physicalCheckDebit ";
 
             if (id != null)
                 xml += "id=\"" + SecurityElement.Escape(id) + "\" ";
@@ -2032,7 +1893,8 @@ namespace Litle.Sdk
                 xml += "customerId=\"" + SecurityElement.Escape(customerId) + "\" ";
             xml += "reportGroup=\"" + SecurityElement.Escape(reportGroup) + "\">";
             if (fundingSubmerchantId != null)
-                xml += "\r\n<fundingSubmerchantId>" + SecurityElement.Escape(fundingSubmerchantId) + "</fundingSubmerchantId>";
+                xml += "\r\n<fundingSubmerchantId>" + SecurityElement.Escape(fundingSubmerchantId) +
+                       "</fundingSubmerchantId>";
             if (fundsTransferId != null)
                 xml += "\r\n<fundsTransferId>" + SecurityElement.Escape(fundsTransferId) + "</fundsTransferId>";
             if (amount != null)

--- a/LitleSdkForNet/LitleSdkForNet/LitleBatchRequest.cs
+++ b/LitleSdkForNet/LitleSdkForNet/LitleBatchRequest.cs
@@ -13,6 +13,7 @@ namespace Litle.Sdk
         public string reportGroup;
 
         public Dictionary<String, String> config;
+        private IDictionary<string, StringBuilder> _memoryStreams; 
 
         public string batchFilePath;
         private string tempBatchFilePath;
@@ -83,8 +84,9 @@ namespace Litle.Sdk
 
         private const string accountUpdateErrorMessage = "Account Updates need to exist in their own batch request!";
 
-        public batchRequest()
+        public batchRequest(IDictionary<string, StringBuilder> memoryStreams)
         {
+            _memoryStreams = memoryStreams;
             config = new Dictionary<String, String>();
 
             config["url"] = Properties.Settings.Default.url;
@@ -106,8 +108,9 @@ namespace Litle.Sdk
             initializeRequest();
         }
 
-        public batchRequest(Dictionary<String, String> config)
+        public batchRequest(IDictionary<string, StringBuilder> memoryStreams, Dictionary<String, String> config)
         {
+            _memoryStreams = memoryStreams;
             this.config = config;
 
             initializeRequest();
@@ -117,8 +120,8 @@ namespace Litle.Sdk
         {
             requestDirectory = config["requestDirectory"] + "\\Requests\\";
             responseDirectory = config["responseDirectory"] + "\\Responses\\";
-
-            litleFile = new litleFile();
+            
+            litleFile = new litleFile(_memoryStreams);
             litleTime = new litleTime();
 
             numAuthorization = 0;
@@ -683,7 +686,7 @@ namespace Litle.Sdk
             }
         }
 
-        public void addEcheckPreNoteCredit(echeckPreNoteCredit echeckPreNoteCredit)
+        public string addEcheckPreNoteCredit(echeckPreNoteCredit echeckPreNoteCredit)
         {
             if (numAccountUpdates == 0)
             {
@@ -695,6 +698,7 @@ namespace Litle.Sdk
             {
                 throw new LitleOnlineException(accountUpdateErrorMessage);
             }
+            return tempBatchFilePath;
         }
 
         public void addUpdateCardValidationNumOnToken(updateCardValidationNumOnToken updateCardValidationNumOnToken)
@@ -1006,12 +1010,12 @@ namespace Litle.Sdk
             litleFile.AppendLineToFile(batchFilePath, xmlHeader);
             litleFile.AppendFileToFile(batchFilePath, tempBatchFilePath);
             litleFile.AppendLineToFile(batchFilePath, xmlFooter);
-
-            tempBatchFilePath = null;
+            
+            //tempBatchFilePath = null;
 
             return batchFilePath;
         }
-
+        
         public string generateXmlHeader()
         {
             string xmlHeader = "\r\n<batchRequest id=\"" + id + "\"\r\n";
@@ -1315,9 +1319,11 @@ namespace Litle.Sdk
         private string responseDirectory;
 
         private Dictionary<String, String> config;
+        private IDictionary<string, StringBuilder> _memoryStreams;
 
-        public RFRRequest()
+        public RFRRequest(IDictionary<string, StringBuilder> memoryStreams)
         {
+            _memoryStreams = memoryStreams;
             config = new Dictionary<String, String>();
 
             config["url"] = Properties.Settings.Default.url;
@@ -1337,14 +1343,15 @@ namespace Litle.Sdk
             config["responseDirectory"] = Properties.Settings.Default.responseDirectory;
 
             litleTime = new litleTime();
-            litleFile = new litleFile();
+            litleFile = new litleFile(_memoryStreams);
 
             requestDirectory = config["requestDirectory"] + "\\Requests\\";
             responseDirectory = config["responseDirectory"] + "\\Responses\\";
         }
 
-        public RFRRequest(Dictionary<String, String> config)
+        public RFRRequest(IDictionary<string, StringBuilder> memoryStreams, Dictionary<String, String> config)
         {
+            _memoryStreams = memoryStreams;
             this.config = config;
 
             initializeRequest();
@@ -1354,8 +1361,8 @@ namespace Litle.Sdk
         {
             requestDirectory = config["requestDirectory"] + "\\Requests\\";
             responseDirectory = config["responseDirectory"] + "\\Responses\\";
-
-            litleFile = new litleFile();
+            
+            litleFile = new litleFile(_memoryStreams);
             litleTime = new litleTime();
         }
 

--- a/LitleSdkForNet/LitleSdkForNet/LitleOnline.cs
+++ b/LitleSdkForNet/LitleSdkForNet/LitleOnline.cs
@@ -11,15 +11,15 @@ namespace Litle.Sdk
     {
         private readonly Dictionary<string, string> config;
         private Communications communication;
-        private readonly IDictionary<string, StringBuilder> _memoryStreams;
+        private readonly IDictionary<string, StringBuilder> _cache;
 
         /**
          * Construct a Litle online using the configuration specified in LitleSdkForNet.dll.config
          */
 
-        public LitleOnline(IDictionary<string, StringBuilder> memoryStreams)
+        public LitleOnline(IDictionary<string, StringBuilder> cache)
         {
-            _memoryStreams = memoryStreams;
+            _cache = cache;
             config = new Dictionary<string, string>();
             config["url"] = Settings.Default.url;
             config["reportGroup"] = Settings.Default.reportGroup;
@@ -32,7 +32,7 @@ namespace Litle.Sdk
             config["proxyPort"] = Settings.Default.proxyPort;
             config["logFile"] = Settings.Default.logFile;
             config["neuterAccountNums"] = Settings.Default.neuterAccountNums;
-            communication = new Communications(_memoryStreams);
+            communication = new Communications(_cache);
         }
 
         /**
@@ -52,11 +52,11 @@ namespace Litle.Sdk
          * printxml (possible values "true" and "false" - defaults to false)
          */
 
-        public LitleOnline(IDictionary<string, StringBuilder> memoryStreams, Dictionary<string, string> config)
+        public LitleOnline(IDictionary<string, StringBuilder> cache, Dictionary<string, string> config)
         {
-            _memoryStreams = memoryStreams;
+            _cache = cache;
             this.config = config;
-            communication = new Communications(_memoryStreams);
+            communication = new Communications(_cache);
         }
 
         public void setCommunication(Communications communication)

--- a/LitleSdkForNet/LitleSdkForNet/LitleOnline.cs
+++ b/LitleSdkForNet/LitleSdkForNet/LitleOnline.cs
@@ -1,36 +1,37 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
-using System.Xml;
-using System.Xml.Serialization;
 using System.IO;
+using System.Text;
+using System.Xml.Serialization;
+using Litle.Sdk.Properties;
 
 namespace Litle.Sdk
 {
     public class LitleOnline : ILitleOnline
     {
-        private Dictionary<String, String> config;
+        private readonly Dictionary<string, string> config;
         private Communications communication;
-        private IDictionary<string, StringBuilder> _memoryStreams;
+        private readonly IDictionary<string, StringBuilder> _memoryStreams;
 
         /**
          * Construct a Litle online using the configuration specified in LitleSdkForNet.dll.config
          */
+
         public LitleOnline(IDictionary<string, StringBuilder> memoryStreams)
         {
             _memoryStreams = memoryStreams;
-            config = new Dictionary<String, String>();
-            config["url"] = Properties.Settings.Default.url;
-            config["reportGroup"] = Properties.Settings.Default.reportGroup;
-            config["username"] = Properties.Settings.Default.username;
-            config["printxml"] = Properties.Settings.Default.printxml;
-            config["timeout"] = Properties.Settings.Default.timeout;
-            config["proxyHost"] = Properties.Settings.Default.proxyHost;
-            config["merchantId"] = Properties.Settings.Default.merchantId;
-            config["password"] = Properties.Settings.Default.password;
-            config["proxyPort"] = Properties.Settings.Default.proxyPort;
-            config["logFile"] = Properties.Settings.Default.logFile;
-            config["neuterAccountNums"] = Properties.Settings.Default.neuterAccountNums;
+            config = new Dictionary<string, string>();
+            config["url"] = Settings.Default.url;
+            config["reportGroup"] = Settings.Default.reportGroup;
+            config["username"] = Settings.Default.username;
+            config["printxml"] = Settings.Default.printxml;
+            config["timeout"] = Settings.Default.timeout;
+            config["proxyHost"] = Settings.Default.proxyHost;
+            config["merchantId"] = Settings.Default.merchantId;
+            config["password"] = Settings.Default.password;
+            config["proxyPort"] = Settings.Default.proxyPort;
+            config["logFile"] = Settings.Default.logFile;
+            config["neuterAccountNums"] = Settings.Default.neuterAccountNums;
             communication = new Communications(_memoryStreams);
         }
 
@@ -50,7 +51,8 @@ namespace Litle.Sdk
          * proxyPort
          * printxml (possible values "true" and "false" - defaults to false)
          */
-        public LitleOnline(IDictionary<string, StringBuilder> memoryStreams, Dictionary<String, String> config)
+
+        public LitleOnline(IDictionary<string, StringBuilder> memoryStreams, Dictionary<string, string> config)
         {
             _memoryStreams = memoryStreams;
             this.config = config;
@@ -64,325 +66,326 @@ namespace Litle.Sdk
 
         public authorizationResponse Authorize(authorization auth)
         {
-            litleOnlineRequest request = createLitleOnlineRequest();          
+            var request = createLitleOnlineRequest();
             fillInReportGroup(auth);
             request.authorization = auth;
 
-            litleOnlineResponse response = sendToLitle(request);
-            authorizationResponse authResponse = (authorizationResponse)response.authorizationResponse;
+            var response = sendToLitle(request);
+            var authResponse = response.authorizationResponse;
             return authResponse;
         }
 
         public authReversalResponse AuthReversal(authReversal reversal)
         {
-            litleOnlineRequest request = createLitleOnlineRequest();
+            var request = createLitleOnlineRequest();
             fillInReportGroup(reversal);
             request.authReversal = reversal;
 
-            litleOnlineResponse response = sendToLitle(request);
-            authReversalResponse reversalResponse = (authReversalResponse)response.authReversalResponse;
+            var response = sendToLitle(request);
+            var reversalResponse = response.authReversalResponse;
             return reversalResponse;
         }
 
         public captureResponse Capture(capture capture)
         {
-            litleOnlineRequest request = createLitleOnlineRequest();
+            var request = createLitleOnlineRequest();
             fillInReportGroup(capture);
             request.capture = capture;
 
-            litleOnlineResponse response = sendToLitle(request);
-            captureResponse captureResponse = (captureResponse)response.captureResponse;
+            var response = sendToLitle(request);
+            var captureResponse = response.captureResponse;
             return captureResponse;
         }
 
         public captureGivenAuthResponse CaptureGivenAuth(captureGivenAuth captureGivenAuth)
         {
-            litleOnlineRequest request = createLitleOnlineRequest();
+            var request = createLitleOnlineRequest();
             fillInReportGroup(captureGivenAuth);
             request.captureGivenAuth = captureGivenAuth;
 
-            litleOnlineResponse response = sendToLitle(request);
-            captureGivenAuthResponse captureGivenAuthResponse = (captureGivenAuthResponse)response.captureGivenAuthResponse;
+            var response = sendToLitle(request);
+            var captureGivenAuthResponse = response.captureGivenAuthResponse;
             return captureGivenAuthResponse;
         }
 
         public creditResponse Credit(credit credit)
         {
-            litleOnlineRequest request = createLitleOnlineRequest();
+            var request = createLitleOnlineRequest();
             fillInReportGroup(credit);
             request.credit = credit;
 
-            litleOnlineResponse response = sendToLitle(request);
-            creditResponse creditResponse = (creditResponse)response.creditResponse;
+            var response = sendToLitle(request);
+            var creditResponse = response.creditResponse;
             return creditResponse;
         }
 
         public echeckCreditResponse EcheckCredit(echeckCredit echeckCredit)
         {
-            litleOnlineRequest request = createLitleOnlineRequest();
+            var request = createLitleOnlineRequest();
             fillInReportGroup(echeckCredit);
             request.echeckCredit = echeckCredit;
 
-            litleOnlineResponse response = sendToLitle(request);
-            echeckCreditResponse echeckCreditResponse = (echeckCreditResponse)response.echeckCreditResponse;
+            var response = sendToLitle(request);
+            var echeckCreditResponse = response.echeckCreditResponse;
             return echeckCreditResponse;
         }
 
         public echeckRedepositResponse EcheckRedeposit(echeckRedeposit echeckRedeposit)
         {
-            litleOnlineRequest request = createLitleOnlineRequest();
+            var request = createLitleOnlineRequest();
             fillInReportGroup(echeckRedeposit);
             request.echeckRedeposit = echeckRedeposit;
 
-            litleOnlineResponse response = sendToLitle(request);
-            echeckRedepositResponse echeckRedepositResponse = (echeckRedepositResponse)response.echeckRedepositResponse;
+            var response = sendToLitle(request);
+            var echeckRedepositResponse = response.echeckRedepositResponse;
             return echeckRedepositResponse;
         }
 
         public echeckSalesResponse EcheckSale(echeckSale echeckSale)
         {
-            litleOnlineRequest request = createLitleOnlineRequest();
+            var request = createLitleOnlineRequest();
             fillInReportGroup(echeckSale);
             request.echeckSale = echeckSale;
 
-            litleOnlineResponse response = sendToLitle(request);
-            echeckSalesResponse echeckSalesResponse = (echeckSalesResponse)response.echeckSalesResponse;
+            var response = sendToLitle(request);
+            var echeckSalesResponse = response.echeckSalesResponse;
             return echeckSalesResponse;
         }
 
         public echeckVerificationResponse EcheckVerification(echeckVerification echeckVerification)
         {
-            litleOnlineRequest request = createLitleOnlineRequest();
+            var request = createLitleOnlineRequest();
             fillInReportGroup(echeckVerification);
             request.echeckVerification = echeckVerification;
 
-            litleOnlineResponse response = sendToLitle(request);
-            echeckVerificationResponse echeckVerificationResponse = (echeckVerificationResponse)response.echeckVerificationResponse;
+            var response = sendToLitle(request);
+            var echeckVerificationResponse = response.echeckVerificationResponse;
             return echeckVerificationResponse;
         }
 
         public forceCaptureResponse ForceCapture(forceCapture forceCapture)
         {
-            litleOnlineRequest request = createLitleOnlineRequest();
+            var request = createLitleOnlineRequest();
             fillInReportGroup(forceCapture);
             request.forceCapture = forceCapture;
 
-            litleOnlineResponse response = sendToLitle(request);
-            forceCaptureResponse forceCaptureResponse = (forceCaptureResponse)response.forceCaptureResponse;
+            var response = sendToLitle(request);
+            var forceCaptureResponse = response.forceCaptureResponse;
             return forceCaptureResponse;
         }
 
         public saleResponse Sale(sale sale)
         {
-            litleOnlineRequest request = createLitleOnlineRequest();
+            var request = createLitleOnlineRequest();
             fillInReportGroup(sale);
             request.sale = sale;
 
-            litleOnlineResponse response = sendToLitle(request);
-            saleResponse saleResponse = (saleResponse)response.saleResponse;
+            var response = sendToLitle(request);
+            var saleResponse = response.saleResponse;
             return saleResponse;
         }
 
         public registerTokenResponse RegisterToken(registerTokenRequestType tokenRequest)
         {
-            litleOnlineRequest request = createLitleOnlineRequest();
+            var request = createLitleOnlineRequest();
             fillInReportGroup(tokenRequest);
             request.registerTokenRequest = tokenRequest;
 
-            litleOnlineResponse response = sendToLitle(request);
-            registerTokenResponse registerTokenResponse = (registerTokenResponse)response.registerTokenResponse;
+            var response = sendToLitle(request);
+            var registerTokenResponse = response.registerTokenResponse;
             return registerTokenResponse;
         }
 
         public litleOnlineResponseTransactionResponseVoidResponse DoVoid(voidTxn v)
         {
-            litleOnlineRequest request = createLitleOnlineRequest();
+            var request = createLitleOnlineRequest();
             fillInReportGroup(v);
             request.voidTxn = v;
 
-            litleOnlineResponse response = sendToLitle(request);
-            litleOnlineResponseTransactionResponseVoidResponse voidResponse = (litleOnlineResponseTransactionResponseVoidResponse)response.voidResponse;
+            var response = sendToLitle(request);
+            var voidResponse = response.voidResponse;
             return voidResponse;
         }
 
         public litleOnlineResponseTransactionResponseEcheckVoidResponse EcheckVoid(echeckVoid v)
         {
-            litleOnlineRequest request = createLitleOnlineRequest();
+            var request = createLitleOnlineRequest();
             fillInReportGroup(v);
             request.echeckVoid = v;
 
-            litleOnlineResponse response = sendToLitle(request);
-            litleOnlineResponseTransactionResponseEcheckVoidResponse voidResponse = (litleOnlineResponseTransactionResponseEcheckVoidResponse)response.echeckVoidResponse;
+            var response = sendToLitle(request);
+            var voidResponse = response.echeckVoidResponse;
             return voidResponse;
         }
 
-        public updateCardValidationNumOnTokenResponse UpdateCardValidationNumOnToken(updateCardValidationNumOnToken updateCardValidationNumOnToken)
+        public updateCardValidationNumOnTokenResponse UpdateCardValidationNumOnToken(
+            updateCardValidationNumOnToken updateCardValidationNumOnToken)
         {
-            litleOnlineRequest request = createLitleOnlineRequest();
+            var request = createLitleOnlineRequest();
             fillInReportGroup(updateCardValidationNumOnToken);
             request.updateCardValidationNumOnToken = updateCardValidationNumOnToken;
 
-            litleOnlineResponse response = sendToLitle(request);
-            updateCardValidationNumOnTokenResponse updateResponse = (updateCardValidationNumOnTokenResponse)response.updateCardValidationNumOnTokenResponse;
+            var response = sendToLitle(request);
+            var updateResponse = response.updateCardValidationNumOnTokenResponse;
             return updateResponse;
         }
 
         public cancelSubscriptionResponse CancelSubscription(cancelSubscription cancelSubscription)
         {
-            litleOnlineRequest request = createLitleOnlineRequest();
+            var request = createLitleOnlineRequest();
             request.cancelSubscription = cancelSubscription;
 
-            litleOnlineResponse response = sendToLitle(request);
-            cancelSubscriptionResponse cancelResponse = (cancelSubscriptionResponse)response.cancelSubscriptionResponse;
+            var response = sendToLitle(request);
+            var cancelResponse = response.cancelSubscriptionResponse;
             return cancelResponse;
         }
 
         public updateSubscriptionResponse UpdateSubscription(updateSubscription updateSubscription)
         {
-            litleOnlineRequest request = createLitleOnlineRequest();
+            var request = createLitleOnlineRequest();
             request.updateSubscription = updateSubscription;
 
-            litleOnlineResponse response = sendToLitle(request);
-            updateSubscriptionResponse updateResponse = (updateSubscriptionResponse)response.updateSubscriptionResponse;
+            var response = sendToLitle(request);
+            var updateResponse = response.updateSubscriptionResponse;
             return updateResponse;
         }
 
         public activateResponse Activate(activate activate)
         {
-            litleOnlineRequest request = createLitleOnlineRequest();
+            var request = createLitleOnlineRequest();
             request.activate = activate;
 
-            litleOnlineResponse response = sendToLitle(request);
-            activateResponse activateResponse = response.activateResponse;
+            var response = sendToLitle(request);
+            var activateResponse = response.activateResponse;
             return activateResponse;
         }
 
         public deactivateResponse Deactivate(deactivate deactivate)
         {
-            litleOnlineRequest request = createLitleOnlineRequest();
+            var request = createLitleOnlineRequest();
             request.deactivate = deactivate;
 
-            litleOnlineResponse response = sendToLitle(request);
-            deactivateResponse deactivateResponse = response.deactivateResponse;
+            var response = sendToLitle(request);
+            var deactivateResponse = response.deactivateResponse;
             return deactivateResponse;
         }
 
         public loadResponse Load(load load)
         {
-            litleOnlineRequest request = createLitleOnlineRequest();
+            var request = createLitleOnlineRequest();
             request.load = load;
 
-            litleOnlineResponse response = sendToLitle(request);
-            loadResponse loadResponse = response.loadResponse;
+            var response = sendToLitle(request);
+            var loadResponse = response.loadResponse;
             return loadResponse;
         }
 
         public unloadResponse Unload(unload unload)
         {
-            litleOnlineRequest request = createLitleOnlineRequest();
+            var request = createLitleOnlineRequest();
             request.unload = unload;
 
-            litleOnlineResponse response = sendToLitle(request);
-            unloadResponse unloadResponse = response.unloadResponse;
+            var response = sendToLitle(request);
+            var unloadResponse = response.unloadResponse;
             return unloadResponse;
         }
 
         public balanceInquiryResponse BalanceInquiry(balanceInquiry balanceInquiry)
         {
-            litleOnlineRequest request = createLitleOnlineRequest();
+            var request = createLitleOnlineRequest();
             request.balanceInquiry = balanceInquiry;
 
-            litleOnlineResponse response = sendToLitle(request);
-            balanceInquiryResponse balanceInquiryResponse = response.balanceInquiryResponse;
+            var response = sendToLitle(request);
+            var balanceInquiryResponse = response.balanceInquiryResponse;
             return balanceInquiryResponse;
         }
 
         public createPlanResponse CreatePlan(createPlan createPlan)
         {
-            litleOnlineRequest request = createLitleOnlineRequest();
+            var request = createLitleOnlineRequest();
             request.createPlan = createPlan;
 
-            litleOnlineResponse response = sendToLitle(request);
-            createPlanResponse createPlanResponse = response.createPlanResponse;
+            var response = sendToLitle(request);
+            var createPlanResponse = response.createPlanResponse;
             return createPlanResponse;
         }
 
         public updatePlanResponse UpdatePlan(updatePlan updatePlan)
         {
-            litleOnlineRequest request = createLitleOnlineRequest();
+            var request = createLitleOnlineRequest();
             request.updatePlan = updatePlan;
 
-            litleOnlineResponse response = sendToLitle(request);
-            updatePlanResponse updatePlanResponse = response.updatePlanResponse;
+            var response = sendToLitle(request);
+            var updatePlanResponse = response.updatePlanResponse;
             return updatePlanResponse;
         }
 
         public refundReversalResponse RefundReversal(refundReversal refundReversal)
         {
-            litleOnlineRequest request = createLitleOnlineRequest();
+            var request = createLitleOnlineRequest();
             request.refundReversal = refundReversal;
 
-            litleOnlineResponse response = sendToLitle(request);
-            refundReversalResponse refundReversalResponse = response.refundReversalResponse;
+            var response = sendToLitle(request);
+            var refundReversalResponse = response.refundReversalResponse;
             return refundReversalResponse;
         }
 
         public depositReversalResponse DepositReversal(depositReversal depositReversal)
         {
-            litleOnlineRequest request = createLitleOnlineRequest();
+            var request = createLitleOnlineRequest();
             request.depositReversal = depositReversal;
 
-            litleOnlineResponse response = sendToLitle(request);
-            depositReversalResponse depositReversalResponse = response.depositReversalResponse;
+            var response = sendToLitle(request);
+            var depositReversalResponse = response.depositReversalResponse;
             return depositReversalResponse;
         }
 
         public activateReversalResponse ActivateReversal(activateReversal activateReversal)
         {
-            litleOnlineRequest request = createLitleOnlineRequest();
+            var request = createLitleOnlineRequest();
             request.activateReversal = activateReversal;
 
-            litleOnlineResponse response = sendToLitle(request);
-            activateReversalResponse activateReversalResponse = response.activateReversalResponse;
+            var response = sendToLitle(request);
+            var activateReversalResponse = response.activateReversalResponse;
             return activateReversalResponse;
         }
 
         public deactivateReversalResponse DeactivateReversal(deactivateReversal deactivateReversal)
         {
-            litleOnlineRequest request = createLitleOnlineRequest();
+            var request = createLitleOnlineRequest();
             request.deactivateReversal = deactivateReversal;
 
-            litleOnlineResponse response = sendToLitle(request);
-            deactivateReversalResponse deactivateReversalResponse = response.deactivateReversalResponse;
+            var response = sendToLitle(request);
+            var deactivateReversalResponse = response.deactivateReversalResponse;
             return deactivateReversalResponse;
         }
 
         public loadReversalResponse LoadReversal(loadReversal loadReversal)
         {
-            litleOnlineRequest request = createLitleOnlineRequest();
+            var request = createLitleOnlineRequest();
             request.loadReversal = loadReversal;
 
-            litleOnlineResponse response = sendToLitle(request);
-            loadReversalResponse loadReversalResponse = response.loadReversalResponse;
+            var response = sendToLitle(request);
+            var loadReversalResponse = response.loadReversalResponse;
             return loadReversalResponse;
         }
 
         public unloadReversalResponse UnloadReversal(unloadReversal unloadReversal)
         {
-            litleOnlineRequest request = createLitleOnlineRequest();
+            var request = createLitleOnlineRequest();
             request.unloadReversal = unloadReversal;
 
-            litleOnlineResponse response = sendToLitle(request);
-            unloadReversalResponse unloadReversalResponse = response.unloadReversalResponse;
+            var response = sendToLitle(request);
+            var unloadReversalResponse = response.unloadReversalResponse;
             return unloadReversalResponse;
         }
 
         private litleOnlineRequest createLitleOnlineRequest()
         {
-            litleOnlineRequest request = new litleOnlineRequest();
+            var request = new litleOnlineRequest();
             request.merchantId = config["merchantId"];
             request.merchantSdk = "DotNet;9.3.2";
-            authentication authentication = new authentication();
+            var authentication = new authentication();
             authentication.password = config["password"];
             authentication.user = config["username"];
             request.authentication = authentication;
@@ -391,11 +394,11 @@ namespace Litle.Sdk
 
         private litleOnlineResponse sendToLitle(litleOnlineRequest request)
         {
-            string xmlRequest = request.Serialize();
-            string xmlResponse = communication.HttpPost(xmlRequest,config);
+            var xmlRequest = request.Serialize();
+            var xmlResponse = communication.HttpPost(xmlRequest, config);
             try
             {
-                litleOnlineResponse litleOnlineResponse = DeserializeObject(xmlResponse);
+                var litleOnlineResponse = DeserializeObject(xmlResponse);
                 if ("1".Equals(litleOnlineResponse.response))
                 {
                     throw new LitleOnlineException(litleOnlineResponse.message);
@@ -408,22 +411,21 @@ namespace Litle.Sdk
             }
         }
 
-        public static String SerializeObject(litleOnlineRequest req)
+        public static string SerializeObject(litleOnlineRequest req)
         {
-            XmlSerializer serializer = new XmlSerializer(typeof(litleOnlineRequest));
-            MemoryStream ms = new MemoryStream();
+            var serializer = new XmlSerializer(typeof (litleOnlineRequest));
+            var ms = new MemoryStream();
             serializer.Serialize(ms, req);
-            return Encoding.UTF8.GetString(ms.GetBuffer());//return string is UTF8 encoded.
-        }// serialize the xml
+            return Encoding.UTF8.GetString(ms.GetBuffer()); //return string is UTF8 encoded.
+        } // serialize the xml
 
         public static litleOnlineResponse DeserializeObject(string response)
         {
-            XmlSerializer serializer = new XmlSerializer(typeof(litleOnlineResponse));
-            StringReader reader = new StringReader(response);
-            litleOnlineResponse i = (litleOnlineResponse)serializer.Deserialize(reader);
+            var serializer = new XmlSerializer(typeof (litleOnlineResponse));
+            var reader = new StringReader(response);
+            var i = (litleOnlineResponse) serializer.Deserialize(reader);
             return i;
-
-        }// deserialize the object
+        } // deserialize the object
 
         private void fillInReportGroup(transactionTypeWithReportGroup txn)
         {

--- a/LitleSdkForNet/LitleSdkForNet/LitleOnline.cs
+++ b/LitleSdkForNet/LitleSdkForNet/LitleOnline.cs
@@ -11,12 +11,14 @@ namespace Litle.Sdk
     {
         private Dictionary<String, String> config;
         private Communications communication;
+        private IDictionary<string, StringBuilder> _memoryStreams;
 
         /**
          * Construct a Litle online using the configuration specified in LitleSdkForNet.dll.config
          */
-        public LitleOnline()
+        public LitleOnline(IDictionary<string, StringBuilder> memoryStreams)
         {
+            _memoryStreams = memoryStreams;
             config = new Dictionary<String, String>();
             config["url"] = Properties.Settings.Default.url;
             config["reportGroup"] = Properties.Settings.Default.reportGroup;
@@ -29,7 +31,7 @@ namespace Litle.Sdk
             config["proxyPort"] = Properties.Settings.Default.proxyPort;
             config["logFile"] = Properties.Settings.Default.logFile;
             config["neuterAccountNums"] = Properties.Settings.Default.neuterAccountNums;
-            communication = new Communications();
+            communication = new Communications(_memoryStreams);
         }
 
         /**
@@ -48,10 +50,11 @@ namespace Litle.Sdk
          * proxyPort
          * printxml (possible values "true" and "false" - defaults to false)
          */
-        public LitleOnline(Dictionary<String, String> config)
+        public LitleOnline(IDictionary<string, StringBuilder> memoryStreams, Dictionary<String, String> config)
         {
+            _memoryStreams = memoryStreams;
             this.config = config;
-            communication = new Communications();
+            communication = new Communications(_memoryStreams);
         }
 
         public void setCommunication(Communications communication)

--- a/LitleSdkForNet/LitleSdkForNet/LitleOnlineException.cs
+++ b/LitleSdkForNet/LitleSdkForNet/LitleOnlineException.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Litle.Sdk
 {
@@ -8,12 +6,10 @@ namespace Litle.Sdk
     {
         public LitleOnlineException(string message) : base(message)
         {
-            
         }
 
         public LitleOnlineException(string message, Exception e) : base(message, e)
         {
-
         }
     }
 }

--- a/LitleSdkForNet/LitleSdkForNet/Settings.cs
+++ b/LitleSdkForNet/LitleSdkForNet/Settings.cs
@@ -1,27 +1,22 @@
-﻿namespace Litle.Sdk.Properties {
-    
-    
+﻿using System.ComponentModel;
+using System.Configuration;
+
+namespace Litle.Sdk.Properties
+{
     // This class allows you to handle specific events on the settings class:
     //  The SettingChanging event is raised before a setting's value is changed.
     //  The PropertyChanged event is raised after a setting's value is changed.
     //  The SettingsLoaded event is raised after the setting values are loaded.
     //  The SettingsSaving event is raised before the setting values are saved.
-    public sealed partial class Settings {
-        
-        public Settings() {
-            // // To add event handlers for saving and changing settings, uncomment the lines below:
-            //
-            // this.SettingChanging += this.SettingChangingEventHandler;
-            //
-            // this.SettingsSaving += this.SettingsSavingEventHandler;
-            //
-        }
-        
-        private void SettingChangingEventHandler(object sender, System.Configuration.SettingChangingEventArgs e) {
+    public sealed partial class Settings
+    {
+        private void SettingChangingEventHandler(object sender, SettingChangingEventArgs e)
+        {
             // Add code to handle the SettingChangingEvent event here.
         }
-        
-        private void SettingsSavingEventHandler(object sender, System.ComponentModel.CancelEventArgs e) {
+
+        private void SettingsSavingEventHandler(object sender, CancelEventArgs e)
+        {
             // Add code to handle the SettingsSaving event here.
         }
     }

--- a/LitleSdkForNet/LitleSdkForNet/XmlFields.cs
+++ b/LitleSdkForNet/LitleSdkForNet/XmlFields.cs
@@ -1,63 +1,58 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
+using System.CodeDom.Compiler;
+using System.Xml.Serialization;
+
 namespace Litle.Sdk
 {
-    /// <remarks/>
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "2.0.50727.42")]
-    [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.litle.com/schema")]
+    /// <remarks />
+    [GeneratedCode("xsd", "2.0.50727.42")]
+    [Serializable]
+    [XmlType(Namespace = "http://www.litle.com/schema")]
     public enum methodOfPaymentTypeEnum
     {
-
-        /// <remarks/>
+        /// <remarks />
         MC,
 
-        /// <remarks/>
+        /// <remarks />
         VI,
 
-        /// <remarks/>
+        /// <remarks />
         AX,
 
-        /// <remarks/>
+        /// <remarks />
         DC,
 
-        /// <remarks/>
+        /// <remarks />
         DI,
 
-        /// <remarks/>
+        /// <remarks />
         PP,
 
-        /// <remarks/>
+        /// <remarks />
         JC,
 
-        /// <remarks/>
+        /// <remarks />
         BL,
 
-        /// <remarks/>
+        /// <remarks />
         EC,
 
-        /// <remarks/>
+        /// <remarks />
         GC,
 
-        /// <remarks/>
-        [System.Xml.Serialization.XmlEnumAttribute("")]
-        Item,
+        /// <remarks />
+        [XmlEnum("")] Item
     }
 
     public abstract class methodOfPaymentSerializer
     {
-        public static String Serialize(methodOfPaymentTypeEnum mop)
+        public static string Serialize(methodOfPaymentTypeEnum mop)
         {
             if (mop == methodOfPaymentTypeEnum.Item)
             {
                 return "";
             }
-            else
-            {
-                return mop.ToString();
-
-            }
+            return mop.ToString();
         }
     }
 }

--- a/LitleSdkForNet/LitleSdkForNet/XmlRequestFields.cs
+++ b/LitleSdkForNet/LitleSdkForNet/XmlRequestFields.cs
@@ -1,14 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Security;
 using System.Xml.Serialization;
+using Litle.Sdk.Properties;
 
 namespace Litle.Sdk
 {
-    public partial class litleOnlineRequest
+    public class litleOnlineRequest
     {
-
         public string merchantId;
         public string merchantSdk;
         public authentication authentication;
@@ -45,8 +44,9 @@ namespace Litle.Sdk
 
         public string Serialize()
         {
-            string xml = "<?xml version='1.0' encoding='utf-8'?>\r\n<litleOnlineRequest merchantId=\"" + merchantId + "\" version=\"9.3\" merchantSdk=\"" + merchantSdk + "\" xmlns=\"http://www.litle.com/schema\">"
-                + authentication.Serialize();
+            var xml = "<?xml version='1.0' encoding='utf-8'?>\r\n<litleOnlineRequest merchantId=\"" + merchantId +
+                      "\" version=\"9.3\" merchantSdk=\"" + merchantSdk + "\" xmlns=\"http://www.litle.com/schema\">"
+                      + authentication.Serialize();
 
             if (authorization != null) xml += authorization.Serialize();
             else if (capture != null) xml += capture.Serialize();
@@ -85,19 +85,20 @@ namespace Litle.Sdk
     }
 
 
-    public partial class authentication
+    public class authentication
     {
         public string user;
         public string password;
-        public String Serialize()
+
+        public string Serialize()
         {
-            return "\r\n<authentication>\r\n<user>" + SecurityElement.Escape(user) + "</user>\r\n<password>" + SecurityElement.Escape(password) + "</password>\r\n</authentication>";
+            return "\r\n<authentication>\r\n<user>" + SecurityElement.Escape(user) + "</user>\r\n<password>" +
+                   SecurityElement.Escape(password) + "</password>\r\n</authentication>";
         }
     }
 
-    public partial class customerInfo
+    public class customerInfo
     {
-
         public string ssn;
 
         public DateTime dob;
@@ -106,42 +107,67 @@ namespace Litle.Sdk
 
         private customerInfoCustomerType customerTypeField;
         private bool customerTypeSet;
+
         public customerInfoCustomerType customerType
         {
-            get { return this.customerTypeField; }
-            set { this.customerTypeField = value; customerTypeSet = true; }
+            get { return customerTypeField; }
+            set
+            {
+                customerTypeField = value;
+                customerTypeSet = true;
+            }
         }
 
         private long incomeAmountField;
         private bool incomeAmountSet;
+
         public long incomeAmount
         {
-            get { return this.incomeAmountField; }
-            set { this.incomeAmountField = value; incomeAmountSet = true; }
+            get { return incomeAmountField; }
+            set
+            {
+                incomeAmountField = value;
+                incomeAmountSet = true;
+            }
         }
 
         private currencyCodeEnum incomeCurrencyField;
         private bool incomeCurrencySet;
+
         public currencyCodeEnum incomeCurrency
         {
-            get { return this.incomeCurrencyField; }
-            set { this.incomeCurrencyField = value; incomeCurrencySet = true; }
+            get { return incomeCurrencyField; }
+            set
+            {
+                incomeCurrencyField = value;
+                incomeCurrencySet = true;
+            }
         }
 
         private bool customerCheckingAccountField;
         private bool customerCheckingAccountSet;
+
         public bool customerCheckingAccount
         {
-            get { return this.customerCheckingAccountField; }
-            set { this.customerCheckingAccountField = value; customerCheckingAccountSet = true; }
+            get { return customerCheckingAccountField; }
+            set
+            {
+                customerCheckingAccountField = value;
+                customerCheckingAccountSet = true;
+            }
         }
 
         private bool customerSavingAccountField;
         private bool customerSavingAccountSet;
+
         public bool customerSavingAccount
         {
-            get { return this.customerSavingAccountField; }
-            set { this.customerSavingAccountField = value; customerSavingAccountSet = true; }
+            get { return customerSavingAccountField; }
+            set
+            {
+                customerSavingAccountField = value;
+                customerSavingAccountSet = true;
+            }
         }
 
         public string employerName;
@@ -150,44 +176,52 @@ namespace Litle.Sdk
 
         private customerInfoResidenceStatus residenceStatusField;
         private bool residenceStatusSet;
+
         public customerInfoResidenceStatus residenceStatus
         {
-            get { return this.residenceStatusField; }
-            set { this.residenceStatusField = value; residenceStatusSet = true; }
+            get { return residenceStatusField; }
+            set
+            {
+                residenceStatusField = value;
+                residenceStatusSet = true;
+            }
         }
 
         private int yearsAtResidenceField;
         private bool yearsAtResidenceSet;
+
         public int yearsAtResidence
         {
-            get { return this.yearsAtResidenceField; }
-            set { this.yearsAtResidenceField = value; yearsAtResidenceSet = true; }
+            get { return yearsAtResidenceField; }
+            set
+            {
+                yearsAtResidenceField = value;
+                yearsAtResidenceSet = true;
+            }
         }
 
         private int yearsAtEmployerField;
         private bool yearsAtEmployerSet;
+
         public int yearsAtEmployer
         {
-            get
-            {
-                return this.yearsAtEmployerField;
-            }
+            get { return yearsAtEmployerField; }
             set
             {
-                this.yearsAtEmployerField = value;
-                this.yearsAtEmployerSet = true;
+                yearsAtEmployerField = value;
+                yearsAtEmployerSet = true;
             }
         }
 
 
         public customerInfo()
         {
-            this.incomeCurrency = currencyCodeEnum.USD;
+            incomeCurrency = currencyCodeEnum.USD;
         }
 
         public string Serialize()
         {
-            string xml = "";
+            var xml = "";
             if (ssn != null)
             {
                 xml += "\r\n<ssn>" + SecurityElement.Escape(ssn) + "</ssn>";
@@ -198,7 +232,8 @@ namespace Litle.Sdk
             }
             if (customerRegistrationDate != null)
             {
-                xml += "\r\n<customerRegistrationDate>" + XmlUtil.toXsdDate(customerRegistrationDate) + "</customerRegistrationDate>";
+                xml += "\r\n<customerRegistrationDate>" + XmlUtil.toXsdDate(customerRegistrationDate) +
+                       "</customerRegistrationDate>";
             }
             if (customerTypeSet)
             {
@@ -214,11 +249,13 @@ namespace Litle.Sdk
             }
             if (customerCheckingAccountSet)
             {
-                xml += "\r\n<customerCheckingAccount>" + customerCheckingAccountField.ToString().ToLower() + "</customerCheckingAccount>";
+                xml += "\r\n<customerCheckingAccount>" + customerCheckingAccountField.ToString().ToLower() +
+                       "</customerCheckingAccount>";
             }
             if (customerSavingAccountSet)
             {
-                xml += "\r\n<customerSavingAccount>" + customerSavingAccountField.ToString().ToLower() + "</customerSavingAccount>";
+                xml += "\r\n<customerSavingAccount>" + customerSavingAccountField.ToString().ToLower() +
+                       "</customerSavingAccount>";
             }
             if (employerName != null)
             {
@@ -226,7 +263,8 @@ namespace Litle.Sdk
             }
             if (customerWorkTelephone != null)
             {
-                xml += "\r\n<customerWorkTelephone>" + SecurityElement.Escape(customerWorkTelephone) + "</customerWorkTelephone>";
+                xml += "\r\n<customerWorkTelephone>" + SecurityElement.Escape(customerWorkTelephone) +
+                       "</customerWorkTelephone>";
             }
             if (residenceStatusSet)
             {
@@ -242,22 +280,18 @@ namespace Litle.Sdk
             }
             return xml;
         }
-
-
     }
 
     public enum customerInfoCustomerType
     {
-
-        /// <remarks/>
+        /// <remarks />
         New,
-        Existing,
+        Existing
     }
 
     public enum currencyCodeEnum
     {
-
-        /// <remarks/>
+        /// <remarks />
         AUD,
         CAD,
         CHF,
@@ -270,80 +304,127 @@ namespace Litle.Sdk
         NZD,
         SEK,
         SGD,
-        USD,
+        USD
     }
 
     public enum customerInfoResidenceStatus
     {
-
-        /// <remarks/>
+        /// <remarks />
         Own,
         Rent,
-        Other,
+        Other
     }
 
-    public partial class enhancedData
+    public class enhancedData
     {
         public string customerReference;
         private long salesTaxField;
         private bool salesTaxSet;
+
         public long salesTax
         {
-            get { return this.salesTaxField; }
-            set { this.salesTaxField = value; this.salesTaxSet = true; }
+            get { return salesTaxField; }
+            set
+            {
+                salesTaxField = value;
+                salesTaxSet = true;
+            }
         }
+
         private enhancedDataDeliveryType deliveryTypeField;
         private bool deliveryTypeSet;
+
         public enhancedDataDeliveryType deliveryType
         {
-            get { return this.deliveryTypeField; }
-            set { this.deliveryTypeField = value; this.deliveryTypeSet = true; }
+            get { return deliveryTypeField; }
+            set
+            {
+                deliveryTypeField = value;
+                deliveryTypeSet = true;
+            }
         }
+
         public bool taxExemptField;
         public bool taxExemptSet;
+
         public bool taxExempt
         {
-            get { return this.taxExemptField; }
-            set { this.taxExemptField = value; this.taxExemptSet = true; }
+            get { return taxExemptField; }
+            set
+            {
+                taxExemptField = value;
+                taxExemptSet = true;
+            }
         }
+
         private long discountAmountField;
         private bool discountAmountSet;
+
         public long discountAmount
         {
-            get { return this.discountAmountField; }
-            set { this.discountAmountField = value; this.discountAmountSet = true; }
+            get { return discountAmountField; }
+            set
+            {
+                discountAmountField = value;
+                discountAmountSet = true;
+            }
         }
+
         private long shippingAmountField;
         private bool shippingAmountSet;
+
         public long shippingAmount
         {
-            get { return this.shippingAmountField; }
-            set { this.shippingAmountField = value; this.shippingAmountSet = true; }
+            get { return shippingAmountField; }
+            set
+            {
+                shippingAmountField = value;
+                shippingAmountSet = true;
+            }
         }
+
         private long dutyAmountField;
         private bool dutyAmountSet;
+
         public long dutyAmount
         {
-            get { return this.dutyAmountField; }
-            set { this.dutyAmountField = value; this.dutyAmountSet = true; }
+            get { return dutyAmountField; }
+            set
+            {
+                dutyAmountField = value;
+                dutyAmountSet = true;
+            }
         }
+
         public string shipFromPostalCode;
         public string destinationPostalCode;
         private countryTypeEnum destinationCountryCodeField;
         private bool destinationCountryCodeSet;
+
         public countryTypeEnum destinationCountry
         {
-            get { return this.destinationCountryCodeField; }
-            set { this.destinationCountryCodeField = value; this.destinationCountryCodeSet = true; }
+            get { return destinationCountryCodeField; }
+            set
+            {
+                destinationCountryCodeField = value;
+                destinationCountryCodeSet = true;
+            }
         }
+
         public string invoiceReferenceNumber;
         private DateTime orderDateField;
         private bool orderDateSet;
+
         public DateTime orderDate
         {
-            get { return this.orderDateField; }
-            set { this.orderDateField = value; this.orderDateSet = true; }
+            get { return orderDateField; }
+            set
+            {
+                orderDateField = value;
+                orderDateSet = true;
+            }
         }
+
         public List<detailTax> detailTaxes;
         public List<lineItemData> lineItems;
 
@@ -355,24 +436,31 @@ namespace Litle.Sdk
 
         public string Serialize()
         {
-            string xml = "";
-            if (customerReference != null) xml += "\r\n<customerReference>" + SecurityElement.Escape(customerReference) + "</customerReference>";
+            var xml = "";
+            if (customerReference != null)
+                xml += "\r\n<customerReference>" + SecurityElement.Escape(customerReference) + "</customerReference>";
             if (salesTaxSet) xml += "\r\n<salesTax>" + salesTaxField + "</salesTax>";
             if (deliveryTypeSet) xml += "\r\n<deliveryType>" + deliveryTypeField + "</deliveryType>";
             if (taxExemptSet) xml += "\r\n<taxExempt>" + taxExemptField.ToString().ToLower() + "</taxExempt>";
             if (discountAmountSet) xml += "\r\n<discountAmount>" + discountAmountField + "</discountAmount>";
             if (shippingAmountSet) xml += "\r\n<shippingAmount>" + shippingAmountField + "</shippingAmount>";
             if (dutyAmountSet) xml += "\r\n<dutyAmount>" + dutyAmountField + "</dutyAmount>";
-            if (shipFromPostalCode != null) xml += "\r\n<shipFromPostalCode>" + SecurityElement.Escape(shipFromPostalCode) + "</shipFromPostalCode>";
-            if (destinationPostalCode != null) xml += "\r\n<destinationPostalCode>" + SecurityElement.Escape(destinationPostalCode) + "</destinationPostalCode>";
-            if (destinationCountryCodeSet) xml += "\r\n<destinationCountryCode>" + destinationCountryCodeField + "</destinationCountryCode>";
-            if (invoiceReferenceNumber != null) xml += "\r\n<invoiceReferenceNumber>" + SecurityElement.Escape(invoiceReferenceNumber) + "</invoiceReferenceNumber>";
+            if (shipFromPostalCode != null)
+                xml += "\r\n<shipFromPostalCode>" + SecurityElement.Escape(shipFromPostalCode) + "</shipFromPostalCode>";
+            if (destinationPostalCode != null)
+                xml += "\r\n<destinationPostalCode>" + SecurityElement.Escape(destinationPostalCode) +
+                       "</destinationPostalCode>";
+            if (destinationCountryCodeSet)
+                xml += "\r\n<destinationCountryCode>" + destinationCountryCodeField + "</destinationCountryCode>";
+            if (invoiceReferenceNumber != null)
+                xml += "\r\n<invoiceReferenceNumber>" + SecurityElement.Escape(invoiceReferenceNumber) +
+                       "</invoiceReferenceNumber>";
             if (orderDateSet) xml += "\r\n<orderDate>" + XmlUtil.toXsdDate(orderDateField) + "</orderDate>";
-            foreach (detailTax detailTax in detailTaxes)
+            foreach (var detailTax in detailTaxes)
             {
                 xml += "\r\n<detailTax>" + detailTax.Serialize() + "\r\n</detailTax>";
             }
-            foreach (lineItemData lineItem in lineItems)
+            foreach (var lineItem in lineItems)
             {
                 xml += "\r\n<lineItemData>" + lineItem.Serialize() + "\r\n</lineItemData>";
             }
@@ -380,14 +468,14 @@ namespace Litle.Sdk
         }
     }
 
-    public partial class voidTxn : transactionTypeWithReportGroup
+    public class voidTxn : transactionTypeWithReportGroup
     {
         public long litleTxnId;
         public processingInstructions processingInstructions;
 
         public override string Serialize()
         {
-            string xml = "\r\n<void";
+            var xml = "\r\n<void";
             xml += " id=\"" + SecurityElement.Escape(id) + "\"";
             if (customerId != null)
             {
@@ -396,55 +484,86 @@ namespace Litle.Sdk
             xml += " reportGroup=\"" + SecurityElement.Escape(reportGroup) + "\"";
             xml += ">";
             xml += "\r\n<litleTxnId>" + litleTxnId + "</litleTxnId>";
-            if (processingInstructions != null) xml += "\r\n<processingInstructions>" + processingInstructions.Serialize() + "\r\n</processingInstructions>";
+            if (processingInstructions != null)
+                xml += "\r\n<processingInstructions>" + processingInstructions.Serialize() +
+                       "\r\n</processingInstructions>";
             xml += "\r\n</void>";
 
             return xml;
         }
-
     }
 
-    public partial class lineItemData
+    public class lineItemData
     {
         private int itemSeqenceNumberField;
         private bool itemSequenceNumberSet;
+
         public int itemSequenceNumber
         {
-            get { return this.itemSeqenceNumberField; }
-            set { this.itemSeqenceNumberField = value; this.itemSequenceNumberSet = true; }
+            get { return itemSeqenceNumberField; }
+            set
+            {
+                itemSeqenceNumberField = value;
+                itemSequenceNumberSet = true;
+            }
         }
+
         public string itemDescription;
         public string productCode;
         public string quantity;
         public string unitOfMeasure;
         private long taxAmountField;
         private bool taxAmountSet;
+
         public long taxAmount
         {
-            get { return this.taxAmountField; }
-            set { this.taxAmountField = value; this.taxAmountSet = true; }
+            get { return taxAmountField; }
+            set
+            {
+                taxAmountField = value;
+                taxAmountSet = true;
+            }
         }
+
         private long lineItemTotalField;
         private bool lineItemTotalSet;
+
         public long lineItemTotal
         {
-            get { return this.lineItemTotalField; }
-            set { this.lineItemTotalField = value; this.lineItemTotalSet = true; }
+            get { return lineItemTotalField; }
+            set
+            {
+                lineItemTotalField = value;
+                lineItemTotalSet = true;
+            }
         }
+
         private long lineItemTotalWithTaxField;
         private bool lineItemTotalWithTaxSet;
+
         public long lineItemTotalWithTax
         {
-            get { return this.lineItemTotalWithTaxField; }
-            set { this.lineItemTotalWithTaxField = value; this.lineItemTotalWithTaxSet = true; }
+            get { return lineItemTotalWithTaxField; }
+            set
+            {
+                lineItemTotalWithTaxField = value;
+                lineItemTotalWithTaxSet = true;
+            }
         }
+
         private long itemDiscountAmountField;
         private bool itemDiscountAmountSet;
+
         public long itemDiscountAmount
         {
-            get { return this.itemDiscountAmountField; }
-            set { this.itemDiscountAmountField = value; this.itemDiscountAmountSet = true; }
+            get { return itemDiscountAmountField; }
+            set
+            {
+                itemDiscountAmountField = value;
+                itemDiscountAmountSet = true;
+            }
         }
+
         public string commodityCode;
         public string unitCost;
         public List<detailTax> detailTaxes;
@@ -456,109 +575,160 @@ namespace Litle.Sdk
 
         public string Serialize()
         {
-            string xml = "";
-            if (itemSequenceNumberSet) xml += "\r\n<itemSequenceNumber>" + itemSeqenceNumberField + "</itemSequenceNumber>";
-            if (itemDescription != null) xml += "\r\n<itemDescription>" + SecurityElement.Escape(itemDescription) + "</itemDescription>";
-            if (productCode != null) xml += "\r\n<productCode>" + SecurityElement.Escape(productCode) + "</productCode>";
+            var xml = "";
+            if (itemSequenceNumberSet)
+                xml += "\r\n<itemSequenceNumber>" + itemSeqenceNumberField + "</itemSequenceNumber>";
+            if (itemDescription != null)
+                xml += "\r\n<itemDescription>" + SecurityElement.Escape(itemDescription) + "</itemDescription>";
+            if (productCode != null)
+                xml += "\r\n<productCode>" + SecurityElement.Escape(productCode) + "</productCode>";
             if (quantity != null) xml += "\r\n<quantity>" + SecurityElement.Escape(quantity) + "</quantity>";
-            if (unitOfMeasure != null) xml += "\r\n<unitOfMeasure>" + SecurityElement.Escape(unitOfMeasure) + "</unitOfMeasure>";
+            if (unitOfMeasure != null)
+                xml += "\r\n<unitOfMeasure>" + SecurityElement.Escape(unitOfMeasure) + "</unitOfMeasure>";
             if (taxAmountSet) xml += "\r\n<taxAmount>" + taxAmountField + "</taxAmount>";
             if (lineItemTotalSet) xml += "\r\n<lineItemTotal>" + lineItemTotalField + "</lineItemTotal>";
-            if (lineItemTotalWithTaxSet) xml += "\r\n<lineItemTotalWithTax>" + lineItemTotalWithTaxField + "</lineItemTotalWithTax>";
-            if (itemDiscountAmountSet) xml += "\r\n<itemDiscountAmount>" + itemDiscountAmountField + "</itemDiscountAmount>";
-            if (commodityCode != null) xml += "\r\n<commodityCode>" + SecurityElement.Escape(commodityCode) + "</commodityCode>";
+            if (lineItemTotalWithTaxSet)
+                xml += "\r\n<lineItemTotalWithTax>" + lineItemTotalWithTaxField + "</lineItemTotalWithTax>";
+            if (itemDiscountAmountSet)
+                xml += "\r\n<itemDiscountAmount>" + itemDiscountAmountField + "</itemDiscountAmount>";
+            if (commodityCode != null)
+                xml += "\r\n<commodityCode>" + SecurityElement.Escape(commodityCode) + "</commodityCode>";
             if (unitCost != null) xml += "\r\n<unitCost>" + SecurityElement.Escape(unitCost) + "</unitCost>";
-            foreach (detailTax detailTax in detailTaxes)
+            foreach (var detailTax in detailTaxes)
             {
                 if (detailTax != null) xml += "\r\n<detailTax>" + detailTax.Serialize() + "</detailTax>";
             }
             return xml;
         }
-
     }
 
 
-    public partial class detailTax
+    public class detailTax
     {
         private bool taxIncludedInTotalField;
         private bool taxIncludedInTotalSet;
+
         public bool taxIncludedInTotal
         {
-            get { return this.taxIncludedInTotalField; }
-            set { this.taxIncludedInTotalField = value; this.taxIncludedInTotalSet = true; }
+            get { return taxIncludedInTotalField; }
+            set
+            {
+                taxIncludedInTotalField = value;
+                taxIncludedInTotalSet = true;
+            }
         }
+
         private long taxAmountField;
         private bool taxAmountSet;
+
         public long taxAmount
         {
-            get { return this.taxAmountField; }
-            set { this.taxAmountField = value; this.taxAmountSet = true; }
+            get { return taxAmountField; }
+            set
+            {
+                taxAmountField = value;
+                taxAmountSet = true;
+            }
         }
+
         public string taxRate;
         private taxTypeIdentifierEnum taxTypeIdentifierField;
         private bool taxTypeIdentifierSet;
+
         public taxTypeIdentifierEnum taxTypeIdentifier
         {
-            get { return this.taxTypeIdentifierField; }
-            set { this.taxTypeIdentifierField = value; this.taxTypeIdentifierSet = true; }
+            get { return taxTypeIdentifierField; }
+            set
+            {
+                taxTypeIdentifierField = value;
+                taxTypeIdentifierSet = true;
+            }
         }
+
         public string cardAcceptorTaxId;
 
         public string Serialize()
         {
-            string xml = "";
-            if (taxIncludedInTotalSet) xml += "\r\n<taxIncludedInTotal>" + taxIncludedInTotalField.ToString().ToLower() + "</taxIncludedInTotal>";
+            var xml = "";
+            if (taxIncludedInTotalSet)
+                xml += "\r\n<taxIncludedInTotal>" + taxIncludedInTotalField.ToString().ToLower() +
+                       "</taxIncludedInTotal>";
             if (taxAmountSet) xml += "\r\n<taxAmount>" + taxAmountField + "</taxAmount>";
             if (taxRate != null) xml += "\r\n<taxRate>" + SecurityElement.Escape(taxRate) + "</taxRate>";
-            if (taxTypeIdentifierSet) xml += "\r\n<taxTypeIdentifier>" + taxTypeIdentifierField + "</taxTypeIdentifier>";
-            if (cardAcceptorTaxId != null) xml += "\r\n<cardAcceptorTaxId>" + SecurityElement.Escape(cardAcceptorTaxId) + "</cardAcceptorTaxId>";
+            if (taxTypeIdentifierSet)
+                xml += "\r\n<taxTypeIdentifier>" + taxTypeIdentifierField + "</taxTypeIdentifier>";
+            if (cardAcceptorTaxId != null)
+                xml += "\r\n<cardAcceptorTaxId>" + SecurityElement.Escape(cardAcceptorTaxId) + "</cardAcceptorTaxId>";
             return xml;
         }
     }
 
-    public partial class transactionTypeWithReportGroupAndPartial : transactionType
+    public class transactionTypeWithReportGroupAndPartial : transactionType
     {
         public string reportGroup;
         private bool partialField;
         protected bool partialSet;
+
         public bool partial
         {
-            get { return this.partialField; }
-            set { this.partialField = value; partialSet = true; }
+            get { return partialField; }
+            set
+            {
+                partialField = value;
+                partialSet = true;
+            }
         }
     }
 
-    public partial class capture : transactionTypeWithReportGroupAndPartial
+    public class capture : transactionTypeWithReportGroupAndPartial
     {
         public long litleTxnId;
         private long amountField;
         private bool amountSet;
+
         public long amount
         {
-            get { return this.amountField; }
-            set { this.amountField = value; amountSet = true; }
+            get { return amountField; }
+            set
+            {
+                amountField = value;
+                amountSet = true;
+            }
         }
+
         private bool surchargeAmountSet;
         private long surchargeAmountField;
+
         public long surchargeAmount
         {
-            get { return this.surchargeAmountField; }
-            set { this.surchargeAmountField = value; this.surchargeAmountSet = true; }
+            get { return surchargeAmountField; }
+            set
+            {
+                surchargeAmountField = value;
+                surchargeAmountSet = true;
+            }
         }
+
         public enhancedData enhancedData;
         public processingInstructions processingInstructions;
         private bool payPalOrderCompleteField;
         private bool payPalOrderCompleteSet;
+
         public bool payPalOrderComplete
         {
-            get { return this.payPalOrderCompleteField; }
-            set { this.payPalOrderCompleteField = value; payPalOrderCompleteSet = true; }
+            get { return payPalOrderCompleteField; }
+            set
+            {
+                payPalOrderCompleteField = value;
+                payPalOrderCompleteSet = true;
+            }
         }
+
         public string payPalNotes;
 
         public override string Serialize()
         {
-            string xml = "\r\n<capture";
+            var xml = "\r\n<capture";
             xml += " id=\"" + SecurityElement.Escape(id) + "\"";
             if (customerId != null)
             {
@@ -574,45 +744,68 @@ namespace Litle.Sdk
             if (amountSet) xml += "\r\n<amount>" + amountField + "</amount>";
             if (surchargeAmountSet) xml += "\r\n<surchargeAmount>" + surchargeAmountField + "</surchargeAmount>";
             if (enhancedData != null) xml += "\r\n<enhancedData>" + enhancedData.Serialize() + "\r\n</enhancedData>";
-            if (processingInstructions != null) xml += "\r\n<processingInstructions>" + processingInstructions.Serialize() + "\r\n</processingInstructions>";
-            if (payPalOrderCompleteSet) xml += "\r\n<payPalOrderComplete>" + payPalOrderCompleteField.ToString().ToLower() + "</payPalOrderComplete>";
-            if (payPalNotes != null) xml += "\r\n<payPalNotes>" + SecurityElement.Escape(payPalNotes) + "</payPalNotes>";
+            if (processingInstructions != null)
+                xml += "\r\n<processingInstructions>" + processingInstructions.Serialize() +
+                       "\r\n</processingInstructions>";
+            if (payPalOrderCompleteSet)
+                xml += "\r\n<payPalOrderComplete>" + payPalOrderCompleteField.ToString().ToLower() +
+                       "</payPalOrderComplete>";
+            if (payPalNotes != null)
+                xml += "\r\n<payPalNotes>" + SecurityElement.Escape(payPalNotes) + "</payPalNotes>";
             xml += "\r\n</capture>";
 
             return xml;
         }
     }
 
-    public partial class echeckCredit : transactionTypeWithReportGroup
+    public class echeckCredit : transactionTypeWithReportGroup
     {
         private long litleTxnIdField;
         private bool litleTxnIdSet;
+
         public long litleTxnId
         {
-            get { return this.litleTxnIdField; }
-            set { this.litleTxnIdField = value; litleTxnIdSet = true; }
+            get { return litleTxnIdField; }
+            set
+            {
+                litleTxnIdField = value;
+                litleTxnIdSet = true;
+            }
         }
+
         private long amountField;
         private bool amountSet;
+
         public long amount
         {
-            get { return this.amountField; }
-            set { this.amountField = value; amountSet = true; }
+            get { return amountField; }
+            set
+            {
+                amountField = value;
+                amountSet = true;
+            }
         }
+
         private bool secondaryAmountSet;
         private long secondaryAmountField;
+
         public long secondaryAmount
         {
-            get { return this.secondaryAmountField; }
-            set { this.secondaryAmountField = value; this.secondaryAmountSet = true; }
+            get { return secondaryAmountField; }
+            set
+            {
+                secondaryAmountField = value;
+                secondaryAmountSet = true;
+            }
         }
+
         public customBilling customBilling;
         public string orderId;
         public orderSourceType orderSource;
         public contact billToAddress;
         public echeckType echeck;
 
-        [Obsolete()]
+        [Obsolete]
         public echeckTokenType token
         {
             get { return echeckToken; }
@@ -625,7 +818,7 @@ namespace Litle.Sdk
 
         public override string Serialize()
         {
-            string xml = "\r\n<echeckCredit";
+            var xml = "\r\n<echeckCredit";
             xml += " id=\"" + SecurityElement.Escape(id) + "\"";
             if (customerId != null)
             {
@@ -639,7 +832,8 @@ namespace Litle.Sdk
                 xml += "\r\n<litleTxnId>" + litleTxnIdField + "</litleTxnId>";
                 if (amountSet) xml += "\r\n<amount>" + amountField + "</amount>";
                 if (secondaryAmountSet) xml += "\r\n<secondaryAmount>" + secondaryAmountField + "</secondaryAmount>";
-                if (customBilling != null) xml += "\r\n<customBilling>" + customBilling.Serialize() + "</customBilling>";
+                if (customBilling != null)
+                    xml += "\r\n<customBilling>" + customBilling.Serialize() + "</customBilling>";
             }
             else
             {
@@ -647,10 +841,12 @@ namespace Litle.Sdk
                 xml += "\r\n<amount>" + amountField + "</amount>";
                 if (secondaryAmountSet) xml += "\r\n<secondaryAmount>" + secondaryAmountField + "</secondaryAmount>";
                 if (orderSource != null) xml += "\r\n<orderSource>" + orderSource.Serialize() + "</orderSource>";
-                if (billToAddress != null) xml += "\r\n<billToAddress>" + billToAddress.Serialize() + "</billToAddress>";
+                if (billToAddress != null)
+                    xml += "\r\n<billToAddress>" + billToAddress.Serialize() + "</billToAddress>";
                 if (echeck != null) xml += "\r\n<echeck>" + echeck.Serialize() + "</echeck>";
                 else if (echeckToken != null) xml += "\r\n<echeckToken>" + echeckToken.Serialize() + "</echeckToken>";
-                if (customBilling != null) xml += "\r\n<customBilling>" + customBilling.Serialize() + "</customBilling>";
+                if (customBilling != null)
+                    xml += "\r\n<customBilling>" + customBilling.Serialize() + "</customBilling>";
                 if (merchantData != null) xml += "\r\n<merchantData>" + merchantData.Serialize() + "</merchantData>";
             }
             xml += "\r\n</echeckCredit>";
@@ -658,38 +854,62 @@ namespace Litle.Sdk
         }
     }
 
-    public partial class echeckSale : transactionTypeWithReportGroup
+    public class echeckSale : transactionTypeWithReportGroup
     {
         private long litleTxnIdField;
         private bool litleTxnIdSet;
+
         public long litleTxnId
         {
-            get { return this.litleTxnIdField; }
-            set { this.litleTxnIdField = value; litleTxnIdSet = true; }
+            get { return litleTxnIdField; }
+            set
+            {
+                litleTxnIdField = value;
+                litleTxnIdSet = true;
+            }
         }
+
         private long amountField;
         private bool amountSet;
+
         public long amount
         {
-            get { return this.amountField; }
-            set { this.amountField = value; amountSet = true; }
+            get { return amountField; }
+            set
+            {
+                amountField = value;
+                amountSet = true;
+            }
         }
+
         private bool secondaryAmountSet;
         private long secondaryAmountField;
+
         public long secondaryAmount
         {
-            get { return this.secondaryAmountField; }
-            set { this.secondaryAmountField = value; this.secondaryAmountSet = true; }
+            get { return secondaryAmountField; }
+            set
+            {
+                secondaryAmountField = value;
+                secondaryAmountSet = true;
+            }
         }
+
         public customBilling customBilling;
         public string orderId;
         private bool verifyField;
         private bool verifySet;
+
         public bool verify
         {
-            get { return this.verifyField; }
-            set { this.verifyField = value; verifySet = true; }
+            get { return verifyField; }
+            set
+            {
+                verifyField = value;
+                verifySet = true;
+            }
         }
+
         public orderSourceType orderSource;
         public contact billToAddress;
         public contact shipToAddress;
@@ -699,7 +919,7 @@ namespace Litle.Sdk
 
         public override string Serialize()
         {
-            string xml = "\r\n<echeckSale";
+            var xml = "\r\n<echeckSale";
             xml += " id=\"" + SecurityElement.Escape(id) + "\"";
             if (customerId != null)
             {
@@ -714,7 +934,8 @@ namespace Litle.Sdk
                 if (amountSet) xml += "\r\n<amount>" + amountField + "</amount>";
                 // let sandbox do the validation for secondaryAmount
                 if (secondaryAmountSet) xml += "\r\n<secondaryAmount>" + secondaryAmountField + "</secondaryAmount>";
-                if (customBilling != null) xml += "\r\n<customBilling>" + customBilling.Serialize() + "</customBilling>";
+                if (customBilling != null)
+                    xml += "\r\n<customBilling>" + customBilling.Serialize() + "</customBilling>";
             }
             else
             {
@@ -723,11 +944,14 @@ namespace Litle.Sdk
                 xml += "\r\n<amount>" + amountField + "</amount>";
                 if (secondaryAmountSet) xml += "\r\n<secondaryAmount>" + secondaryAmountField + "</secondaryAmount>";
                 if (orderSource != null) xml += "\r\n<orderSource>" + orderSource.Serialize() + "</orderSource>";
-                if (billToAddress != null) xml += "\r\n<billToAddress>" + billToAddress.Serialize() + "</billToAddress>";
-                if (shipToAddress != null) xml += "\r\n<shipToAddress>" + shipToAddress.Serialize() + "</shipToAddress>";
+                if (billToAddress != null)
+                    xml += "\r\n<billToAddress>" + billToAddress.Serialize() + "</billToAddress>";
+                if (shipToAddress != null)
+                    xml += "\r\n<shipToAddress>" + shipToAddress.Serialize() + "</shipToAddress>";
                 if (echeck != null) xml += "\r\n<echeck>" + echeck.Serialize() + "</echeck>";
                 else if (token != null) xml += "\r\n<echeckToken>" + token.Serialize() + "</echeckToken>";
-                if (customBilling != null) xml += "\r\n<customBilling>" + customBilling.Serialize() + "</customBilling>";
+                if (customBilling != null)
+                    xml += "\r\n<customBilling>" + customBilling.Serialize() + "</customBilling>";
                 if (merchantData != null) xml += "\r\n<merchantData>" + merchantData.Serialize() + "</merchantData>";
             }
             xml += "\r\n</echeckSale>";
@@ -736,23 +960,35 @@ namespace Litle.Sdk
     }
 
 
-    public partial class echeckVerification : transactionTypeWithReportGroup
+    public class echeckVerification : transactionTypeWithReportGroup
     {
         private long litleTxnIdField;
         private bool litleTxnIdSet;
+
         public long litleTxnId
         {
-            get { return this.litleTxnIdField; }
-            set { this.litleTxnIdField = value; litleTxnIdSet = true; }
+            get { return litleTxnIdField; }
+            set
+            {
+                litleTxnIdField = value;
+                litleTxnIdSet = true;
+            }
         }
+
         public string orderId;
         private long amountField;
         private bool amountSet;
+
         public long amount
         {
-            get { return this.amountField; }
-            set { this.amountField = value; amountSet = true; }
+            get { return amountField; }
+            set
+            {
+                amountField = value;
+                amountSet = true;
+            }
         }
+
         public orderSourceType orderSource;
         public contact billToAddress;
         public echeckType echeck;
@@ -761,7 +997,7 @@ namespace Litle.Sdk
 
         public override string Serialize()
         {
-            string xml = "\r\n<echeckVerification";
+            var xml = "\r\n<echeckVerification";
             xml += " id=\"" + SecurityElement.Escape(id) + "\"";
             if (customerId != null)
             {
@@ -783,7 +1019,7 @@ namespace Litle.Sdk
         }
     }
 
-    public partial class registerTokenRequestType : transactionTypeWithReportGroup
+    public class registerTokenRequestType : transactionTypeWithReportGroup
     {
         public string orderId;
         public string accountNumber;
@@ -794,7 +1030,7 @@ namespace Litle.Sdk
 
         public override string Serialize()
         {
-            string xml = "\r\n<registerTokenRequest";
+            var xml = "\r\n<registerTokenRequest";
             xml += " id=\"" + SecurityElement.Escape(id) + "\"";
             if (customerId != null)
             {
@@ -805,16 +1041,19 @@ namespace Litle.Sdk
 
             xml += "\r\n<orderId>" + orderId + "</orderId>";
             if (accountNumber != null) xml += "\r\n<accountNumber>" + accountNumber + "</accountNumber>";
-            else if (echeckForToken != null) xml += "\r\n<echeckForToken>" + echeckForToken.Serialize() + "</echeckForToken>";
-            else if (paypageRegistrationId != null) xml += "\r\n<paypageRegistrationId>" + paypageRegistrationId + "</paypageRegistrationId>";
+            else if (echeckForToken != null)
+                xml += "\r\n<echeckForToken>" + echeckForToken.Serialize() + "</echeckForToken>";
+            else if (paypageRegistrationId != null)
+                xml += "\r\n<paypageRegistrationId>" + paypageRegistrationId + "</paypageRegistrationId>";
             else if (applepay != null) xml += "\r\n<applepay>" + applepay.Serialize() + "\r\n</applepay>";
-            if (cardValidationNum != null) xml += "\r\n<cardValidationNum>" + cardValidationNum + "</cardValidationNum>";
+            if (cardValidationNum != null)
+                xml += "\r\n<cardValidationNum>" + cardValidationNum + "</cardValidationNum>";
             xml += "\r\n</registerTokenRequest>";
             return xml;
         }
     }
 
-    public partial class updateCardValidationNumOnToken : transactionTypeWithReportGroup
+    public class updateCardValidationNumOnToken : transactionTypeWithReportGroup
     {
         public string orderId;
         public string litleToken;
@@ -822,7 +1061,7 @@ namespace Litle.Sdk
 
         public override string Serialize()
         {
-            string xml = "\r\n<updateCardValidationNumOnToken";
+            var xml = "\r\n<updateCardValidationNumOnToken";
             xml += " id=\"" + SecurityElement.Escape(id) + "\"";
             if (customerId != null)
             {
@@ -833,20 +1072,21 @@ namespace Litle.Sdk
 
             if (orderId != null) xml += "\r\n<orderId>" + SecurityElement.Escape(orderId) + "</orderId>";
             if (litleToken != null) xml += "\r\n<litleToken>" + SecurityElement.Escape(litleToken) + "</litleToken>";
-            if (cardValidationNum != null) xml += "\r\n<cardValidationNum>" + SecurityElement.Escape(cardValidationNum) + "</cardValidationNum>";
+            if (cardValidationNum != null)
+                xml += "\r\n<cardValidationNum>" + SecurityElement.Escape(cardValidationNum) + "</cardValidationNum>";
             xml += "\r\n</updateCardValidationNumOnToken>";
             return xml;
         }
     }
 
-    public partial class echeckForTokenType
+    public class echeckForTokenType
     {
         public string accNum;
         public string routingNum;
 
         public string Serialize()
         {
-            string xml = "";
+            var xml = "";
             if (accNum != null) xml += "\r\n<accNum>" + SecurityElement.Escape(accNum) + "</accNum>";
             if (routingNum != null) xml += "\r\n<routingNum>" + SecurityElement.Escape(routingNum) + "</routingNum>";
             return xml;
@@ -854,36 +1094,60 @@ namespace Litle.Sdk
     }
 
 
-    public partial class credit : transactionTypeWithReportGroup
+    public class credit : transactionTypeWithReportGroup
     {
         private long litleTxnIdField;
         private bool litleTxnIdSet;
+
         public long litleTxnId
         {
-            get { return this.litleTxnIdField; }
-            set { this.litleTxnIdField = value; litleTxnIdSet = true; }
+            get { return litleTxnIdField; }
+            set
+            {
+                litleTxnIdField = value;
+                litleTxnIdSet = true;
+            }
         }
+
         private long amountField;
         private bool amountSet;
+
         public long amount
         {
-            get { return this.amountField; }
-            set { this.amountField = value; amountSet = true; }
+            get { return amountField; }
+            set
+            {
+                amountField = value;
+                amountSet = true;
+            }
         }
+
         private bool secondaryAmountSet;
         private long secondaryAmountField;
+
         public long secondaryAmount
         {
-            get { return this.secondaryAmountField; }
-            set { this.secondaryAmountField = value; this.secondaryAmountSet = true; }
+            get { return secondaryAmountField; }
+            set
+            {
+                secondaryAmountField = value;
+                secondaryAmountSet = true;
+            }
         }
+
         private bool surchargeAmountSet;
         private long surchargeAmountField;
+
         public long surchargeAmount
         {
-            get { return this.surchargeAmountField; }
-            set { this.surchargeAmountField = value; this.surchargeAmountSet = true; }
+            get { return surchargeAmountField; }
+            set
+            {
+                surchargeAmountField = value;
+                surchargeAmountSet = true;
+            }
         }
+
         public customBilling customBilling;
         public enhancedData enhancedData;
         public processingInstructions processingInstructions;
@@ -897,21 +1161,27 @@ namespace Litle.Sdk
         public payPal paypal;
         private taxTypeIdentifierEnum taxTypeField;
         private bool taxTypeSet;
+
         public taxTypeIdentifierEnum taxType
         {
-            get { return this.taxTypeField; }
-            set { this.taxTypeField = value; taxTypeSet = true; }
+            get { return taxTypeField; }
+            set
+            {
+                taxTypeField = value;
+                taxTypeSet = true;
+            }
         }
+
         public billMeLaterRequest billMeLaterRequest;
         public pos pos;
         public amexAggregatorData amexAggregatorData;
         public merchantDataType merchantData;
-        public String payPalNotes;
-        public String actionReason;
+        public string payPalNotes;
+        public string actionReason;
 
         public override string Serialize()
         {
-            string xml = "\r\n<credit";
+            var xml = "\r\n<credit";
             xml += " id=\"" + SecurityElement.Escape(id) + "\"";
             if (customerId != null)
             {
@@ -926,9 +1196,12 @@ namespace Litle.Sdk
                 if (amountSet) xml += "\r\n<amount>" + amountField + "</amount>";
                 if (secondaryAmountSet) xml += "\r\n<secondaryAmount>" + secondaryAmountField + "</secondaryAmount>";
                 if (surchargeAmountSet) xml += "\r\n<surchargeAmount>" + surchargeAmountField + "</surchargeAmount>";
-                if (customBilling != null) xml += "\r\n<customBilling>" + customBilling.Serialize() + "</customBilling>";
+                if (customBilling != null)
+                    xml += "\r\n<customBilling>" + customBilling.Serialize() + "</customBilling>";
                 if (enhancedData != null) xml += "\r\n<enhancedData>" + enhancedData.Serialize() + "</enhancedData>";
-                if (processingInstructions != null) xml += "\r\n<processingInstructions>" + processingInstructions.Serialize() + "</processingInstructions>";
+                if (processingInstructions != null)
+                    xml += "\r\n<processingInstructions>" + processingInstructions.Serialize() +
+                           "</processingInstructions>";
                 if (pos != null) xml += "\r\n<pos>" + pos.Serialize() + "</pos>";
             }
             else
@@ -938,7 +1211,8 @@ namespace Litle.Sdk
                 if (secondaryAmountSet) xml += "\r\n<secondaryAmount>" + secondaryAmountField + "</secondaryAmount>";
                 if (surchargeAmountSet) xml += "\r\n<surchargeAmount>" + surchargeAmountField + "</surchargeAmount>";
                 if (orderSource != null) xml += "\r\n<orderSource>" + orderSource.Serialize() + "</orderSource>";
-                if (billToAddress != null) xml += "\r\n<billToAddress>" + billToAddress.Serialize() + "</billToAddress>";
+                if (billToAddress != null)
+                    xml += "\r\n<billToAddress>" + billToAddress.Serialize() + "</billToAddress>";
                 if (card != null) xml += "\r\n<card>" + card.Serialize() + "</card>";
                 else if (token != null) xml += "\r\n<token>" + token.Serialize() + "</token>";
                 else if (mpos != null) xml += "\r\n<mpos>" + mpos.Serialize() + "</mpos>";
@@ -946,34 +1220,48 @@ namespace Litle.Sdk
                 else if (paypal != null)
                 {
                     xml += "\r\n<paypal>";
-                    if (paypal.payerId != null) xml += "\r\n<payerId>" + SecurityElement.Escape(paypal.payerId) + "</payerId>";
-                    else if (paypal.payerEmail != null) xml += "\r\n<payerEmail>" + SecurityElement.Escape(paypal.payerEmail) + "</payerEmail>";
+                    if (paypal.payerId != null)
+                        xml += "\r\n<payerId>" + SecurityElement.Escape(paypal.payerId) + "</payerId>";
+                    else if (paypal.payerEmail != null)
+                        xml += "\r\n<payerEmail>" + SecurityElement.Escape(paypal.payerEmail) + "</payerEmail>";
                     xml += "\r\n</paypal>";
                 }
-                if (customBilling != null) xml += "\r\n<customBilling>" + customBilling.Serialize() + "</customBilling>";
+                if (customBilling != null)
+                    xml += "\r\n<customBilling>" + customBilling.Serialize() + "</customBilling>";
                 if (taxTypeSet) xml += "\r\n<taxType>" + taxTypeField + "</taxType>";
-                if (billMeLaterRequest != null) xml += "\r\n<billMeLaterRequest>" + billMeLaterRequest.Serialize() + "</billMeLaterRequest>";
+                if (billMeLaterRequest != null)
+                    xml += "\r\n<billMeLaterRequest>" + billMeLaterRequest.Serialize() + "</billMeLaterRequest>";
                 if (enhancedData != null) xml += "\r\n<enhancedData>" + enhancedData.Serialize() + "</enhancedData>";
-                if (processingInstructions != null) xml += "\r\n<processingInstructions>" + processingInstructions.Serialize() + "</processingInstructions>";
+                if (processingInstructions != null)
+                    xml += "\r\n<processingInstructions>" + processingInstructions.Serialize() +
+                           "</processingInstructions>";
                 if (pos != null) xml += "\r\n<pos>" + pos.Serialize() + "</pos>";
-                if (amexAggregatorData != null) xml += "\r\n<amexAggregatorData>" + amexAggregatorData.Serialize() + "</amexAggregatorData>";
+                if (amexAggregatorData != null)
+                    xml += "\r\n<amexAggregatorData>" + amexAggregatorData.Serialize() + "</amexAggregatorData>";
                 if (merchantData != null) xml += "\r\n<merchantData>" + merchantData.Serialize() + "</merchantData>";
             }
-            if (payPalNotes != null) xml += "\r\n<payPalNotes>" + SecurityElement.Escape(payPalNotes) + "</payPalNotes>";
-            if (actionReason != null) xml += "\r\n<actionReason>" + SecurityElement.Escape(actionReason) + "</actionReason>";
+            if (payPalNotes != null)
+                xml += "\r\n<payPalNotes>" + SecurityElement.Escape(payPalNotes) + "</payPalNotes>";
+            if (actionReason != null)
+                xml += "\r\n<actionReason>" + SecurityElement.Escape(actionReason) + "</actionReason>";
             xml += "\r\n</credit>";
             return xml;
         }
     }
 
-    public partial class echeckType
+    public class echeckType
     {
         private echeckAccountTypeEnum accTypeField;
         private bool accTypeSet;
+
         public echeckAccountTypeEnum accType
         {
-            get { return this.accTypeField; }
-            set { this.accTypeField = value; accTypeSet = true; }
+            get { return accTypeField; }
+            set
+            {
+                accTypeField = value;
+                accTypeSet = true;
+            }
         }
 
         public string accNum;
@@ -983,95 +1271,124 @@ namespace Litle.Sdk
 
         public string Serialize()
         {
-            string xml = "";
-            string accTypeName = accTypeField.ToString();
-            XmlEnumAttribute[] attributes = 
-                (XmlEnumAttribute[])typeof(echeckAccountTypeEnum).GetMember(accTypeField.ToString())[0].GetCustomAttributes(typeof(XmlEnumAttribute), false);
+            var xml = "";
+            var accTypeName = accTypeField.ToString();
+            var attributes =
+                (XmlEnumAttribute[])
+                    typeof (echeckAccountTypeEnum).GetMember(accTypeField.ToString())[0].GetCustomAttributes(
+                        typeof (XmlEnumAttribute), false);
             if (attributes.Length > 0) accTypeName = attributes[0].Name;
             if (accTypeSet) xml += "\r\n<accType>" + accTypeName + "</accType>";
             if (accNum != null) xml += "\r\n<accNum>" + SecurityElement.Escape(accNum) + "</accNum>";
             if (routingNum != null) xml += "\r\n<routingNum>" + SecurityElement.Escape(routingNum) + "</routingNum>";
             if (checkNum != null) xml += "\r\n<checkNum>" + SecurityElement.Escape(checkNum) + "</checkNum>";
-            if (ccdPaymentInformation != null) xml += "\r\n<ccdPaymentInformation>" + SecurityElement.Escape(ccdPaymentInformation) + "</ccdPaymentInformation>";
+            if (ccdPaymentInformation != null)
+                xml += "\r\n<ccdPaymentInformation>" + SecurityElement.Escape(ccdPaymentInformation) +
+                       "</ccdPaymentInformation>";
             return xml;
         }
     }
 
-    public partial class echeckTokenType
+    public class echeckTokenType
     {
         public string litleToken;
         public string routingNum;
         private echeckAccountTypeEnum accTypeField;
         private bool accTypeSet;
+
         public echeckAccountTypeEnum accType
         {
-            get { return this.accTypeField; }
-            set { this.accTypeField = value; accTypeSet = true; }
+            get { return accTypeField; }
+            set
+            {
+                accTypeField = value;
+                accTypeSet = true;
+            }
         }
+
         public string checkNum;
 
         public string Serialize()
         {
-            string xml = "";
+            var xml = "";
             if (litleToken != null) xml += "\r\n<litleToken>" + SecurityElement.Escape(litleToken) + "</litleToken>";
             if (routingNum != null) xml += "\r\n<routingNum>" + SecurityElement.Escape(routingNum) + "</routingNum>";
             if (accTypeSet) xml += "\r\n<accType>" + accTypeField + "</accType>";
             if (checkNum != null) xml += "\r\n<checkNum>" + SecurityElement.Escape(checkNum) + "</checkNum>";
             return xml;
         }
-
     }
 
 
-    public partial class pos
+    public class pos
     {
         private posCapabilityTypeEnum capabilityField;
         private bool capabilitySet;
+
         public posCapabilityTypeEnum capability
         {
-            get { return this.capabilityField; }
-            set { this.capabilityField = value; capabilitySet = true; }
+            get { return capabilityField; }
+            set
+            {
+                capabilityField = value;
+                capabilitySet = true;
+            }
         }
 
         private posEntryModeTypeEnum entryModeField;
         private bool entryModeSet;
+
         public posEntryModeTypeEnum entryMode
         {
-            get { return this.entryModeField; }
-            set { this.entryModeField = value; entryModeSet = true; }
+            get { return entryModeField; }
+            set
+            {
+                entryModeField = value;
+                entryModeSet = true;
+            }
         }
 
         private posCardholderIdTypeEnum cardholderIdField;
         private bool cardholderIdSet;
+
         public posCardholderIdTypeEnum cardholderId
         {
-            get { return this.cardholderIdField; }
-            set { this.cardholderIdField = value; cardholderIdSet = true; }
+            get { return cardholderIdField; }
+            set
+            {
+                cardholderIdField = value;
+                cardholderIdSet = true;
+            }
         }
+
         public string terminalId;
 
         private posCatLevelEnum catLevelField;
         private bool catLevelSet;
+
         public posCatLevelEnum catLevel
         {
-            get { return this.catLevelField; }
-            set { this.catLevelField = value; catLevelSet = true; }
+            get { return catLevelField; }
+            set
+            {
+                catLevelField = value;
+                catLevelSet = true;
+            }
         }
 
         public string Serialize()
         {
-            string xml = "";
+            var xml = "";
             if (capabilitySet) xml += "\r\n<capability>" + capabilityField + "</capability>";
             if (entryModeSet) xml += "\r\n<entryMode>" + entryModeField + "</entryMode>";
             if (cardholderIdSet) xml += "\r\n<cardholderId>" + cardholderIdField + "</cardholderId>";
             if (terminalId != null) xml += "\r\n<terminalId>" + SecurityElement.Escape(terminalId) + "</terminalId>";
-            if (catLevelSet) xml += "\r\n<catLevel>" + catLevelField.Serialize() +"</catLevel>";
+            if (catLevelSet) xml += "\r\n<catLevel>" + catLevelField.Serialize() + "</catLevel>";
             return xml;
         }
-
     }
 
-    public partial class payPal
+    public class payPal
     {
         public string payerId;
         public string payerEmail;
@@ -1080,16 +1397,17 @@ namespace Litle.Sdk
 
         public string Serialize()
         {
-            string xml = "";
+            var xml = "";
             if (payerId != null) xml += "\r\n<payerId>" + SecurityElement.Escape(payerId) + "</payerId>";
             if (payerEmail != null) xml += "\r\n<payerEmail>" + SecurityElement.Escape(payerEmail) + "</payerEmail>";
             if (token != null) xml += "\r\n<token>" + SecurityElement.Escape(token) + "</token>";
-            if (transactionId != null) xml += "\r\n<transactionId>" + SecurityElement.Escape(transactionId) + "</transactionId>";
+            if (transactionId != null)
+                xml += "\r\n<transactionId>" + SecurityElement.Escape(transactionId) + "</transactionId>";
             return xml;
         }
     }
 
-    public partial class merchantDataType
+    public class merchantDataType
     {
         public string campaign;
         public string affiliate;
@@ -1097,126 +1415,177 @@ namespace Litle.Sdk
 
         public string Serialize()
         {
-            string xml = "";
+            var xml = "";
             if (campaign != null) xml += "\r\n<campaign>" + SecurityElement.Escape(campaign) + "</campaign>";
             if (affiliate != null) xml += "\r\n<affiliate>" + SecurityElement.Escape(affiliate) + "</affiliate>";
-            if (merchantGroupingId != null) xml += "\r\n<merchantGroupingId>" + SecurityElement.Escape(merchantGroupingId) + "</merchantGroupingId>";
+            if (merchantGroupingId != null)
+                xml += "\r\n<merchantGroupingId>" + SecurityElement.Escape(merchantGroupingId) + "</merchantGroupingId>";
             return xml;
         }
     }
 
-    public partial class cardTokenType
+    public class cardTokenType
     {
         public string litleToken;
         public string expDate;
         public string cardValidationNum;
         private methodOfPaymentTypeEnum typeField;
         private bool typeSet;
+
         public methodOfPaymentTypeEnum type
         {
-            get { return this.typeField; }
-            set { this.typeField = value; typeSet = true; }
+            get { return typeField; }
+            set
+            {
+                typeField = value;
+                typeSet = true;
+            }
         }
 
         public string Serialize()
         {
-            string xml = "\r\n<litleToken>" + SecurityElement.Escape(litleToken) + "</litleToken>";
+            var xml = "\r\n<litleToken>" + SecurityElement.Escape(litleToken) + "</litleToken>";
             if (expDate != null) xml += "\r\n<expDate>" + SecurityElement.Escape(expDate) + "</expDate>";
-            if (cardValidationNum != null) xml += "\r\n<cardValidationNum>" + SecurityElement.Escape(cardValidationNum) + "</cardValidationNum>";
+            if (cardValidationNum != null)
+                xml += "\r\n<cardValidationNum>" + SecurityElement.Escape(cardValidationNum) + "</cardValidationNum>";
             if (typeSet) xml += "\r\n<type>" + methodOfPaymentSerializer.Serialize(typeField) + "</type>";
             return xml;
         }
     }
 
-    public partial class cardPaypageType
+    public class cardPaypageType
     {
         public string paypageRegistrationId;
         public string expDate;
         public string cardValidationNum;
         private methodOfPaymentTypeEnum typeField;
         private bool typeSet;
+
         public methodOfPaymentTypeEnum type
         {
-            get { return this.typeField; }
-            set { this.typeField = value; typeSet = true; }
+            get { return typeField; }
+            set
+            {
+                typeField = value;
+                typeSet = true;
+            }
         }
 
         public string Serialize()
         {
-            string xml = "\r\n<paypageRegistrationId>" + SecurityElement.Escape(paypageRegistrationId) + "</paypageRegistrationId>";
+            var xml = "\r\n<paypageRegistrationId>" + SecurityElement.Escape(paypageRegistrationId) +
+                      "</paypageRegistrationId>";
             if (expDate != null) xml += "\r\n<expDate>" + SecurityElement.Escape(expDate) + "</expDate>";
-            if (cardValidationNum != null) xml += "\r\n<cardValidationNum>" + SecurityElement.Escape(cardValidationNum) + "</cardValidationNum>";
+            if (cardValidationNum != null)
+                xml += "\r\n<cardValidationNum>" + SecurityElement.Escape(cardValidationNum) + "</cardValidationNum>";
             if (typeSet) xml += "\r\n<type>" + methodOfPaymentSerializer.Serialize(typeField) + "</type>";
             return xml;
         }
     }
 
-    public partial class billMeLaterRequest
+    public class billMeLaterRequest
     {
         private long bmlMerchantIdField;
         private bool bmlMerchantIdSet;
+
         public long bmlMerchantId
         {
-            get { return this.bmlMerchantIdField; }
-            set { this.bmlMerchantIdField = value; bmlMerchantIdSet = true; }
+            get { return bmlMerchantIdField; }
+            set
+            {
+                bmlMerchantIdField = value;
+                bmlMerchantIdSet = true;
+            }
         }
+
         private long bmlProductTypeField;
         private bool bmlProductTypeSet;
+
         public long bmlProductType
         {
-            get { return this.bmlProductTypeField; }
-            set { this.bmlProductTypeField = value; bmlProductTypeSet = true; }
+            get { return bmlProductTypeField; }
+            set
+            {
+                bmlProductTypeField = value;
+                bmlProductTypeSet = true;
+            }
         }
+
         private int termsAndConditionsField;
         private bool termsAndConditionsSet;
+
         public int termsAndConditions
         {
-            get { return this.termsAndConditionsField; }
-            set { this.termsAndConditionsField = value; termsAndConditionsSet = true; }
+            get { return termsAndConditionsField; }
+            set
+            {
+                termsAndConditionsField = value;
+                termsAndConditionsSet = true;
+            }
         }
+
         public string preapprovalNumber;
         private int merchantPromotionalCodeField;
         private bool merchantPromotionalCodeSet;
+
         public int merchantPromotionalCode
         {
-            get { return this.merchantPromotionalCodeField; }
-            set { this.merchantPromotionalCodeField = value; merchantPromotionalCodeSet = true; }
+            get { return merchantPromotionalCodeField; }
+            set
+            {
+                merchantPromotionalCodeField = value;
+                merchantPromotionalCodeSet = true;
+            }
         }
+
         public string virtualAuthenticationKeyPresenceIndicator;
         public string virtualAuthenticationKeyData;
         private int itemCategoryCodeField;
         private bool itemCategoryCodeSet;
+
         public int itemCategoryCode
         {
-            get { return this.itemCategoryCodeField; }
-            set { this.itemCategoryCodeField = value; itemCategoryCodeSet = true; }
+            get { return itemCategoryCodeField; }
+            set
+            {
+                itemCategoryCodeField = value;
+                itemCategoryCodeSet = true;
+            }
         }
 
         public string Serialize()
         {
-            string xml = "";
+            var xml = "";
             if (bmlMerchantIdSet) xml += "\r\n<bmlMerchantId>" + bmlMerchantIdField + "</bmlMerchantId>";
             if (bmlProductTypeSet) xml += "\r\n<bmlProductType>" + bmlProductTypeField + "</bmlProductType>";
-            if (termsAndConditionsSet) xml += "\r\n<termsAndConditions>" + termsAndConditionsField + "</termsAndConditions>";
-            if (preapprovalNumber != null) xml += "\r\n<preapprovalNumber>" + SecurityElement.Escape(preapprovalNumber) + "</preapprovalNumber>";
-            if (merchantPromotionalCodeSet) xml += "\r\n<merchantPromotionalCode>" + merchantPromotionalCodeField + "</merchantPromotionalCode>";
-            if (virtualAuthenticationKeyPresenceIndicator != null) xml += "\r\n<virtualAuthenticationKeyPresenceIndicator>" + SecurityElement.Escape(virtualAuthenticationKeyPresenceIndicator) + "</virtualAuthenticationKeyPresenceIndicator>";
-            if (virtualAuthenticationKeyData != null) xml += "\r\n<virtualAuthenticationKeyData>" + SecurityElement.Escape(virtualAuthenticationKeyData) + "</virtualAuthenticationKeyData>";
+            if (termsAndConditionsSet)
+                xml += "\r\n<termsAndConditions>" + termsAndConditionsField + "</termsAndConditions>";
+            if (preapprovalNumber != null)
+                xml += "\r\n<preapprovalNumber>" + SecurityElement.Escape(preapprovalNumber) + "</preapprovalNumber>";
+            if (merchantPromotionalCodeSet)
+                xml += "\r\n<merchantPromotionalCode>" + merchantPromotionalCodeField + "</merchantPromotionalCode>";
+            if (virtualAuthenticationKeyPresenceIndicator != null)
+                xml += "\r\n<virtualAuthenticationKeyPresenceIndicator>" +
+                       SecurityElement.Escape(virtualAuthenticationKeyPresenceIndicator) +
+                       "</virtualAuthenticationKeyPresenceIndicator>";
+            if (virtualAuthenticationKeyData != null)
+                xml += "\r\n<virtualAuthenticationKeyData>" + SecurityElement.Escape(virtualAuthenticationKeyData) +
+                       "</virtualAuthenticationKeyData>";
             if (itemCategoryCodeSet) xml += "\r\n<itemCategoryCode>" + itemCategoryCodeField + "</itemCategoryCode>";
             return xml;
         }
-
     }
 
-    public partial class customBilling
+    public class customBilling
     {
         public string phone;
         public string city;
         public string url;
         public string descriptor;
+
         public string Serialize()
         {
-            string xml = "";
+            var xml = "";
             if (phone != null) xml += "\r\n<phone>" + SecurityElement.Escape(phone) + "</phone>";
             else if (city != null) xml += "\r\n<city>" + SecurityElement.Escape(city) + "</city>";
             else if (url != null) xml += "\r\n<url>" + SecurityElement.Escape(url) + "</url>";
@@ -1225,39 +1594,47 @@ namespace Litle.Sdk
         }
     }
 
-    public partial class amexAggregatorData
+    public class amexAggregatorData
     {
         public string sellerId;
         public string sellerMerchantCategoryCode;
+
         public string Serialize()
         {
-            string xml = "";
+            var xml = "";
             xml += "\r\n<sellerId>" + SecurityElement.Escape(sellerId) + "</sellerId>";
-            xml += "\r\n<sellerMerchantCategoryCode>" + SecurityElement.Escape(sellerMerchantCategoryCode) + "</sellerMerchantCategoryCode>";
+            xml += "\r\n<sellerMerchantCategoryCode>" + SecurityElement.Escape(sellerMerchantCategoryCode) +
+                   "</sellerMerchantCategoryCode>";
             return xml;
         }
-
     }
 
-    public partial class processingInstructions
+    public class processingInstructions
     {
         private bool bypassVelocityCheckField;
         private bool bypassVelocityCheckSet;
+
         public bool bypassVelocityCheck
         {
-            get { return this.bypassVelocityCheckField; }
-            set { this.bypassVelocityCheckField = value; this.bypassVelocityCheckSet = true; }
+            get { return bypassVelocityCheckField; }
+            set
+            {
+                bypassVelocityCheckField = value;
+                bypassVelocityCheckSet = true;
+            }
         }
 
         public string Serialize()
         {
-            string xml = "";
-            if (bypassVelocityCheckSet) xml += "\r\n<bypassVelocityCheck>" + bypassVelocityCheckField.ToString().ToLower() + "</bypassVelocityCheck>";
+            var xml = "";
+            if (bypassVelocityCheckSet)
+                xml += "\r\n<bypassVelocityCheck>" + bypassVelocityCheckField.ToString().ToLower() +
+                       "</bypassVelocityCheck>";
             return xml;
         }
     }
 
-    public partial class echeckRedeposit : baseRequestTransactionEcheckRedeposit
+    public class echeckRedeposit : baseRequestTransactionEcheckRedeposit
     {
         //litleTxnIdField and set are in super
         public echeckType echeck;
@@ -1266,7 +1643,7 @@ namespace Litle.Sdk
 
         public override string Serialize()
         {
-            string xml = "\r\n<echeckRedeposit";
+            var xml = "\r\n<echeckRedeposit";
             xml += " id=\"" + id + "\"";
             if (customerId != null)
             {
@@ -1276,45 +1653,58 @@ namespace Litle.Sdk
             if (litleTxnIdSet) xml += "\r\n<litleTxnId>" + litleTxnIdField + "</litleTxnId>";
             if (echeck != null) xml += "\r\n<echeck>" + echeck.Serialize() + "</echeck>";
             else if (token != null) xml += "\r\n<echeckToken>" + token.Serialize() + "</echeckToken>";
-            if (merchantData != null) { xml += "\r\n<merchantData>" + merchantData.Serialize() + "\r\n</merchantData>"; }
+            if (merchantData != null)
+            {
+                xml += "\r\n<merchantData>" + merchantData.Serialize() + "\r\n</merchantData>";
+            }
             xml += "\r\n</echeckRedeposit>";
             return xml;
         }
     }
 
-    public partial class authorization : transactionTypeWithReportGroup
+    public class authorization : transactionTypeWithReportGroup
     {
-
         private long litleTxnIdField;
         private bool litleTxnIdSet;
+
         public long litleTxnId
         {
-            get
-            {
-                return this.litleTxnIdField;
-            }
+            get { return litleTxnIdField; }
             set
             {
-                this.litleTxnIdField = value;
-                this.litleTxnIdSet = true;
+                litleTxnIdField = value;
+                litleTxnIdSet = true;
             }
         }
+
         public string orderId;
         public long amount;
         private bool secondaryAmountSet;
         private long secondaryAmountField;
+
         public long secondaryAmount
         {
-            get { return this.secondaryAmountField; }
-            set { this.secondaryAmountField = value; this.secondaryAmountSet = true; }
+            get { return secondaryAmountField; }
+            set
+            {
+                secondaryAmountField = value;
+                secondaryAmountSet = true;
+            }
         }
+
         private bool surchargeAmountSet;
         private long surchargeAmountField;
+
         public long surchargeAmount
         {
-            get { return this.surchargeAmountField; }
-            set { this.surchargeAmountField = value; this.surchargeAmountSet = true; }
+            get { return surchargeAmountField; }
+            set
+            {
+                surchargeAmountField = value;
+                surchargeAmountSet = true;
+            }
         }
+
         public orderSourceType orderSource;
         public customerInfo customerInfo;
         public contact billToAddress;
@@ -1332,66 +1722,69 @@ namespace Litle.Sdk
         public customBilling customBilling;
         private govtTaxTypeEnum taxTypeField;
         private bool taxTypeSet;
+
         public govtTaxTypeEnum taxType
         {
-            get { return this.taxTypeField; }
-            set { this.taxTypeField = value; this.taxTypeSet = true; }
+            get { return taxTypeField; }
+            set
+            {
+                taxTypeField = value;
+                taxTypeSet = true;
+            }
         }
+
         public enhancedData enhancedData;
         public amexAggregatorData amexAggregatorData;
         private bool allowPartialAuthField;
         private bool allowPartialAuthSet;
+
         public bool allowPartialAuth
         {
-            get
-            {
-                return this.allowPartialAuthField;
-            }
+            get { return allowPartialAuthField; }
             set
             {
-                this.allowPartialAuthField = value;
-                this.allowPartialAuthSet = true;
+                allowPartialAuthField = value;
+                allowPartialAuthSet = true;
             }
         }
+
         public healthcareIIAS healthcareIIAS;
         public filteringType filtering;
         public merchantDataType merchantData;
         public recyclingRequestType recyclingRequest;
         private bool fraudFilterOverrideField;
         private bool fraudFilterOverrideSet;
+
         public bool fraudFilterOverride
         {
-            get
-            {
-                return this.fraudFilterOverrideField;
-            }
+            get { return fraudFilterOverrideField; }
             set
             {
-                this.fraudFilterOverrideField = value;
-                this.fraudFilterOverrideSet = true;
+                fraudFilterOverrideField = value;
+                fraudFilterOverrideSet = true;
             }
         }
+
         public recurringRequest recurringRequest;
         private bool debtRepaymentField;
         private bool debtRepaymentSet;
+
         public bool debtRepayment
         {
-            get
-            {
-                return this.debtRepaymentField;
-            }
+            get { return debtRepaymentField; }
             set
             {
-                this.debtRepaymentField = value;
-                this.debtRepaymentSet = true;
+                debtRepaymentField = value;
+                debtRepaymentSet = true;
             }
         }
+
         public advancedFraudChecksType advancedFraudChecks;
         public wallet wallet;
 
-        public override String Serialize()
+        public override string Serialize()
         {
-            string xml = "\r\n<authorization";
+            var xml = "\r\n<authorization";
             xml += " id=\"" + SecurityElement.Escape(id) + "\"";
             if (customerId != null)
             {
@@ -1452,11 +1845,13 @@ namespace Litle.Sdk
                 }
                 if (cardholderAuthentication != null)
                 {
-                    xml += "\r\n<cardholderAuthentication>" + cardholderAuthentication.Serialize() + "\r\n</cardholderAuthentication>";
+                    xml += "\r\n<cardholderAuthentication>" + cardholderAuthentication.Serialize() +
+                           "\r\n</cardholderAuthentication>";
                 }
                 if (processingInstructions != null)
                 {
-                    xml += "\r\n<processingInstructions>" + processingInstructions.Serialize() + "\r\n</processingInstructions>";
+                    xml += "\r\n<processingInstructions>" + processingInstructions.Serialize() +
+                           "\r\n</processingInstructions>";
                 }
                 if (pos != null)
                 {
@@ -1498,12 +1893,15 @@ namespace Litle.Sdk
                 {
                     xml += "\r\n<recyclingRequest>" + recyclingRequest.Serialize() + "\r\n</recyclingRequest>";
                 }
-                if (fraudFilterOverrideSet) xml += "\r\n<fraudFilterOverride>" + fraudFilterOverrideField.ToString().ToLower() + "</fraudFilterOverride>";
+                if (fraudFilterOverrideSet)
+                    xml += "\r\n<fraudFilterOverride>" + fraudFilterOverrideField.ToString().ToLower() +
+                           "</fraudFilterOverride>";
                 if (recurringRequest != null)
                 {
                     xml += "\r\n<recurringRequest>" + recurringRequest.Serialize() + "\r\n</recurringRequest>";
                 }
-                if (debtRepaymentSet) xml += "\r\n<debtRepayment>" + debtRepayment.ToString().ToLower() + "</debtRepayment>";
+                if (debtRepaymentSet)
+                    xml += "\r\n<debtRepayment>" + debtRepayment.ToString().ToLower() + "</debtRepayment>";
                 if (advancedFraudChecks != null)
                 {
                     xml += "\r\n<advancedFraudChecks>" + advancedFraudChecks.Serialize() + "\r\n</advancedFraudChecks>";
@@ -1513,45 +1911,55 @@ namespace Litle.Sdk
                     xml += "\r\n<wallet>" + wallet.Serialize() + "\r\n</wallet>";
                 }
             }
-            
+
             xml += "\r\n</authorization>";
             return xml;
         }
     }
 
-    public partial class sale : transactionTypeWithReportGroup
+    public class sale : transactionTypeWithReportGroup
     {
-
         private long litleTxnIdField;
         private bool litleTxnIdSet;
+
         public long litleTxnId
         {
-            get
-            {
-                return this.litleTxnIdField;
-            }
+            get { return litleTxnIdField; }
             set
             {
-                this.litleTxnIdField = value;
-                this.litleTxnIdSet = true;
+                litleTxnIdField = value;
+                litleTxnIdSet = true;
             }
         }
+
         public string orderId;
         public long amount;
         private bool secondaryAmountSet;
         private long secondaryAmountField;
+
         public long secondaryAmount
         {
-            get { return this.secondaryAmountField; }
-            set { this.secondaryAmountField = value; this.secondaryAmountSet = true; }
+            get { return secondaryAmountField; }
+            set
+            {
+                secondaryAmountField = value;
+                secondaryAmountSet = true;
+            }
         }
+
         private bool surchargeAmountSet;
         private long surchargeAmountField;
+
         public long surchargeAmount
         {
-            get { return this.surchargeAmountField; }
-            set { this.surchargeAmountField = value; this.surchargeAmountSet = true; }
+            get { return surchargeAmountField; }
+            set
+            {
+                surchargeAmountField = value;
+                surchargeAmountSet = true;
+            }
         }
+
         public orderSourceType orderSource;
         public customerInfo customerInfo;
         public contact billToAddress;
@@ -1567,77 +1975,86 @@ namespace Litle.Sdk
         public customBilling customBilling;
         private govtTaxTypeEnum taxTypeField;
         private bool taxTypeSet;
+
         public govtTaxTypeEnum taxType
         {
-            get { return this.taxTypeField; }
-            set { this.taxTypeField = value; this.taxTypeSet = true; }
+            get { return taxTypeField; }
+            set
+            {
+                taxTypeField = value;
+                taxTypeSet = true;
+            }
         }
+
         public enhancedData enhancedData;
         public processingInstructions processingInstructions;
         public pos pos;
         private bool payPalOrderCompleteField;
         private bool payPalOrderCompleteSet;
+
         public bool payPalOrderComplete
         {
-            get { return this.payPalOrderCompleteField; }
-            set { this.payPalOrderCompleteField = value; this.payPalOrderCompleteSet = true; }
+            get { return payPalOrderCompleteField; }
+            set
+            {
+                payPalOrderCompleteField = value;
+                payPalOrderCompleteSet = true;
+            }
         }
+
         public string payPalNotes;
         public amexAggregatorData amexAggregatorData;
         private bool allowPartialAuthField;
         private bool allowPartialAuthSet;
+
         public bool allowPartialAuth
         {
-            get
-            {
-                return this.allowPartialAuthField;
-            }
+            get { return allowPartialAuthField; }
             set
             {
-                this.allowPartialAuthField = value;
-                this.allowPartialAuthSet = true;
+                allowPartialAuthField = value;
+                allowPartialAuthSet = true;
             }
         }
+
         public healthcareIIAS healthcareIIAS;
         public filteringType filtering;
         public merchantDataType merchantData;
         public recyclingRequestType recyclingRequest;
         private bool fraudFilterOverrideField;
         private bool fraudFilterOverrideSet;
+
         public bool fraudFilterOverride
         {
-            get
-            {
-                return this.fraudFilterOverrideField;
-            }
+            get { return fraudFilterOverrideField; }
             set
             {
-                this.fraudFilterOverrideField = value;
-                this.fraudFilterOverrideSet = true;
+                fraudFilterOverrideField = value;
+                fraudFilterOverrideSet = true;
             }
         }
+
         public recurringRequest recurringRequest;
         public litleInternalRecurringRequest litleInternalRecurringRequest;
         private bool debtRepaymentField;
         private bool debtRepaymentSet;
+
         public bool debtRepayment
         {
-            get
-            {
-                return this.debtRepaymentField;
-            }
+            get { return debtRepaymentField; }
             set
             {
-                this.debtRepaymentField = value;
-                this.debtRepaymentSet = true;
+                debtRepaymentField = value;
+                debtRepaymentSet = true;
             }
         }
+
         public advancedFraudChecksType advancedFraudChecks;
         public wallet wallet;
 
-        public override String Serialize()
+        public override string Serialize()
         {
-            string xml = "\r\n<sale";
+            var xml = "\r\n<sale";
             xml += " id=\"" + SecurityElement.Escape(id) + "\"";
             if (customerId != null)
             {
@@ -1692,7 +2109,8 @@ namespace Litle.Sdk
             }
             if (cardholderAuthentication != null)
             {
-                xml += "\r\n<cardholderAuthentication>" + cardholderAuthentication.Serialize() + "\r\n</cardholderAuthentication>";
+                xml += "\r\n<cardholderAuthentication>" + cardholderAuthentication.Serialize() +
+                       "\r\n</cardholderAuthentication>";
             }
             if (customBilling != null)
             {
@@ -1708,14 +2126,18 @@ namespace Litle.Sdk
             }
             if (processingInstructions != null)
             {
-                xml += "\r\n<processingInstructions>" + processingInstructions.Serialize() + "\r\n</processingInstructions>";
+                xml += "\r\n<processingInstructions>" + processingInstructions.Serialize() +
+                       "\r\n</processingInstructions>";
             }
             if (pos != null)
             {
                 xml += "\r\n<pos>" + pos.Serialize() + "\r\n</pos>";
             }
-            if (payPalOrderCompleteSet) xml += "\r\n<payPalOrderCompleteSet>" + payPalOrderCompleteField.ToString().ToLower() + "</payPalOrderCompleteSet>";
-            if (payPalNotes != null) xml += "\r\n<payPalNotes>" + SecurityElement.Escape(payPalNotes) + "</payPalNotes>";
+            if (payPalOrderCompleteSet)
+                xml += "\r\n<payPalOrderCompleteSet>" + payPalOrderCompleteField.ToString().ToLower() +
+                       "</payPalOrderCompleteSet>";
+            if (payPalNotes != null)
+                xml += "\r\n<payPalNotes>" + SecurityElement.Escape(payPalNotes) + "</payPalNotes>";
             if (amexAggregatorData != null)
             {
                 xml += "\r\n<amexAggregatorData>" + amexAggregatorData.Serialize() + "\r\n</amexAggregatorData>";
@@ -1740,17 +2162,22 @@ namespace Litle.Sdk
             {
                 xml += "\r\n<recyclingRequest>" + recyclingRequest.Serialize() + "\r\n</recyclingRequest>";
             }
-            if (fraudFilterOverrideSet) xml += "\r\n<fraudFilterOverride>" + fraudFilterOverrideField.ToString().ToLower() + "</fraudFilterOverride>";
+            if (fraudFilterOverrideSet)
+                xml += "\r\n<fraudFilterOverride>" + fraudFilterOverrideField.ToString().ToLower() +
+                       "</fraudFilterOverride>";
             if (recurringRequest != null)
             {
                 xml += "\r\n<recurringRequest>" + recurringRequest.Serialize() + "\r\n</recurringRequest>";
             }
             if (litleInternalRecurringRequest != null)
             {
-                xml += "\r\n<litleInternalRecurringRequest>" + litleInternalRecurringRequest.Serialize() + "\r\n</litleInternalRecurringRequest>";
+                xml += "\r\n<litleInternalRecurringRequest>" + litleInternalRecurringRequest.Serialize() +
+                       "\r\n</litleInternalRecurringRequest>";
             }
-            if (debtRepaymentSet) xml += "\r\n<debtRepayment>" + debtRepayment.ToString().ToLower() + "</debtRepayment>";
-            if (advancedFraudChecks != null) xml += "\r\n<advancedFraudChecks>" + advancedFraudChecks.Serialize() + "\r\n</advancedFraudChecks>";
+            if (debtRepaymentSet)
+                xml += "\r\n<debtRepayment>" + debtRepayment.ToString().ToLower() + "</debtRepayment>";
+            if (advancedFraudChecks != null)
+                xml += "\r\n<advancedFraudChecks>" + advancedFraudChecks.Serialize() + "\r\n</advancedFraudChecks>";
             if (wallet != null)
             {
                 xml += "\r\n<wallet>" + wallet.Serialize() + "\r\n</wallet>";
@@ -1760,24 +2187,36 @@ namespace Litle.Sdk
         }
     }
 
-    public partial class forceCapture : transactionTypeWithReportGroup
+    public class forceCapture : transactionTypeWithReportGroup
     {
         public string orderId;
         public long amount;
         private bool secondaryAmountSet;
         private long secondaryAmountField;
+
         public long secondaryAmount
         {
-            get { return this.secondaryAmountField; }
-            set { this.secondaryAmountField = value; this.secondaryAmountSet = true; }
+            get { return secondaryAmountField; }
+            set
+            {
+                secondaryAmountField = value;
+                secondaryAmountSet = true;
+            }
         }
+
         private bool surchargeAmountSet;
         private long surchargeAmountField;
+
         public long surchargeAmount
         {
-            get { return this.surchargeAmountField; }
-            set { this.surchargeAmountField = value; this.surchargeAmountSet = true; }
+            get { return surchargeAmountField; }
+            set
+            {
+                surchargeAmountField = value;
+                surchargeAmountSet = true;
+            }
         }
+
         public orderSourceType orderSource;
         public contact billToAddress;
         public cardType card;
@@ -1787,11 +2226,17 @@ namespace Litle.Sdk
         public customBilling customBilling;
         private govtTaxTypeEnum taxTypeField;
         private bool taxTypeSet;
+
         public govtTaxTypeEnum taxType
         {
-            get { return this.taxTypeField; }
-            set { this.taxTypeField = value; this.taxTypeSet = true; }
+            get { return taxTypeField; }
+            set
+            {
+                taxTypeField = value;
+                taxTypeSet = true;
+            }
         }
+
         public enhancedData enhancedData;
         public processingInstructions processingInstructions;
         public pos pos;
@@ -1799,22 +2244,20 @@ namespace Litle.Sdk
         public merchantDataType merchantData;
         private bool debtRepaymentField;
         private bool debtRepaymentSet;
+
         public bool debtRepayment
         {
-            get
-            {
-                return this.debtRepaymentField;
-            }
+            get { return debtRepaymentField; }
             set
             {
-                this.debtRepaymentField = value;
-                this.debtRepaymentSet = true;
+                debtRepaymentField = value;
+                debtRepaymentSet = true;
             }
         }
 
-        public override String Serialize()
+        public override string Serialize()
         {
-            string xml = "\r\n<forceCapture";
+            var xml = "\r\n<forceCapture";
             xml += " id=\"" + SecurityElement.Escape(id) + "\"";
             if (customerId != null)
             {
@@ -1860,7 +2303,8 @@ namespace Litle.Sdk
             }
             if (processingInstructions != null)
             {
-                xml += "\r\n<processingInstructions>" + processingInstructions.Serialize() + "\r\n</processingInstructions>";
+                xml += "\r\n<processingInstructions>" + processingInstructions.Serialize() +
+                       "\r\n</processingInstructions>";
             }
             if (pos != null)
             {
@@ -1874,31 +2318,44 @@ namespace Litle.Sdk
             {
                 xml += "\r\n<merchantData>" + merchantData.Serialize() + "\r\n</merchantData>";
             }
-            if (debtRepaymentSet) xml += "\r\n<debtRepayment>" + debtRepayment.ToString().ToLower() + "</debtRepayment>";
+            if (debtRepaymentSet)
+                xml += "\r\n<debtRepayment>" + debtRepayment.ToString().ToLower() + "</debtRepayment>";
             xml += "\r\n</forceCapture>";
             return xml;
         }
     }
 
-    public partial class captureGivenAuth : transactionTypeWithReportGroup
+    public class captureGivenAuth : transactionTypeWithReportGroup
     {
         public string orderId;
         public authInformation authInformation;
         public long amount;
         private bool secondaryAmountSet;
         private long secondaryAmountField;
+
         public long secondaryAmount
         {
-            get { return this.secondaryAmountField; }
-            set { this.secondaryAmountField = value; this.secondaryAmountSet = true; }
+            get { return secondaryAmountField; }
+            set
+            {
+                secondaryAmountField = value;
+                secondaryAmountSet = true;
+            }
         }
+
         private bool surchargeAmountSet;
         private long surchargeAmountField;
+
         public long surchargeAmount
         {
-            get { return this.surchargeAmountField; }
-            set { this.surchargeAmountField = value; this.surchargeAmountSet = true; }
+            get { return surchargeAmountField; }
+            set
+            {
+                surchargeAmountField = value;
+                surchargeAmountSet = true;
+            }
         }
+
         public orderSourceType orderSource;
         public contact billToAddress;
         public contact shipToAddress;
@@ -1909,11 +2366,17 @@ namespace Litle.Sdk
         public customBilling customBilling;
         private govtTaxTypeEnum taxTypeField;
         private bool taxTypeSet;
+
         public govtTaxTypeEnum taxType
         {
-            get { return this.taxTypeField; }
-            set { this.taxTypeField = value; this.taxTypeSet = true; }
+            get { return taxTypeField; }
+            set
+            {
+                taxTypeField = value;
+                taxTypeSet = true;
+            }
         }
+
         public billMeLaterRequest billMeLaterRequest;
         public enhancedData enhancedData;
         public processingInstructions processingInstructions;
@@ -1922,22 +2385,20 @@ namespace Litle.Sdk
         public merchantDataType merchantData;
         private bool debtRepaymentField;
         private bool debtRepaymentSet;
+
         public bool debtRepayment
         {
-            get
-            {
-                return this.debtRepaymentField;
-            }
+            get { return debtRepaymentField; }
             set
             {
-                this.debtRepaymentField = value;
-                this.debtRepaymentSet = true;
+                debtRepaymentField = value;
+                debtRepaymentSet = true;
             }
         }
 
-        public override String Serialize()
+        public override string Serialize()
         {
-            string xml = "\r\n<captureGivenAuth";
+            var xml = "\r\n<captureGivenAuth";
             xml += " id=\"" + SecurityElement.Escape(id) + "\"";
             if (customerId != null)
             {
@@ -1945,7 +2406,8 @@ namespace Litle.Sdk
             }
             xml += " reportGroup=\"" + SecurityElement.Escape(reportGroup) + "\">";
             xml += "\r\n<orderId>" + SecurityElement.Escape(orderId) + "</orderId>";
-            if (authInformation != null) xml += "\r\n<authInformation>" + authInformation.Serialize() + "\r\n</authInformation>";
+            if (authInformation != null)
+                xml += "\r\n<authInformation>" + authInformation.Serialize() + "\r\n</authInformation>";
             xml += "\r\n<amount>" + amount + "</amount>";
             if (secondaryAmountSet) xml += "\r\n<secondaryAmount>" + secondaryAmountField + "</secondaryAmount>";
             if (surchargeAmountSet) xml += "\r\n<surchargeAmount>" + surchargeAmountField + "</surchargeAmount>";
@@ -1992,7 +2454,8 @@ namespace Litle.Sdk
             }
             if (processingInstructions != null)
             {
-                xml += "\r\n<processingInstructions>" + processingInstructions.Serialize() + "\r\n</processingInstructions>";
+                xml += "\r\n<processingInstructions>" + processingInstructions.Serialize() +
+                       "\r\n</processingInstructions>";
             }
             if (pos != null)
             {
@@ -2006,40 +2469,39 @@ namespace Litle.Sdk
             {
                 xml += "\r\n<merchantData>" + merchantData.Serialize() + "\r\n</merchantData>";
             }
-            if (debtRepaymentSet) xml += "\r\n<debtRepayment>" + debtRepayment.ToString().ToLower() + "</debtRepayment>";
+            if (debtRepaymentSet)
+                xml += "\r\n<debtRepayment>" + debtRepayment.ToString().ToLower() + "</debtRepayment>";
             xml += "\r\n</captureGivenAuth>";
             return xml;
         }
     }
 
-    public partial class cancelSubscription : recurringTransactionType
+    public class cancelSubscription : recurringTransactionType
     {
         private long subscriptionIdField;
         private bool subscriptionIdSet;
+
         public long subscriptionId
         {
-            get
-            {
-                return this.subscriptionIdField;
-            }
+            get { return subscriptionIdField; }
             set
             {
-                this.subscriptionIdField = value;
-                this.subscriptionIdSet = true;
+                subscriptionIdField = value;
+                subscriptionIdSet = true;
             }
         }
 
-        public override String Serialize()
+        public override string Serialize()
         {
-            string xml = "\r\n<cancelSubscription>";
+            var xml = "\r\n<cancelSubscription>";
             if (subscriptionIdSet) xml += "\r\n<subscriptionId>" + subscriptionIdField + "</subscriptionId>";
             xml += "\r\n</cancelSubscription>";
             return xml;
         }
     }
 
-    [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.litle.com/schema")]
+    [Serializable]
+    [XmlType(Namespace = "http://www.litle.com/schema")]
     public enum intervalType
     {
         ANNUAL,
@@ -2049,25 +2511,30 @@ namespace Litle.Sdk
         WEEKLY
     }
 
-    [System.SerializableAttribute()]
-    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.litle.com/schema")]
+    [Serializable]
+    [XmlType(Namespace = "http://www.litle.com/schema")]
     public enum trialIntervalType
     {
         MONTH,
         DAY
     }
 
-    public partial class createPlan : recurringTransactionType
+    public class createPlan : recurringTransactionType
     {
         public string planCode;
         public string name;
 
         private string descriptionField;
         private bool descriptionSet;
+
         public string description
         {
-            get { return this.descriptionField; }
-            set { this.descriptionField = value; this.descriptionSet = true; }
+            get { return descriptionField; }
+            set
+            {
+                descriptionField = value;
+                descriptionSet = true;
+            }
         }
 
         public intervalType intervalType;
@@ -2075,88 +2542,115 @@ namespace Litle.Sdk
 
         public int numberOfPaymentsField;
         public bool numberOfPaymentsSet;
+
         public int numberOfPayments
         {
-            get { return this.numberOfPaymentsField; }
-            set { this.numberOfPaymentsField = value; this.numberOfPaymentsSet = true; }
+            get { return numberOfPaymentsField; }
+            set
+            {
+                numberOfPaymentsField = value;
+                numberOfPaymentsSet = true;
+            }
         }
 
         public int trialNumberOfIntervalsField;
         public bool trialNumberOfIntervalsSet;
+
         public int trialNumberOfIntervals
         {
-            get { return this.trialNumberOfIntervalsField; }
-            set { this.trialNumberOfIntervalsField = value; this.trialNumberOfIntervalsSet = true; }
+            get { return trialNumberOfIntervalsField; }
+            set
+            {
+                trialNumberOfIntervalsField = value;
+                trialNumberOfIntervalsSet = true;
+            }
         }
 
         private trialIntervalType trialIntervalTypeField;
         private bool trialIntervalTypeSet;
-        public trialIntervalType trialIntervalType 
+
+        public trialIntervalType trialIntervalType
         {
-            get { return this.trialIntervalTypeField; }
-            set { this.trialIntervalTypeField = value; this.trialIntervalTypeSet = true; }
+            get { return trialIntervalTypeField; }
+            set
+            {
+                trialIntervalTypeField = value;
+                trialIntervalTypeSet = true;
+            }
         }
 
         private bool activeField;
         private bool activeSet;
+
         public bool active
         {
-            get { return this.activeField; }
-            set { this.activeField = value; this.activeSet = true; }
+            get { return activeField; }
+            set
+            {
+                activeField = value;
+                activeSet = true;
+            }
         }
 
-        public override String Serialize()
+        public override string Serialize()
         {
-            string xml = "\r\n<createPlan>";
+            var xml = "\r\n<createPlan>";
             xml += "\r\n<planCode>" + SecurityElement.Escape(planCode) + "</planCode>";
             xml += "\r\n<name>" + SecurityElement.Escape(name) + "</name>";
-            if (descriptionSet) xml += "\r\n<description>" + SecurityElement.Escape(descriptionField) + "</description>";
+            if (descriptionSet)
+                xml += "\r\n<description>" + SecurityElement.Escape(descriptionField) + "</description>";
             xml += "\r\n<intervalType>" + intervalType + "</intervalType>";
             xml += "\r\n<amount>" + amount + "</amount>";
             if (numberOfPaymentsSet) xml += "\r\n<numberOfPayments>" + numberOfPaymentsField + "</numberOfPayments>";
-            if (trialNumberOfIntervalsSet) xml += "\r\n<trialNumberOfIntervals>" + trialNumberOfIntervalsField + "</trialNumberOfIntervals>";
-            if (trialIntervalTypeSet) xml += "\r\n<trialIntervalType>" + trialIntervalTypeField + "</trialIntervalType>";
+            if (trialNumberOfIntervalsSet)
+                xml += "\r\n<trialNumberOfIntervals>" + trialNumberOfIntervalsField + "</trialNumberOfIntervals>";
+            if (trialIntervalTypeSet)
+                xml += "\r\n<trialIntervalType>" + trialIntervalTypeField + "</trialIntervalType>";
             if (activeSet) xml += "\r\n<active>" + activeField.ToString().ToLower() + "</active>";
             xml += "\r\n</createPlan>";
             return xml;
         }
     }
 
-    public partial class updatePlan : recurringTransactionType
+    public class updatePlan : recurringTransactionType
     {
         public string planCode;
 
         private bool activeField;
         private bool activeSet;
+
         public bool active
         {
-            get { return this.activeField; }
-            set { this.activeField = value; this.activeSet = true; }
+            get { return activeField; }
+            set
+            {
+                activeField = value;
+                activeSet = true;
+            }
         }
 
-        public override String Serialize()
+        public override string Serialize()
         {
-            string xml = "\r\n<updatePlan>";
+            var xml = "\r\n<updatePlan>";
             xml += "\r\n<planCode>" + SecurityElement.Escape(planCode) + "</planCode>";
             if (activeSet) xml += "\r\n<active>" + activeField.ToString().ToLower() + "</active>";
             xml += "\r\n</updatePlan>";
             return xml;
         }
     }
-    public partial class updateSubscription : recurringTransactionType
+
+    public class updateSubscription : recurringTransactionType
     {
         private long subscriptionIdField;
         private bool subscriptionIdSet;
+
         public long subscriptionId
         {
-            get
-            {
-                return this.subscriptionIdField;
-            }
+            get { return subscriptionIdField; }
             set
             {
-                this.subscriptionIdField = value;
-                this.subscriptionIdSet = true;
+                subscriptionIdField = value;
+                subscriptionIdSet = true;
             }
         }
 
@@ -2167,16 +2661,14 @@ namespace Litle.Sdk
         public cardPaypageType paypage;
         private DateTime billingDateField;
         private bool billingDateSet;
+
         public DateTime billingDate
         {
-            get
-            {
-                return this.billingDateField;
-            }
+            get { return billingDateField; }
             set
             {
-                this.billingDateField = value;
-                this.billingDateSet = true;
+                billingDateField = value;
+                billingDateSet = true;
             }
         }
 
@@ -2197,37 +2689,38 @@ namespace Litle.Sdk
             deleteAddOns = new List<deleteAddOn>();
         }
 
-        public override String Serialize()
+        public override string Serialize()
         {
-            string xml = "\r\n<updateSubscription>";
+            var xml = "\r\n<updateSubscription>";
             if (subscriptionIdSet) xml += "\r\n<subscriptionId>" + subscriptionIdField + "</subscriptionId>";
             if (planCode != null) xml += "\r\n<planCode>" + SecurityElement.Escape(planCode) + "</planCode>";
-            if (billToAddress != null) xml += "\r\n<billToAddress>" + billToAddress.Serialize() + "\r\n</billToAddress>";
+            if (billToAddress != null)
+                xml += "\r\n<billToAddress>" + billToAddress.Serialize() + "\r\n</billToAddress>";
             if (card != null) xml += "\r\n<card>" + card.Serialize() + "\r\n</card>";
             else if (token != null) xml += "\r\n<token>" + token.Serialize() + "\r\n</token>";
             else if (paypage != null) xml += "\r\n<paypage>" + paypage.Serialize() + "\r\n</paypage>";
             if (billingDateSet) xml += "\r\n<billingDate>" + XmlUtil.toXsdDate(billingDateField) + "</billingDate>";
-            foreach (createDiscount createDiscount in createDiscounts) 
+            foreach (var createDiscount in createDiscounts)
             {
                 xml += "\r\n<createDiscount>" + createDiscount.Serialize() + "\r\n</createDiscount>";
             }
-            foreach (updateDiscount updateDiscount in updateDiscounts)
+            foreach (var updateDiscount in updateDiscounts)
             {
                 xml += "\r\n<updateDiscount>" + updateDiscount.Serialize() + "\r\n</updateDiscount>";
             }
-            foreach (deleteDiscount deleteDiscount in deleteDiscounts)
+            foreach (var deleteDiscount in deleteDiscounts)
             {
                 xml += "\r\n<deleteDiscount>" + deleteDiscount.Serialize() + "\r\n</deleteDiscount>";
             }
-            foreach (createAddOn createAddOn in createAddOns)
+            foreach (var createAddOn in createAddOns)
             {
                 xml += "\r\n<createAddOn>" + createAddOn.Serialize() + "\r\n</createAddOn>";
             }
-            foreach (updateAddOn updateAddOn in updateAddOns)
+            foreach (var updateAddOn in updateAddOns)
             {
                 xml += "\r\n<updateAddOn>" + updateAddOn.Serialize() + "\r\n</updateAddOn>";
             }
-            foreach (deleteAddOn deleteAddOn in deleteAddOns)
+            foreach (var deleteAddOn in deleteAddOns)
             {
                 xml += "\r\n<deleteAddOn>" + deleteAddOn.Serialize() + "\r\n</deleteAddOn>";
             }
@@ -2240,31 +2733,41 @@ namespace Litle.Sdk
     {
         public string Serialize()
         {
-            string xml = "";
+            var xml = "";
             if (avsResult != null) xml += "\r\n<avsResult>" + SecurityElement.Escape(avsResult) + "</avsResult>";
-            if (cardValidationResult != null) xml += "\r\n<cardValidationResult>" + SecurityElement.Escape(cardValidationResult) + "</cardValidationResult>";
-            if (authenticationResult != null) xml += "\r\n<authenticationResult>" + SecurityElement.Escape(authenticationResult) + "</authenticationResult>";
-            if (advancedAVSResult != null) xml += "\r\n<advancedAVSResult>" + SecurityElement.Escape(advancedAVSResult) + "</advancedAVSResult>";
+            if (cardValidationResult != null)
+                xml += "\r\n<cardValidationResult>" + SecurityElement.Escape(cardValidationResult) +
+                       "</cardValidationResult>";
+            if (authenticationResult != null)
+                xml += "\r\n<authenticationResult>" + SecurityElement.Escape(authenticationResult) +
+                       "</authenticationResult>";
+            if (advancedAVSResult != null)
+                xml += "\r\n<advancedAVSResult>" + SecurityElement.Escape(advancedAVSResult) + "</advancedAVSResult>";
             return xml;
         }
     }
 
-    public partial class authInformation
+    public class authInformation
     {
         public DateTime authDate;
         public string authCode;
         public fraudResult fraudResult;
         private long authAmountField;
         private bool authAmountSet;
+
         public long authAmount
         {
-            get { return this.authAmountField; }
-            set { this.authAmountField = value; this.authAmountSet = true; }
+            get { return authAmountField; }
+            set
+            {
+                authAmountField = value;
+                authAmountSet = true;
+            }
         }
 
         public string Serialize()
         {
-            string xml = "";
+            var xml = "";
             if (authDate != null) xml += "\r\n<authDate>" + XmlUtil.toXsdDate(authDate) + "</authDate>";
             if (authCode != null) xml += "\r\n<authCode>" + SecurityElement.Escape(authCode) + "</authCode>";
             if (fraudResult != null) xml += "\r\n<fraudResult>" + fraudResult.Serialize() + "</fraudResult>";
@@ -2277,13 +2780,13 @@ namespace Litle.Sdk
     {
         public static string toXsdDate(DateTime dateTime)
         {
-            string year = dateTime.Year.ToString();
-            string month = dateTime.Month.ToString();
+            var year = dateTime.Year.ToString();
+            var month = dateTime.Month.ToString();
             if (dateTime.Month < 10)
             {
                 month = "0" + month;
             }
-            string day = dateTime.Day.ToString();
+            var day = dateTime.Day.ToString();
             if (dateTime.Day < 10)
             {
                 day = "0" + day;
@@ -2292,50 +2795,64 @@ namespace Litle.Sdk
         }
     }
 
-    public partial class recyclingRequestType
+    public class recyclingRequestType
     {
         private recycleByTypeEnum recycleByField;
         private bool recycleBySet;
+
         public recycleByTypeEnum recycleBy
         {
-            get { return this.recycleByField; }
-            set { this.recycleByField = value; this.recycleBySet = true; }
+            get { return recycleByField; }
+            set
+            {
+                recycleByField = value;
+                recycleBySet = true;
+            }
         }
+
         public string recycleId;
 
         public string Serialize()
         {
-            string xml = "";
+            var xml = "";
             if (recycleBySet) xml += "\r\n<recycleBy>" + recycleByField + "</recycleBy>";
             if (recycleId != null) xml += "\r\n<recycleId>" + SecurityElement.Escape(recycleId) + "</recycleId>";
             return xml;
         }
     }
 
-    public partial class litleInternalRecurringRequest
+    public class litleInternalRecurringRequest
     {
         public string subscriptionId;
         public string recurringTxnId;
 
         private bool finalPaymentField;
         private bool finalPaymentSet;
+
         public bool finalPayment
         {
-            get { return this.finalPaymentField; }
-            set { this.finalPaymentField = value; this.finalPaymentSet = true; }
+            get { return finalPaymentField; }
+            set
+            {
+                finalPaymentField = value;
+                finalPaymentSet = true;
+            }
         }
 
         public string Serialize()
         {
-            string xml = "";
-            if (subscriptionId != null) xml += "\r\n<subscriptionId>" + SecurityElement.Escape(subscriptionId) + "</subscriptionId>";
-            if (recurringTxnId != null) xml += "\r\n<recurringTxnId>" + SecurityElement.Escape(recurringTxnId) + "</recurringTxnId>";
-            if(finalPaymentSet) xml += "\r\n<finalPayment>" + finalPaymentField.ToString().ToLower() + "</finalPayment>";
+            var xml = "";
+            if (subscriptionId != null)
+                xml += "\r\n<subscriptionId>" + SecurityElement.Escape(subscriptionId) + "</subscriptionId>";
+            if (recurringTxnId != null)
+                xml += "\r\n<recurringTxnId>" + SecurityElement.Escape(recurringTxnId) + "</recurringTxnId>";
+            if (finalPaymentSet)
+                xml += "\r\n<finalPayment>" + finalPaymentField.ToString().ToLower() + "</finalPayment>";
             return xml;
         }
     }
 
-    public partial class createDiscount
+    public class createDiscount
     {
         public string discountCode;
         public string name;
@@ -2345,7 +2862,7 @@ namespace Litle.Sdk
 
         public string Serialize()
         {
-            string xml = "";
+            var xml = "";
             xml += "\r\n<discountCode>" + SecurityElement.Escape(discountCode) + "</discountCode>";
             xml += "\r\n<name>" + SecurityElement.Escape(name) + "</name>";
             xml += "\r\n<amount>" + amount + "</amount>";
@@ -2355,45 +2872,65 @@ namespace Litle.Sdk
         }
     }
 
-    public partial class updateDiscount
+    public class updateDiscount
     {
         public string discountCode;
 
         private string nameField;
         private bool nameSet;
+
         public string name
         {
-            get { return this.nameField; }
-            set { this.nameField = value; this.nameSet = true; }
+            get { return nameField; }
+            set
+            {
+                nameField = value;
+                nameSet = true;
+            }
         }
 
         private long amountField;
         private bool amountSet;
+
         public long amount
         {
-            get { return this.amountField; }
-            set { this.amountField = value; this.amountSet = true; }
+            get { return amountField; }
+            set
+            {
+                amountField = value;
+                amountSet = true;
+            }
         }
 
         private DateTime startDateField;
         private bool startDateSet;
+
         public DateTime startDate
         {
-            get { return this.startDateField; }
-            set { this.startDateField = value; this.startDateSet = true; }
+            get { return startDateField; }
+            set
+            {
+                startDateField = value;
+                startDateSet = true;
+            }
         }
 
         private DateTime endDateField;
         private bool endDateSet;
+
         public DateTime endDate
         {
-            get { return this.endDateField; }
-            set { this.endDateField = value; this.endDateSet = true; }
+            get { return endDateField; }
+            set
+            {
+                endDateField = value;
+                endDateSet = true;
+            }
         }
 
         public string Serialize()
         {
-            string xml = "";
+            var xml = "";
             xml += "\r\n<discountCode>" + SecurityElement.Escape(discountCode) + "</discountCode>";
             if (nameSet) xml += "\r\n<name>" + SecurityElement.Escape(nameField) + "</name>";
             if (amountSet) xml += "\r\n<amount>" + amountField + "</amount>";
@@ -2403,19 +2940,19 @@ namespace Litle.Sdk
         }
     }
 
-    public partial class deleteDiscount
+    public class deleteDiscount
     {
         public string discountCode;
 
         public string Serialize()
         {
-            string xml = "";
+            var xml = "";
             xml += "\r\n<discountCode>" + SecurityElement.Escape(discountCode) + "</discountCode>";
             return xml;
         }
     }
 
-    public partial class createAddOn
+    public class createAddOn
     {
         public string addOnCode;
         public string name;
@@ -2425,7 +2962,7 @@ namespace Litle.Sdk
 
         public string Serialize()
         {
-            string xml = "";
+            var xml = "";
             xml += "\r\n<addOnCode>" + SecurityElement.Escape(addOnCode) + "</addOnCode>";
             xml += "\r\n<name>" + SecurityElement.Escape(name) + "</name>";
             xml += "\r\n<amount>" + amount + "</amount>";
@@ -2435,45 +2972,65 @@ namespace Litle.Sdk
         }
     }
 
-    public partial class updateAddOn
+    public class updateAddOn
     {
         public string addOnCode;
 
         private string nameField;
         private bool nameSet;
+
         public string name
         {
-            get { return this.nameField; }
-            set { this.nameField = value; this.nameSet = true; }
+            get { return nameField; }
+            set
+            {
+                nameField = value;
+                nameSet = true;
+            }
         }
 
         private long amountField;
         private bool amountSet;
+
         public long amount
         {
-            get { return this.amountField; }
-            set { this.amountField = value; this.amountSet = true; }
+            get { return amountField; }
+            set
+            {
+                amountField = value;
+                amountSet = true;
+            }
         }
 
         private DateTime startDateField;
         private bool startDateSet;
+
         public DateTime startDate
         {
-            get { return this.startDateField; }
-            set { this.startDateField = value; this.startDateSet = true; }
+            get { return startDateField; }
+            set
+            {
+                startDateField = value;
+                startDateSet = true;
+            }
         }
 
         private DateTime endDateField;
         private bool endDateSet;
+
         public DateTime endDate
         {
-            get { return this.endDateField; }
-            set { this.endDateField = value; this.endDateSet = true; }
+            get { return endDateField; }
+            set
+            {
+                endDateField = value;
+                endDateSet = true;
+            }
         }
 
         public string Serialize()
         {
-            string xml = "";
+            var xml = "";
             xml += "\r\n<addOnCode>" + SecurityElement.Escape(addOnCode) + "</addOnCode>";
             if (nameSet) xml += "\r\n<name>" + SecurityElement.Escape(nameField) + "</name>";
             if (amountSet) xml += "\r\n<amount>" + amountField + "</amount>";
@@ -2483,42 +3040,59 @@ namespace Litle.Sdk
         }
     }
 
-    public partial class deleteAddOn
+    public class deleteAddOn
     {
         public string addOnCode;
 
         public string Serialize()
         {
-            string xml = "";
+            var xml = "";
             xml += "\r\n<addOnCode>" + SecurityElement.Escape(addOnCode) + "</addOnCode>";
             return xml;
         }
     }
 
 
-    public partial class subscription
+    public class subscription
     {
         public string planCode;
         private bool numberOfPaymentsSet;
         private int numberOfPaymentsField;
+
         public int numberOfPayments
         {
-            get { return this.numberOfPaymentsField; }
-            set { this.numberOfPaymentsField = value; this.numberOfPaymentsSet = true; }
+            get { return numberOfPaymentsField; }
+            set
+            {
+                numberOfPaymentsField = value;
+                numberOfPaymentsSet = true;
+            }
         }
+
         private bool startDateSet;
         private DateTime startDateField;
+
         public DateTime startDate
         {
-            get { return this.startDateField; }
-            set { this.startDateField = value; this.startDateSet = true; }
+            get { return startDateField; }
+            set
+            {
+                startDateField = value;
+                startDateSet = true;
+            }
         }
+
         private bool amountSet;
         private long amountField;
+
         public long amount
         {
-            get { return this.amountField; }
-            set { this.amountField = value; this.amountSet = true; }
+            get { return amountField; }
+            set
+            {
+                amountField = value;
+                amountSet = true;
+            }
         }
 
         public List<createDiscount> createDiscounts;
@@ -2533,16 +3107,16 @@ namespace Litle.Sdk
 
         public string Serialize()
         {
-            string xml = "";
+            var xml = "";
             xml += "\r\n<planCode>" + planCode + "</planCode>";
-            if(numberOfPaymentsSet) xml += "\r\n<numberOfPayments>" + numberOfPayments + "</numberOfPayments>";
+            if (numberOfPaymentsSet) xml += "\r\n<numberOfPayments>" + numberOfPayments + "</numberOfPayments>";
             if (startDateSet) xml += "\r\n<startDate>" + XmlUtil.toXsdDate(startDateField) + "</startDate>";
-            if(amountSet) xml += "\r\n<amount>" + amountField + "</amount>";
-            foreach(createDiscount createDiscount in createDiscounts) 
+            if (amountSet) xml += "\r\n<amount>" + amountField + "</amount>";
+            foreach (var createDiscount in createDiscounts)
             {
                 xml += "\r\n<createDiscount>" + createDiscount.Serialize() + "\r\n</createDiscount>";
             }
-            foreach (createAddOn createAddOn in createAddOns)
+            foreach (var createAddOn in createAddOns)
             {
                 xml += "\r\n<createAddOn>" + createAddOn.Serialize() + "\r\n</createAddOn>";
             }
@@ -2552,128 +3126,173 @@ namespace Litle.Sdk
     }
 
 
-
-
-
-    public partial class filteringType
+    public class filteringType
     {
         private bool prepaidField;
         private bool prepaidSet;
+
         public bool prepaid
         {
-            get { return this.prepaidField; }
-            set { this.prepaidField = value; this.prepaidSet = true; }
+            get { return prepaidField; }
+            set
+            {
+                prepaidField = value;
+                prepaidSet = true;
+            }
         }
 
         private bool internationalField;
         private bool internationalSet;
+
         public bool international
         {
-            get { return this.internationalField; }
-            set { this.internationalField = value; this.internationalSet = true; }
+            get { return internationalField; }
+            set
+            {
+                internationalField = value;
+                internationalSet = true;
+            }
         }
 
         private bool chargebackField;
         private bool chargebackSet;
+
         public bool chargeback
         {
-            get { return this.chargebackField; }
-            set { this.chargebackField = value; this.chargebackSet = true; }
+            get { return chargebackField; }
+            set
+            {
+                chargebackField = value;
+                chargebackSet = true;
+            }
         }
 
         public string Serialize()
         {
-            string xml = "";
+            var xml = "";
             if (prepaidSet) xml += "\r\n<prepaid>" + prepaidField.ToString().ToLower() + "</prepaid>";
-            if (internationalSet) xml += "\r\n<international>" + internationalField.ToString().ToLower() + "</international>";
+            if (internationalSet)
+                xml += "\r\n<international>" + internationalField.ToString().ToLower() + "</international>";
             if (chargebackSet) xml += "\r\n<chargeback>" + chargebackField.ToString().ToLower() + "</chargeback>";
             return xml;
         }
-
     }
 
-    public partial class healthcareIIAS
+    public class healthcareIIAS
     {
         public healthcareAmounts healthcareAmounts;
         private IIASFlagType IIASFlagField;
         private bool IIASFlagSet;
+
         public IIASFlagType IIASFlag
         {
-            get { return this.IIASFlagField; }
-            set { this.IIASFlagField = value; this.IIASFlagSet = true; }
+            get { return IIASFlagField; }
+            set
+            {
+                IIASFlagField = value;
+                IIASFlagSet = true;
+            }
         }
 
         public string Serialize()
         {
-            string xml = "";
-            if (healthcareAmounts != null) xml += "\r\n<healthcareAmounts>" + healthcareAmounts.Serialize() + "</healthcareAmounts>";
+            var xml = "";
+            if (healthcareAmounts != null)
+                xml += "\r\n<healthcareAmounts>" + healthcareAmounts.Serialize() + "</healthcareAmounts>";
             if (IIASFlagSet) xml += "\r\n<IIASFlag>" + IIASFlagField + "</IIASFlag>";
             return xml;
         }
     }
 
-    public partial class recurringRequest
+    public class recurringRequest
     {
         public subscription subscription;
 
         public string Serialize()
         {
-            string xml = "";
+            var xml = "";
             if (subscription != null) xml += "\r\n<subscription>" + subscription.Serialize() + "\r\n</subscription>";
             return xml;
         }
     }
 
 
-    public partial class healthcareAmounts
+    public class healthcareAmounts
     {
         private int totalHealthcareAmountField;
         private bool totalHealthcareAmountSet;
+
         public int totalHealthcareAmount
         {
-            get { return this.totalHealthcareAmountField; }
-            set { this.totalHealthcareAmountField = value; this.totalHealthcareAmountSet = true; }
+            get { return totalHealthcareAmountField; }
+            set
+            {
+                totalHealthcareAmountField = value;
+                totalHealthcareAmountSet = true;
+            }
         }
 
         private int RxAmountField;
         private bool RxAmountSet;
+
         public int RxAmount
         {
-            get { return this.RxAmountField; }
-            set { this.RxAmountField = value; this.RxAmountSet = true; }
+            get { return RxAmountField; }
+            set
+            {
+                RxAmountField = value;
+                RxAmountSet = true;
+            }
         }
 
         private int visionAmountField;
         private bool visionAmountSet;
+
         public int visionAmount
         {
-            get { return this.visionAmountField; }
-            set { this.visionAmountField = value; this.visionAmountSet = true; }
+            get { return visionAmountField; }
+            set
+            {
+                visionAmountField = value;
+                visionAmountSet = true;
+            }
         }
 
         private int clinicOtherAmountField;
         private bool clinicOtherAmountSet;
+
         public int clinicOtherAmount
         {
-            get { return this.clinicOtherAmountField; }
-            set { this.clinicOtherAmountField = value; this.clinicOtherAmountSet = true; }
+            get { return clinicOtherAmountField; }
+            set
+            {
+                clinicOtherAmountField = value;
+                clinicOtherAmountSet = true;
+            }
         }
 
         private int dentalAmountField;
         private bool dentalAmountSet;
+
         public int dentalAmount
         {
-            get { return this.dentalAmountField; }
-            set { this.dentalAmountField = value; this.dentalAmountSet = true; }
+            get { return dentalAmountField; }
+            set
+            {
+                dentalAmountField = value;
+                dentalAmountSet = true;
+            }
         }
 
         public string Serialize()
         {
-            string xml = "";
-            if (totalHealthcareAmountSet) xml += "\r\n<totalHealthcareAmount>" + totalHealthcareAmountField + "</totalHealthcareAmount>";
+            var xml = "";
+            if (totalHealthcareAmountSet)
+                xml += "\r\n<totalHealthcareAmount>" + totalHealthcareAmountField + "</totalHealthcareAmount>";
             if (RxAmountSet) xml += "\r\n<RxAmount>" + RxAmountField + "</RxAmount>";
             if (visionAmountSet) xml += "\r\n<visionAmount>" + visionAmountField + "</visionAmount>";
-            if (clinicOtherAmountSet) xml += "\r\n<clinicOtherAmount>" + clinicOtherAmountField + "</clinicOtherAmount>";
+            if (clinicOtherAmountSet)
+                xml += "\r\n<clinicOtherAmount>" + clinicOtherAmountField + "</clinicOtherAmount>";
             if (dentalAmountSet) xml += "\r\n<dentalAmount>" + dentalAmountField + "</dentalAmount>";
             return xml;
         }
@@ -2693,14 +3312,21 @@ namespace Litle.Sdk
         public static readonly orderSourceType echeckppd = new orderSourceType("echeckppd");
         public static readonly orderSourceType applepay = new orderSourceType("applepay");
 
-        private orderSourceType(String value) { this.value = value; }
-        public string Serialize() { return value; }
-        private string value;
+        private orderSourceType(string value)
+        {
+            this.value = value;
+        }
+
+        public string Serialize()
+        {
+            return value;
+        }
+
+        private readonly string value;
     }
 
-    public partial class contact
+    public class contact
     {
-
         public string name;
         public string firstName;
         public string middleInitial;
@@ -2714,25 +3340,36 @@ namespace Litle.Sdk
         public string zip;
         private countryTypeEnum countryField;
         private bool countrySpecified;
+
         public countryTypeEnum country
         {
-            get { return this.countryField; }
-            set { this.countryField = value; countrySpecified = true; }
+            get { return countryField; }
+            set
+            {
+                countryField = value;
+                countrySpecified = true;
+            }
         }
+
         public string email;
         public string phone;
 
         public string Serialize()
         {
-            string xml = "";
+            var xml = "";
             if (name != null) xml += "\r\n<name>" + SecurityElement.Escape(name) + "</name>";
             if (firstName != null) xml += "\r\n<firstName>" + SecurityElement.Escape(firstName) + "</firstName>";
-            if (middleInitial != null) xml += "\r\n<middleInitial>" + SecurityElement.Escape(middleInitial) + "</middleInitial>";
+            if (middleInitial != null)
+                xml += "\r\n<middleInitial>" + SecurityElement.Escape(middleInitial) + "</middleInitial>";
             if (lastName != null) xml += "\r\n<lastName>" + SecurityElement.Escape(lastName) + "</lastName>";
-            if (companyName != null) xml += "\r\n<companyName>" + SecurityElement.Escape(companyName) + "</companyName>";
-            if (addressLine1 != null) xml += "\r\n<addressLine1>" + SecurityElement.Escape(addressLine1) + "</addressLine1>";
-            if (addressLine2 != null) xml += "\r\n<addressLine2>" + SecurityElement.Escape(addressLine2) + "</addressLine2>";
-            if (addressLine3 != null) xml += "\r\n<addressLine3>" + SecurityElement.Escape(addressLine3) + "</addressLine3>";
+            if (companyName != null)
+                xml += "\r\n<companyName>" + SecurityElement.Escape(companyName) + "</companyName>";
+            if (addressLine1 != null)
+                xml += "\r\n<addressLine1>" + SecurityElement.Escape(addressLine1) + "</addressLine1>";
+            if (addressLine2 != null)
+                xml += "\r\n<addressLine2>" + SecurityElement.Escape(addressLine2) + "</addressLine2>";
+            if (addressLine3 != null)
+                xml += "\r\n<addressLine3>" + SecurityElement.Escape(addressLine3) + "</addressLine3>";
             if (city != null) xml += "\r\n<city>" + SecurityElement.Escape(city) + "</city>";
             if (state != null) xml += "\r\n<state>" + SecurityElement.Escape(state) + "</state>";
             if (zip != null) xml += "\r\n<zip>" + SecurityElement.Escape(zip) + "</zip>";
@@ -2745,8 +3382,7 @@ namespace Litle.Sdk
 
     public enum countryTypeEnum
     {
-
-        /// <remarks/>
+        /// <remarks />
         USA,
         AF,
         AX,
@@ -2996,85 +3632,134 @@ namespace Litle.Sdk
         ZM,
         ZW,
         RS,
-        ME,
+        ME
     }
 
-    public partial class fraudCheckType
+    public class fraudCheckType
     {
-        public String authenticationValue;
-        public String authenticationTransactionId;
-        public String customerIpAddress;
+        public string authenticationValue;
+        public string authenticationTransactionId;
+        public string customerIpAddress;
         private bool authenticatedByMerchantField;
         private bool authenticatedByMerchantSet;
+
         public bool authenticatedByMerchant
         {
-            get { return this.authenticatedByMerchantField; }
-            set { this.authenticatedByMerchantField = value; authenticatedByMerchantSet = true; }
+            get { return authenticatedByMerchantField; }
+            set
+            {
+                authenticatedByMerchantField = value;
+                authenticatedByMerchantSet = true;
+            }
         }
 
         public string Serialize()
         {
-            string xml = "";
-            if (authenticationValue != null) xml += "\r\n<authenticationValue>" + SecurityElement.Escape(authenticationValue) + "</authenticationValue>";
-            if (authenticationTransactionId != null) xml += "\r\n<authenticationTransactionId>" + SecurityElement.Escape(authenticationTransactionId) + "</authenticationTransactionId>";
-            if (customerIpAddress != null) xml += "\r\n<customerIpAddress>" + SecurityElement.Escape(customerIpAddress) + "</customerIpAddress>";
-            if (authenticatedByMerchantSet) xml += "\r\n<authenticatedByMerchant>" + authenticatedByMerchantField + "</authenticatedByMerchant>";
+            var xml = "";
+            if (authenticationValue != null)
+                xml += "\r\n<authenticationValue>" + SecurityElement.Escape(authenticationValue) +
+                       "</authenticationValue>";
+            if (authenticationTransactionId != null)
+                xml += "\r\n<authenticationTransactionId>" + SecurityElement.Escape(authenticationTransactionId) +
+                       "</authenticationTransactionId>";
+            if (customerIpAddress != null)
+                xml += "\r\n<customerIpAddress>" + SecurityElement.Escape(customerIpAddress) + "</customerIpAddress>";
+            if (authenticatedByMerchantSet)
+                xml += "\r\n<authenticatedByMerchant>" + authenticatedByMerchantField + "</authenticatedByMerchant>";
             return xml;
         }
     }
 
-    public partial class advancedFraudChecksType
+    public class advancedFraudChecksType
     {
         public string threatMetrixSessionId;
         private string customAttribute1Field;
         private bool customAttribute1Set;
-        public string customAttribute1 { 
-            get { return this.customAttribute1Field; } 
-            set { this.customAttribute1Field = value; customAttribute1Set = true; } 
+
+        public string customAttribute1
+        {
+            get { return customAttribute1Field; }
+            set
+            {
+                customAttribute1Field = value;
+                customAttribute1Set = true;
+            }
         }
+
         private string customAttribute2Field;
         private bool customAttribute2Set;
+
         public string customAttribute2
         {
-            get { return this.customAttribute2Field; }
-            set { this.customAttribute2Field = value; customAttribute2Set = true; }
+            get { return customAttribute2Field; }
+            set
+            {
+                customAttribute2Field = value;
+                customAttribute2Set = true;
+            }
         }
+
         private string customAttribute3Field;
         private bool customAttribute3Set;
+
         public string customAttribute3
         {
-            get { return this.customAttribute3Field; }
-            set { this.customAttribute3Field = value; customAttribute3Set = true; }
+            get { return customAttribute3Field; }
+            set
+            {
+                customAttribute3Field = value;
+                customAttribute3Set = true;
+            }
         }
+
         private string customAttribute4Field;
         private bool customAttribute4Set;
+
         public string customAttribute4
         {
-            get { return this.customAttribute4Field; }
-            set { this.customAttribute4Field = value; customAttribute4Set = true; }
+            get { return customAttribute4Field; }
+            set
+            {
+                customAttribute4Field = value;
+                customAttribute4Set = true;
+            }
         }
+
         private string customAttribute5Field;
         private bool customAttribute5Set;
+
         public string customAttribute5
         {
-            get { return this.customAttribute5Field; }
-            set { this.customAttribute5Field = value; customAttribute5Set = true; }
+            get { return customAttribute5Field; }
+            set
+            {
+                customAttribute5Field = value;
+                customAttribute5Set = true;
+            }
         }
 
         public string Serialize()
         {
-            string xml = "";
-            if (threatMetrixSessionId != null) xml += "\r\n<threatMetrixSessionId>" + SecurityElement.Escape(threatMetrixSessionId) + "</threatMetrixSessionId>";
-            if (customAttribute1Set) xml += "\r\n<customAttribute1>" + SecurityElement.Escape(customAttribute1Field) + "</customAttribute1>";
-            if (customAttribute2Set) xml += "\r\n<customAttribute2>" + SecurityElement.Escape(customAttribute2Field) + "</customAttribute2>";
-            if (customAttribute3Set) xml += "\r\n<customAttribute3>" + SecurityElement.Escape(customAttribute3Field) + "</customAttribute3>";
-            if (customAttribute4Set) xml += "\r\n<customAttribute4>" + SecurityElement.Escape(customAttribute4Field) + "</customAttribute4>";
-            if (customAttribute5Set) xml += "\r\n<customAttribute5>" + SecurityElement.Escape(customAttribute5Field) + "</customAttribute5>";
+            var xml = "";
+            if (threatMetrixSessionId != null)
+                xml += "\r\n<threatMetrixSessionId>" + SecurityElement.Escape(threatMetrixSessionId) +
+                       "</threatMetrixSessionId>";
+            if (customAttribute1Set)
+                xml += "\r\n<customAttribute1>" + SecurityElement.Escape(customAttribute1Field) + "</customAttribute1>";
+            if (customAttribute2Set)
+                xml += "\r\n<customAttribute2>" + SecurityElement.Escape(customAttribute2Field) + "</customAttribute2>";
+            if (customAttribute3Set)
+                xml += "\r\n<customAttribute3>" + SecurityElement.Escape(customAttribute3Field) + "</customAttribute3>";
+            if (customAttribute4Set)
+                xml += "\r\n<customAttribute4>" + SecurityElement.Escape(customAttribute4Field) + "</customAttribute4>";
+            if (customAttribute5Set)
+                xml += "\r\n<customAttribute5>" + SecurityElement.Escape(customAttribute5Field) + "</customAttribute5>";
             return xml;
         }
     }
 
-    public partial class mposType {
+    public class mposType
+    {
         public string ksn;
         public string formatId;
         public string encryptedTrack;
@@ -3083,7 +3768,7 @@ namespace Litle.Sdk
 
         public string Serialize()
         {
-            string xml = "";
+            var xml = "";
             if (ksn != null)
             {
                 xml += "\r\n<ksn>" + ksn + "</ksn>";
@@ -3096,7 +3781,7 @@ namespace Litle.Sdk
             {
                 xml += "\r\n<encryptedTrack>" + SecurityElement.Escape(encryptedTrack) + "</encryptedTrack>";
             }
-            if (track1Status == 0 || track1Status == 1 )
+            if (track1Status == 0 || track1Status == 1)
             {
                 xml += "\r\n<track1Status>" + track1Status + "</track1Status>";
             }
@@ -3109,7 +3794,7 @@ namespace Litle.Sdk
         }
     }
 
-    public partial class cardType
+    public class cardType
     {
         public methodOfPaymentTypeEnum type;
         public string number;
@@ -3119,7 +3804,7 @@ namespace Litle.Sdk
 
         public string Serialize()
         {
-            string xml = "";
+            var xml = "";
             if (track == null)
             {
                 xml += "\r\n<type>" + methodOfPaymentSerializer.Serialize(type) + "</type>";
@@ -3144,51 +3829,69 @@ namespace Litle.Sdk
         }
     }
 
-    public partial class virtualGiftCardType
+    public class virtualGiftCardType
     {
         public int accountNumberLength
         {
-            get { return this.accountNumberLengthField; }
-            set { this.accountNumberLengthField = value; accountNumberLengthSet = true; }
+            get { return accountNumberLengthField; }
+            set
+            {
+                accountNumberLengthField = value;
+                accountNumberLengthSet = true;
+            }
         }
+
         private int accountNumberLengthField;
         private bool accountNumberLengthSet;
 
         public string giftCardBin;
 
-        public String Serialize()
+        public string Serialize()
         {
-            String xml = "";
-            if (accountNumberLengthSet) xml += "\r\n<accountNumberLength>" + accountNumberLengthField + "</accountNumberLength>";
-            if (giftCardBin != null) xml += "\r\n<giftCardBin>" + SecurityElement.Escape(giftCardBin) + "</giftCardBin>";
+            var xml = "";
+            if (accountNumberLengthSet)
+                xml += "\r\n<accountNumberLength>" + accountNumberLengthField + "</accountNumberLength>";
+            if (giftCardBin != null)
+                xml += "\r\n<giftCardBin>" + SecurityElement.Escape(giftCardBin) + "</giftCardBin>";
             return xml;
         }
-
     }
 
-    public partial class authReversal : transactionTypeWithReportGroup
+    public class authReversal : transactionTypeWithReportGroup
     {
         public long litleTxnId;
         private long amountField;
         private bool amountSet;
+
         public long amount
         {
-            get { return this.amountField; }
-            set { this.amountField = value; amountSet = true; }
+            get { return amountField; }
+            set
+            {
+                amountField = value;
+                amountSet = true;
+            }
         }
+
         private bool surchargeAmountSet;
         private long surchargeAmountField;
+
         public long surchargeAmount
         {
-            get { return this.surchargeAmountField; }
-            set { this.surchargeAmountField = value; this.surchargeAmountSet = true; }
+            get { return surchargeAmountField; }
+            set
+            {
+                surchargeAmountField = value;
+                surchargeAmountSet = true;
+            }
         }
+
         public string payPalNotes;
         public string actionReason;
 
         public override string Serialize()
         {
-            string xml = "\r\n<authReversal";
+            var xml = "\r\n<authReversal";
             xml += " id=\"" + SecurityElement.Escape(id) + "\"";
             if (customerId != null)
             {
@@ -3212,16 +3915,15 @@ namespace Litle.Sdk
             xml += "\r\n</authReversal>";
             return xml;
         }
-
     }
 
-    public partial class echeckVoid : transactionTypeWithReportGroup
+    public class echeckVoid : transactionTypeWithReportGroup
     {
         public long litleTxnId;
 
         public override string Serialize()
         {
-            string xml = "\r\n<echeckVoid";
+            var xml = "\r\n<echeckVoid";
             xml += " id=\"" + SecurityElement.Escape(id) + "\"";
             if (customerId != null)
             {
@@ -3232,7 +3934,6 @@ namespace Litle.Sdk
             xml += "\r\n</echeckVoid>";
             return xml;
         }
-
     }
 
     public class accountUpdate : transactionTypeWithReportGroup
@@ -3243,7 +3944,7 @@ namespace Litle.Sdk
 
         public override string Serialize()
         {
-            string xml = "\r\n<accountUpdate ";
+            var xml = "\r\n<accountUpdate ";
 
             if (id != null)
             {
@@ -3279,19 +3980,22 @@ namespace Litle.Sdk
     public class accountUpdateFileRequestData
     {
         public string merchantId;
+
         public accountUpdateFileRequestData()
         {
-            merchantId = Properties.Settings.Default.merchantId;
+            merchantId = Settings.Default.merchantId;
         }
-        public accountUpdateFileRequestData(Dictionary<String,String> config) 
+
+        public accountUpdateFileRequestData(Dictionary<string, string> config)
         {
-            this.merchantId = config["merchantId"];
+            merchantId = config["merchantId"];
         }
+
         public DateTime postDay; //yyyy-MM-dd
 
         public string Serialize()
         {
-            string xml = "\r\n<merchantId>" + SecurityElement.Escape(merchantId) + "</merchantId>";
+            var xml = "\r\n<merchantId>" + SecurityElement.Escape(merchantId) + "</merchantId>";
 
             if (postDay != null)
             {
@@ -3302,7 +4006,7 @@ namespace Litle.Sdk
         }
     }
 
-    public partial class activate : transactionTypeWithReportGroup
+    public class activate : transactionTypeWithReportGroup
     {
         public string orderId;
         public long amount;
@@ -3312,7 +4016,7 @@ namespace Litle.Sdk
 
         public override string Serialize()
         {
-            string xml = "\r\n<activate";
+            var xml = "\r\n<activate";
             xml += " id=\"" + SecurityElement.Escape(id) + "\"";
             if (customerId != null)
             {
@@ -3323,13 +4027,14 @@ namespace Litle.Sdk
             xml += "\r\n<amount>" + amount + "</amount>";
             xml += "\r\n<orderSource>" + orderSource.Serialize() + "</orderSource>";
             if (card != null) xml += "\r\n<card>" + card.Serialize() + "\r\n</card>";
-            else if (virtualGiftCard != null) xml += "\r\n<virtualGiftCard>" + virtualGiftCard.Serialize() + "\r\n</virtualGiftCard>";
+            else if (virtualGiftCard != null)
+                xml += "\r\n<virtualGiftCard>" + virtualGiftCard.Serialize() + "\r\n</virtualGiftCard>";
             xml += "\r\n</activate>";
             return xml;
         }
     }
 
-    public partial class deactivate : transactionTypeWithReportGroup
+    public class deactivate : transactionTypeWithReportGroup
     {
         public string orderId;
         public orderSourceType orderSource;
@@ -3337,7 +4042,7 @@ namespace Litle.Sdk
 
         public override string Serialize()
         {
-            string xml = "\r\n<deactivate";
+            var xml = "\r\n<deactivate";
             xml += " id=\"" + SecurityElement.Escape(id) + "\"";
             if (customerId != null)
             {
@@ -3352,7 +4057,7 @@ namespace Litle.Sdk
         }
     }
 
-    public partial class load : transactionTypeWithReportGroup
+    public class load : transactionTypeWithReportGroup
     {
         public string orderId;
         public long amount;
@@ -3361,7 +4066,7 @@ namespace Litle.Sdk
 
         public override string Serialize()
         {
-            string xml = "\r\n<load";
+            var xml = "\r\n<load";
             xml += " id=\"" + SecurityElement.Escape(id) + "\"";
             if (customerId != null)
             {
@@ -3377,7 +4082,7 @@ namespace Litle.Sdk
         }
     }
 
-    public partial class unload : transactionTypeWithReportGroup
+    public class unload : transactionTypeWithReportGroup
     {
         public string orderId;
         public long amount;
@@ -3386,7 +4091,7 @@ namespace Litle.Sdk
 
         public override string Serialize()
         {
-            string xml = "\r\n<unload";
+            var xml = "\r\n<unload";
             xml += " id=\"" + SecurityElement.Escape(id) + "\"";
             if (customerId != null)
             {
@@ -3402,7 +4107,7 @@ namespace Litle.Sdk
         }
     }
 
-    public partial class balanceInquiry : transactionTypeWithReportGroup
+    public class balanceInquiry : transactionTypeWithReportGroup
     {
         public string orderId;
         public orderSourceType orderSource;
@@ -3410,7 +4115,7 @@ namespace Litle.Sdk
 
         public override string Serialize()
         {
-            string xml = "\r\n<balanceInquiry";
+            var xml = "\r\n<balanceInquiry";
             xml += " id=\"" + SecurityElement.Escape(id) + "\"";
             if (customerId != null)
             {
@@ -3425,13 +4130,13 @@ namespace Litle.Sdk
         }
     }
 
-    public partial class loadReversal : transactionTypeWithReportGroup
+    public class loadReversal : transactionTypeWithReportGroup
     {
-        public String litleTxnId;
+        public string litleTxnId;
 
         public override string Serialize()
         {
-            string xml = "\r\n<loadReversal";
+            var xml = "\r\n<loadReversal";
             xml += " id=\"" + SecurityElement.Escape(id) + "\"";
             if (customerId != null)
             {
@@ -3444,13 +4149,13 @@ namespace Litle.Sdk
         }
     }
 
-    public partial class unloadReversal : transactionTypeWithReportGroup
+    public class unloadReversal : transactionTypeWithReportGroup
     {
-        public String litleTxnId;
+        public string litleTxnId;
 
         public override string Serialize()
         {
-            string xml = "\r\n<unloadReversal";
+            var xml = "\r\n<unloadReversal";
             xml += " id=\"" + SecurityElement.Escape(id) + "\"";
             if (customerId != null)
             {
@@ -3463,13 +4168,13 @@ namespace Litle.Sdk
         }
     }
 
-    public partial class deactivateReversal : transactionTypeWithReportGroup
+    public class deactivateReversal : transactionTypeWithReportGroup
     {
-        public String litleTxnId;
+        public string litleTxnId;
 
         public override string Serialize()
         {
-            string xml = "\r\n<deactivateReversal";
+            var xml = "\r\n<deactivateReversal";
             xml += " id=\"" + SecurityElement.Escape(id) + "\"";
             if (customerId != null)
             {
@@ -3482,13 +4187,13 @@ namespace Litle.Sdk
         }
     }
 
-    public partial class activateReversal : transactionTypeWithReportGroup
+    public class activateReversal : transactionTypeWithReportGroup
     {
-        public String litleTxnId;
+        public string litleTxnId;
 
         public override string Serialize()
         {
-            string xml = "\r\n<activateReversal";
+            var xml = "\r\n<activateReversal";
             xml += " id=\"" + SecurityElement.Escape(id) + "\"";
             if (customerId != null)
             {
@@ -3501,13 +4206,13 @@ namespace Litle.Sdk
         }
     }
 
-    public partial class refundReversal : transactionTypeWithReportGroup
+    public class refundReversal : transactionTypeWithReportGroup
     {
-        public String litleTxnId;
+        public string litleTxnId;
 
         public override string Serialize()
         {
-            string xml = "\r\n<refundReversal";
+            var xml = "\r\n<refundReversal";
             xml += " id=\"" + SecurityElement.Escape(id) + "\"";
             if (customerId != null)
             {
@@ -3520,13 +4225,13 @@ namespace Litle.Sdk
         }
     }
 
-    public partial class depositReversal : transactionTypeWithReportGroup
+    public class depositReversal : transactionTypeWithReportGroup
     {
-        public String litleTxnId;
+        public string litleTxnId;
 
         public override string Serialize()
         {
-            string xml = "\r\n<depositReversal";
+            var xml = "\r\n<depositReversal";
             xml += " id=\"" + SecurityElement.Escape(id) + "\"";
             if (customerId != null)
             {
@@ -3539,7 +4244,7 @@ namespace Litle.Sdk
         }
     }
 
-    public partial class applepayType
+    public class applepayType
     {
         public string data;
         public applepayHeaderType header;
@@ -3548,7 +4253,7 @@ namespace Litle.Sdk
 
         public string Serialize()
         {
-            string xml = "";
+            var xml = "";
             if (data != null) xml += "\r\n<data>" + SecurityElement.Escape(data) + "</data>";
             if (header != null) xml += "\r\n<header>" + header.Serialize() + "</header>";
             if (signature != null) xml += "\r\n<signature>" + SecurityElement.Escape(signature) + "</signature>";
@@ -3557,7 +4262,7 @@ namespace Litle.Sdk
         }
     }
 
-    public partial class applepayHeaderType
+    public class applepayHeaderType
     {
         public string applicationData;
         public string ephemeralPublicKey;
@@ -3566,27 +4271,32 @@ namespace Litle.Sdk
 
         public string Serialize()
         {
-            string xml = "";
-            if (applicationData != null) xml += "\r\n<applicationData>" + SecurityElement.Escape(applicationData) + "</applicationData>";
-            if (ephemeralPublicKey != null) xml += "\r\n<ephemeralPublicKey>" + SecurityElement.Escape(ephemeralPublicKey) + "</ephemeralPublicKey>";
-            if (publicKeyHash != null) xml += "\r\n<publicKeyHash>" + SecurityElement.Escape(publicKeyHash) + "</publicKeyHash>";
-            if (transactionId != null) xml += "\r\n<transactionId>" + SecurityElement.Escape(transactionId) + "</transactionId>";
+            var xml = "";
+            if (applicationData != null)
+                xml += "\r\n<applicationData>" + SecurityElement.Escape(applicationData) + "</applicationData>";
+            if (ephemeralPublicKey != null)
+                xml += "\r\n<ephemeralPublicKey>" + SecurityElement.Escape(ephemeralPublicKey) + "</ephemeralPublicKey>";
+            if (publicKeyHash != null)
+                xml += "\r\n<publicKeyHash>" + SecurityElement.Escape(publicKeyHash) + "</publicKeyHash>";
+            if (transactionId != null)
+                xml += "\r\n<transactionId>" + SecurityElement.Escape(transactionId) + "</transactionId>";
             return xml;
         }
     }
 
-    public partial class wallet
+    public class wallet
     {
         public walletWalletSourceType walletSourceType;
         public string walletSourceTypeId;
 
         public string Serialize()
         {
-            string xml = "";
+            var xml = "";
             if (walletSourceType != null) xml += "\r\n<walletSourceType>" + walletSourceType + "</walletSourceType>";
-            if (walletSourceTypeId != null) xml += "\r\n<walletSourceTypeId>" + SecurityElement.Escape(walletSourceTypeId) + "</walletSourceTypeId>";
+            if (walletSourceTypeId != null)
+                xml += "\r\n<walletSourceTypeId>" + SecurityElement.Escape(walletSourceTypeId) + "</walletSourceTypeId>";
             return xml;
-        } 
+        }
     }
 
     public enum walletWalletSourceType
@@ -3594,60 +4304,57 @@ namespace Litle.Sdk
         MasterPass
     }
 
-    public partial class fraudCheck : transactionTypeWithReportGroup
+    public class fraudCheck : transactionTypeWithReportGroup
     {
-
         public advancedFraudChecksType advancedFraudChecks;
 
         private contact billToAddressField;
         private bool billToAddressSet;
+
         public contact billToAddress
         {
-            get
-            {
-                return this.billToAddressField;
-            }
+            get { return billToAddressField; }
             set
             {
-                this.billToAddressField = value; this.billToAddressSet = true;
+                billToAddressField = value;
+                billToAddressSet = true;
             }
         }
 
         private contact shipToAddressField;
         private bool shipToAddressSet;
+
         public contact shipToAddress
         {
-            get
-            {
-                return this.shipToAddressField;
-            }
+            get { return shipToAddressField; }
             set
             {
-                this.shipToAddressField = value; this.shipToAddressSet = true;
+                shipToAddressField = value;
+                shipToAddressSet = true;
             }
         }
 
         private int amountField;
         private bool amountSet;
+
         public int amount
         {
-            get
-            {
-                return this.amountField;
-            }
+            get { return amountField; }
             set
             {
-                this.amountField = value; this.amountSet = true;
+                amountField = value;
+                amountSet = true;
             }
         }
 
         public override string Serialize()
         {
-            string xml = "";
-            if (advancedFraudChecks != null) xml += "\r\n<advancedFraudChecks>" + advancedFraudChecks.Serialize() + "</advancedFraudChecks>";
+            var xml = "";
+            if (advancedFraudChecks != null)
+                xml += "\r\n<advancedFraudChecks>" + advancedFraudChecks.Serialize() + "</advancedFraudChecks>";
             if (billToAddressSet) xml += "\r\n<billToAddress>" + billToAddressField.Serialize() + "</billToAddress>";
             if (shipToAddressSet) xml += "\r\n<shipToAddress>" + shipToAddressField.Serialize() + "</shipToAddress>";
-            if (amountSet) xml += "\r\n<amount>" + amountField.ToString() + "</amount>";
+            if (amountSet) xml += "\r\n<amount>" + amountField + "</amount>";
             return xml;
         }
     }

--- a/LitleSdkForNet/LitleSdkForNet/XmlResponseFields.cs
+++ b/LitleSdkForNet/LitleSdkForNet/XmlResponseFields.cs
@@ -10,10 +10,7 @@
 
 using System.Xml;
 using System.Xml.Serialization;
-using System.Collections.Generic;
-using System.Runtime.Serialization;
 using System;
-using System.Xml.Schema;
 using System.IO;
 
 // 

--- a/LitleSdkForNet/LitleSdkForNet/XmlResponseFields.cs
+++ b/LitleSdkForNet/LitleSdkForNet/XmlResponseFields.cs
@@ -4589,15 +4589,15 @@ namespace Litle.Sdk
         {
         }
 
-        public litleResponse(string filePath)
+        public litleResponse(MemoryStream stream)
         {
-            XmlTextReader reader = new XmlTextReader(filePath);
-            readXml(reader, filePath);
+            XmlTextReader reader = new XmlTextReader(stream);
+            readXml(reader, stream);
         }
 
-        public litleResponse(XmlReader reader, string filePath)
+        public litleResponse(XmlReader reader, MemoryStream stream)
         {
-            readXml(reader, filePath);
+            readXml(reader, stream);
         }
 
         public void setBatchResponseReader(XmlReader xmlReader)
@@ -4610,7 +4610,7 @@ namespace Litle.Sdk
             this.rfrResponseReader = xmlReader;
         }
 
-        public void readXml(XmlReader reader, string filePath)
+        public void readXml(XmlReader reader, MemoryStream stream)
         {
             if (reader.ReadToFollowing("litleResponse"))
             {
@@ -4630,15 +4630,14 @@ namespace Litle.Sdk
             }
 
             this.originalXmlReader = reader;
-            this.filePath = filePath;
 
-            this.batchResponseReader = new XmlTextReader(filePath);
+            this.batchResponseReader = new XmlTextReader(stream);
             if (!batchResponseReader.ReadToFollowing("batchResponse"))
             {
                 batchResponseReader.Close();
             }
 
-            this.rfrResponseReader = new XmlTextReader(filePath);
+            this.rfrResponseReader = new XmlTextReader(stream);
             if (!rfrResponseReader.ReadToFollowing("RFRResponse"))
             {
                 rfrResponseReader.Close();

--- a/LitleSdkForNet/LitleSdkForNet/XmlSerializer.cs
+++ b/LitleSdkForNet/LitleSdkForNet/XmlSerializer.cs
@@ -21,14 +21,12 @@ namespace Litle.Sdk
             }
             return Encoding.UTF8.GetString(ms.GetBuffer()); //return string is UTF8 encoded.
         } // serialize the xml
-
-        public virtual litleResponse DeserializeObjectFromFile(Communications communications, string filePath)
+        
+        public virtual litleResponse DeserializeObjectFromString(string value)
         {
             litleResponse i;
             try
             {
-                var stream = communications[filePath];
-                var value = stream.ToString();
                 var bytes = Encoding.UTF8.GetBytes(value);
                 using (var memoryStream = new MemoryStream(bytes))
                 {

--- a/LitleSdkForNet/LitleSdkForNet/XmlSerializer.cs
+++ b/LitleSdkForNet/LitleSdkForNet/XmlSerializer.cs
@@ -1,18 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.IO;
 using System.Text;
-using System.IO;
-using System.Xml.Serialization;
 using System.Xml;
+using System.Xml.Serialization;
 
 namespace Litle.Sdk
 {
     public class litleXmlSerializer
     {
-        virtual public String SerializeObject(litleOnlineRequest req)
+        public virtual string SerializeObject(litleOnlineRequest req)
         {
-            XmlSerializer serializer = new XmlSerializer(typeof(litleOnlineRequest));
-            MemoryStream ms = new MemoryStream();
+            var serializer = new XmlSerializer(typeof (litleOnlineRequest));
+            var ms = new MemoryStream();
             try
             {
                 serializer.Serialize(ms, req);
@@ -21,10 +19,10 @@ namespace Litle.Sdk
             {
                 throw new LitleOnlineException("Error in sending request to Litle!", e);
             }
-            return Encoding.UTF8.GetString(ms.GetBuffer());//return string is UTF8 encoded.
-        }// serialize the xml
+            return Encoding.UTF8.GetString(ms.GetBuffer()); //return string is UTF8 encoded.
+        } // serialize the xml
 
-        virtual public litleResponse DeserializeObjectFromFile(Communications communications, string filePath)
+        public virtual litleResponse DeserializeObjectFromFile(Communications communications, string filePath)
         {
             litleResponse i;
             try
@@ -42,6 +40,6 @@ namespace Litle.Sdk
                 throw new LitleOnlineException("Error in recieving response from Litle!", e);
             }
             return i;
-        }// deserialize the object
+        } // deserialize the object
     }
 }

--- a/LitleSdkForNet/LitleSdkForNet/XmlSerializer.cs
+++ b/LitleSdkForNet/LitleSdkForNet/XmlSerializer.cs
@@ -24,12 +24,18 @@ namespace Litle.Sdk
             return Encoding.UTF8.GetString(ms.GetBuffer());//return string is UTF8 encoded.
         }// serialize the xml
 
-        virtual public litleResponse DeserializeObjectFromFile(string filePath)
+        virtual public litleResponse DeserializeObjectFromFile(Communications communications, string filePath)
         {
             litleResponse i;
             try
             {
-                i = new litleResponse(filePath);
+                var stream = communications[filePath];
+                var value = stream.ToString();
+                var bytes = Encoding.UTF8.GetBytes(value);
+                using (var memoryStream = new MemoryStream(bytes))
+                {
+                    i = new litleResponse(memoryStream);
+                }
             }
             catch (XmlException e)
             {

--- a/LitleSdkForNet/LitleSdkForNetTest/Certification/TestCert1Base.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Certification/TestCert1Base.cs
@@ -1,14 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Text;
+using Litle.Sdk.Properties;
 using NUnit.Framework;
-using Litle.Sdk;
 
 namespace Litle.Sdk.Test.Certification
 {
     [TestFixture]
-    class TestCert1Base
+    internal class TestCert1Base
     {
         private LitleOnline litle;
         private IDictionary<string, StringBuilder> _memoryCache;
@@ -17,19 +15,19 @@ namespace Litle.Sdk.Test.Certification
         public void setUp()
         {
             _memoryCache = new Dictionary<string, StringBuilder>();
-            Dictionary<string, string> config = new Dictionary<string, string>();
+            var config = new Dictionary<string, string>();
             config.Add("url", "https://www.testlitle.com/sandbox/communicator/online");
             config.Add("reportGroup", "Default Report Group");
             config.Add("username", "DOTNET");
             config.Add("version", "9.00");
-            config.Add("timeout", Properties.Settings.Default.timeout);
+            config.Add("timeout", Settings.Default.timeout);
             config.Add("merchantId", "101");
             config.Add("password", "TESTCASE");
             config.Add("printxml", "true");
             config.Add("logFile", null);
             config.Add("neuterAccountNums", null);
-            config.Add("proxyHost", Properties.Settings.Default.proxyHost);
-            config.Add("proxyPort", Properties.Settings.Default.proxyPort);
+            config.Add("proxyHost", Settings.Default.proxyHost);
+            config.Add("proxyPort", Settings.Default.proxyPort);
             litle = new LitleOnline(_memoryCache, config);
         }
 
@@ -37,12 +35,11 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void Test1Auth()
         {
-           
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "1";
             authorization.amount = 10010;
             authorization.orderSource = orderSourceType.ecommerce;
-            contact contact = new contact();
+            var contact = new contact();
             contact.name = "John Smith";
             contact.addressLine1 = "1 Main St.";
             contact.city = "Burlington";
@@ -50,35 +47,35 @@ namespace Litle.Sdk.Test.Certification
             contact.zip = "01803-3747";
             contact.country = countryTypeEnum.US;
             authorization.billToAddress = contact;
-            cardType card = new cardType();            
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4457010000000009";
             card.expDate = "0112";
             card.cardValidationNum = "349";
             authorization.card = card;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("000", response.response);
             Assert.AreEqual("Approved", response.message);
             Assert.AreEqual("11111 ", response.authCode);
             Assert.AreEqual("01", response.fraudResult.avsResult);
             Assert.AreEqual("M", response.fraudResult.cardValidationResult);
 
-            capture capture = new capture();
+            var capture = new capture();
             capture.litleTxnId = response.litleTxnId;
-            captureResponse captureResponse = litle.Capture(capture);
+            var captureResponse = litle.Capture(capture);
             Assert.AreEqual("000", captureResponse.response);
             Assert.AreEqual("Approved", captureResponse.message);
 
-            credit credit = new credit();
+            var credit = new credit();
             credit.litleTxnId = captureResponse.litleTxnId;
-            creditResponse creditResponse = litle.Credit(credit);
+            var creditResponse = litle.Credit(credit);
             Assert.AreEqual("000", creditResponse.response);
             Assert.AreEqual("Approved", creditResponse.message);
 
-            voidTxn newvoid = new voidTxn(); 
+            var newvoid = new voidTxn();
             newvoid.litleTxnId = creditResponse.litleTxnId;
-            litleOnlineResponseTransactionResponseVoidResponse voidResponse = litle.DoVoid(newvoid);
+            var voidResponse = litle.DoVoid(newvoid);
             Assert.AreEqual("000", voidResponse.response);
             Assert.AreEqual("Approved", voidResponse.message);
         }
@@ -86,11 +83,11 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void Test1AVS()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "1";
             authorization.amount = 0;
             authorization.orderSource = orderSourceType.ecommerce;
-            contact contact = new contact();
+            var contact = new contact();
             contact.name = "John Smith";
             contact.addressLine1 = "1 Main St.";
             contact.city = "Burlington";
@@ -98,14 +95,14 @@ namespace Litle.Sdk.Test.Certification
             contact.zip = "01803-3747";
             contact.country = countryTypeEnum.US;
             authorization.billToAddress = contact;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4457010000000009";
             card.expDate = "0112";
             card.cardValidationNum = "349";
             authorization.card = card;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("000", response.response);
             Assert.AreEqual("Approved", response.message);
             Assert.AreEqual("11111 ", response.authCode);
@@ -116,11 +113,11 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test1Sale()
         {
-            sale sale = new sale();
+            var sale = new sale();
             sale.orderId = "1";
             sale.amount = 10010;
             sale.orderSource = orderSourceType.ecommerce;
-            contact contact = new contact();
+            var contact = new contact();
             contact.name = "John Smith";
             contact.addressLine1 = "1 Main St.";
             contact.city = "Burlington";
@@ -128,42 +125,42 @@ namespace Litle.Sdk.Test.Certification
             contact.zip = "01803-3747";
             contact.country = countryTypeEnum.US;
             sale.billToAddress = contact;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4457010000000009";
             card.expDate = "0112";
             card.cardValidationNum = "349";
             sale.card = card;
 
-            saleResponse response = litle.Sale(sale);
+            var response = litle.Sale(sale);
             Assert.AreEqual("000", response.response);
             Assert.AreEqual("Approved", response.message);
             Assert.AreEqual("11111 ", response.authCode);
             Assert.AreEqual("01", response.fraudResult.avsResult);
             Assert.AreEqual("M", response.fraudResult.cardValidationResult);
 
-            credit credit = new credit();
+            var credit = new credit();
             credit.litleTxnId = response.litleTxnId;
-            creditResponse creditResponse = litle.Credit(credit);
+            var creditResponse = litle.Credit(credit);
             Assert.AreEqual("000", creditResponse.response);
             Assert.AreEqual("Approved", creditResponse.message);
 
 
-            voidTxn newvoid = new voidTxn();
+            var newvoid = new voidTxn();
             newvoid.litleTxnId = creditResponse.litleTxnId;
-            litleOnlineResponseTransactionResponseVoidResponse voidResponse = litle.DoVoid(newvoid);
-            Assert.AreEqual("000",voidResponse.response);
-            Assert.AreEqual("Approved",voidResponse.message);
+            var voidResponse = litle.DoVoid(newvoid);
+            Assert.AreEqual("000", voidResponse.response);
+            Assert.AreEqual("Approved", voidResponse.message);
         }
 
         [Test]
         public void test2Auth()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "2";
             authorization.amount = 20020;
             authorization.orderSource = orderSourceType.ecommerce;
-            contact contact = new contact();
+            var contact = new contact();
             contact.name = "Mike J. Hammer";
             contact.addressLine1 = "2 Main St.";
             contact.addressLine2 = "Apt. 222";
@@ -172,50 +169,50 @@ namespace Litle.Sdk.Test.Certification
             contact.zip = "02915";
             contact.country = countryTypeEnum.US;
             authorization.billToAddress = contact;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.MC;
             card.number = "5112010000000003";
             card.expDate = "0212";
             card.cardValidationNum = "261";
             authorization.card = card;
-            fraudCheckType authenticationvalue = new fraudCheckType();
+            var authenticationvalue = new fraudCheckType();
             authenticationvalue.authenticationValue = "BwABBJQ1AgAAAAAgJDUCAAAAAAA=";
             authorization.cardholderAuthentication = authenticationvalue;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("000", response.response);
             Assert.AreEqual("Approved", response.message);
             Assert.AreEqual("22222", response.authCode);
             Assert.AreEqual("10", response.fraudResult.avsResult);
             Assert.AreEqual("M", response.fraudResult.cardValidationResult);
 
-            capture capture = new capture();
+            var capture = new capture();
             capture.litleTxnId = response.litleTxnId;
-            captureResponse captureresponse = litle.Capture(capture);
+            var captureresponse = litle.Capture(capture);
             Assert.AreEqual("000", captureresponse.response);
             Assert.AreEqual("Approved", captureresponse.message);
 
-            credit credit = new credit();
+            var credit = new credit();
             credit.litleTxnId = captureresponse.litleTxnId;
-            creditResponse creditResponse = litle.Credit(credit);
+            var creditResponse = litle.Credit(credit);
             Assert.AreEqual("000", creditResponse.response);
             Assert.AreEqual("Approved", creditResponse.message);
 
-            voidTxn newvoid = new voidTxn();
+            var newvoid = new voidTxn();
             newvoid.litleTxnId = creditResponse.litleTxnId;
-            litleOnlineResponseTransactionResponseVoidResponse voidResponse = litle.DoVoid(newvoid);
-            Assert.AreEqual("000",voidResponse.response);
-            Assert.AreEqual("Approved",voidResponse.message);
+            var voidResponse = litle.DoVoid(newvoid);
+            Assert.AreEqual("000", voidResponse.response);
+            Assert.AreEqual("Approved", voidResponse.message);
         }
 
         [Test]
         public void test2AVS()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "2";
             authorization.amount = 0;
             authorization.orderSource = orderSourceType.ecommerce;
-            contact contact = new contact();
+            var contact = new contact();
             contact.name = "Mike J. Hammer";
             contact.addressLine1 = "2 Main St.";
             contact.addressLine2 = "Apt. 222";
@@ -224,33 +221,32 @@ namespace Litle.Sdk.Test.Certification
             contact.zip = "02915";
             contact.country = countryTypeEnum.US;
             authorization.billToAddress = contact;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.MC;
             card.number = "5112010000000003";
             card.expDate = "0212";
             card.cardValidationNum = "261";
             authorization.card = card;
-            fraudCheckType authenticationvalue = new fraudCheckType();
+            var authenticationvalue = new fraudCheckType();
             authenticationvalue.authenticationValue = "BwABBJQ1AgAAAAAgJDUCAAAAAAA=";
             authorization.cardholderAuthentication = authenticationvalue;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("000", response.response);
             Assert.AreEqual("Approved", response.message);
             Assert.AreEqual("22222", response.authCode);
             Assert.AreEqual("10", response.fraudResult.avsResult);
             Assert.AreEqual("M", response.fraudResult.cardValidationResult);
-
         }
 
         [Test]
         public void test2Sale()
         {
-            sale sale = new sale();
+            var sale = new sale();
             sale.orderId = "2";
             sale.amount = 20020;
             sale.orderSource = orderSourceType.ecommerce;
-            contact contact = new contact();
+            var contact = new contact();
             contact.name = "Mike J. Hammer";
             contact.addressLine1 = "2 Main St.";
             contact.addressLine2 = "Apt. 222";
@@ -259,32 +255,32 @@ namespace Litle.Sdk.Test.Certification
             contact.zip = "02915";
             contact.country = countryTypeEnum.US;
             sale.billToAddress = contact;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.MC;
             card.number = "5112010000000003";
             card.expDate = "0212";
             card.cardValidationNum = "261";
             sale.card = card;
-            fraudCheckType authenticationvalue = new fraudCheckType();
+            var authenticationvalue = new fraudCheckType();
             authenticationvalue.authenticationValue = "BwABBJQ1AgAAAAAgJDUCAAAAAAA=";
             sale.cardholderAuthentication = authenticationvalue;
 
-            saleResponse response = litle.Sale(sale);
+            var response = litle.Sale(sale);
             Assert.AreEqual("000", response.response);
             Assert.AreEqual("Approved", response.message);
             Assert.AreEqual("22222", response.authCode);
             Assert.AreEqual("10", response.fraudResult.avsResult);
             Assert.AreEqual("M", response.fraudResult.cardValidationResult);
 
-            credit credit = new credit();
+            var credit = new credit();
             credit.litleTxnId = response.litleTxnId;
-            creditResponse creditResponse = litle.Credit(credit);
+            var creditResponse = litle.Credit(credit);
             Assert.AreEqual("000", creditResponse.response);
             Assert.AreEqual("Approved", creditResponse.message);
 
-            voidTxn newvoid = new voidTxn();
+            var newvoid = new voidTxn();
             newvoid.litleTxnId = creditResponse.litleTxnId;
-            litleOnlineResponseTransactionResponseVoidResponse voidResponse = litle.DoVoid(newvoid);
+            var voidResponse = litle.DoVoid(newvoid);
             Assert.AreEqual("000", voidResponse.response);
             Assert.AreEqual("Approved", voidResponse.message);
         }
@@ -292,11 +288,11 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test3Auth()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "3";
             authorization.amount = 30030;
             authorization.orderSource = orderSourceType.ecommerce;
-            contact contact = new contact();
+            var contact = new contact();
             contact.name = "Eileen Jones";
             contact.addressLine1 = "3 Main St.";
             contact.city = "Bloomfield";
@@ -304,35 +300,35 @@ namespace Litle.Sdk.Test.Certification
             contact.zip = "06002";
             contact.country = countryTypeEnum.US;
             authorization.billToAddress = contact;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.DI;
             card.number = "6011010000000003";
             card.expDate = "0312";
             card.cardValidationNum = "758";
             authorization.card = card;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("000", response.response);
             Assert.AreEqual("Approved", response.message);
             Assert.AreEqual("33333", response.authCode);
             Assert.AreEqual("10", response.fraudResult.avsResult);
             Assert.AreEqual("M", response.fraudResult.cardValidationResult);
 
-            capture capture = new capture();
+            var capture = new capture();
             capture.litleTxnId = response.litleTxnId;
-            captureResponse captureResponse = litle.Capture(capture);
+            var captureResponse = litle.Capture(capture);
             Assert.AreEqual("000", captureResponse.response);
             Assert.AreEqual("Approved", captureResponse.message);
 
-            credit credit = new credit();
+            var credit = new credit();
             credit.litleTxnId = captureResponse.litleTxnId;
-            creditResponse creditResponse = litle.Credit(credit);
+            var creditResponse = litle.Credit(credit);
             Assert.AreEqual("000", creditResponse.response);
             Assert.AreEqual("Approved", creditResponse.message);
 
-            voidTxn newvoid = new voidTxn();
+            var newvoid = new voidTxn();
             newvoid.litleTxnId = creditResponse.litleTxnId;
-            litleOnlineResponseTransactionResponseVoidResponse voidResponse = litle.DoVoid(newvoid);
+            var voidResponse = litle.DoVoid(newvoid);
             Assert.AreEqual("000", voidResponse.response);
             Assert.AreEqual("Approved", voidResponse.message);
         }
@@ -340,11 +336,11 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test3AVS()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "3";
             authorization.amount = 0;
             authorization.orderSource = orderSourceType.ecommerce;
-            contact contact = new contact();
+            var contact = new contact();
             contact.name = "Eileen Jones";
             contact.addressLine1 = "3 Main St.";
             contact.city = "Bloomfield";
@@ -352,30 +348,29 @@ namespace Litle.Sdk.Test.Certification
             contact.zip = "06002";
             contact.country = countryTypeEnum.US;
             authorization.billToAddress = contact;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.DI;
             card.number = "6011010000000003";
             card.expDate = "0312";
             card.cardValidationNum = "758";
             authorization.card = card;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("000", response.response);
             Assert.AreEqual("Approved", response.message);
             Assert.AreEqual("33333", response.authCode);
             Assert.AreEqual("10", response.fraudResult.avsResult);
             Assert.AreEqual("M", response.fraudResult.cardValidationResult);
-
         }
 
         [Test]
         public void test3Sale()
         {
-            sale sale = new sale();
+            var sale = new sale();
             sale.orderId = "3";
             sale.amount = 30030;
             sale.orderSource = orderSourceType.ecommerce;
-            contact contact = new contact();
+            var contact = new contact();
             contact.name = "Eileen Jones";
             contact.addressLine1 = "3 Main St.";
             contact.city = "Bloomfield";
@@ -383,29 +378,29 @@ namespace Litle.Sdk.Test.Certification
             contact.zip = "06002";
             contact.country = countryTypeEnum.US;
             sale.billToAddress = contact;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.DI;
             card.number = "6011010000000003";
             card.expDate = "0312";
             card.cardValidationNum = "758";
             sale.card = card;
 
-            saleResponse response = litle.Sale(sale);
+            var response = litle.Sale(sale);
             Assert.AreEqual("000", response.response);
             Assert.AreEqual("Approved", response.message);
             Assert.AreEqual("33333", response.authCode);
             Assert.AreEqual("10", response.fraudResult.avsResult);
             Assert.AreEqual("M", response.fraudResult.cardValidationResult);
 
-            credit credit = new credit();
+            var credit = new credit();
             credit.litleTxnId = response.litleTxnId;
-            creditResponse creditResponse = litle.Credit(credit);
+            var creditResponse = litle.Credit(credit);
             Assert.AreEqual("000", creditResponse.response);
             Assert.AreEqual("Approved", creditResponse.message);
 
-            voidTxn newvoid = new voidTxn();
+            var newvoid = new voidTxn();
             newvoid.litleTxnId = creditResponse.litleTxnId;
-            litleOnlineResponseTransactionResponseVoidResponse voidResponse = litle.DoVoid(newvoid);
+            var voidResponse = litle.DoVoid(newvoid);
             Assert.AreEqual("000", voidResponse.response);
             Assert.AreEqual("Approved", voidResponse.message);
         }
@@ -413,11 +408,11 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test4Auth()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "4";
             authorization.amount = 40040;
             authorization.orderSource = orderSourceType.ecommerce;
-            contact contact = new contact();
+            var contact = new contact();
             contact.name = "Bob Black";
             contact.addressLine1 = "4 Main St.";
             contact.city = "Laurel";
@@ -425,34 +420,34 @@ namespace Litle.Sdk.Test.Certification
             contact.zip = "20708";
             contact.country = countryTypeEnum.US;
             authorization.billToAddress = contact;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.AX;
             card.number = "375001000000005";
             card.expDate = "0412";
             card.cardValidationNum = "758";
             authorization.card = card;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("000", response.response);
             Assert.AreEqual("Approved", response.message);
             Assert.AreEqual("44444", response.authCode);
             Assert.AreEqual("12", response.fraudResult.avsResult);
 
-            capture capture = new capture();
+            var capture = new capture();
             capture.litleTxnId = response.litleTxnId;
-            captureResponse captureresponse = litle.Capture(capture);
+            var captureresponse = litle.Capture(capture);
             Assert.AreEqual("000", captureresponse.response);
             Assert.AreEqual("Approved", captureresponse.message);
 
-            credit credit = new credit();
+            var credit = new credit();
             credit.litleTxnId = captureresponse.litleTxnId;
-            creditResponse creditResponse = litle.Credit(credit);
+            var creditResponse = litle.Credit(credit);
             Assert.AreEqual("000", creditResponse.response);
             Assert.AreEqual("Approved", creditResponse.message);
 
-            voidTxn newvoid = new voidTxn();
+            var newvoid = new voidTxn();
             newvoid.litleTxnId = creditResponse.litleTxnId;
-            litleOnlineResponseTransactionResponseVoidResponse voidResponse = litle.DoVoid(newvoid);
+            var voidResponse = litle.DoVoid(newvoid);
             Assert.AreEqual("000", voidResponse.response);
             Assert.AreEqual("Approved", voidResponse.message);
         }
@@ -460,11 +455,11 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test4AVS()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "4";
             authorization.amount = 0;
             authorization.orderSource = orderSourceType.ecommerce;
-            contact contact = new contact();
+            var contact = new contact();
             contact.name = "Bob Black";
             contact.addressLine1 = "4 Main St.";
             contact.city = "Laurel";
@@ -472,14 +467,14 @@ namespace Litle.Sdk.Test.Certification
             contact.zip = "20708";
             contact.country = countryTypeEnum.US;
             authorization.billToAddress = contact;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.AX;
             card.number = "375001000000005";
             card.expDate = "0412";
             card.cardValidationNum = "758";
             authorization.card = card;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("000", response.response);
             Assert.AreEqual("Approved", response.message);
             Assert.AreEqual("44444", response.authCode);
@@ -489,11 +484,11 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test4Sale()
         {
-            sale sale = new sale();
+            var sale = new sale();
             sale.orderId = "4";
             sale.amount = 40040;
             sale.orderSource = orderSourceType.ecommerce;
-            contact contact = new contact();
+            var contact = new contact();
             contact.name = "Bob Black";
             contact.addressLine1 = "4 Main St.";
             contact.city = "Laurel";
@@ -501,28 +496,28 @@ namespace Litle.Sdk.Test.Certification
             contact.zip = "20708";
             contact.country = countryTypeEnum.US;
             sale.billToAddress = contact;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.AX;
             card.number = "375001000000005";
             card.expDate = "0412";
             card.cardValidationNum = "758";
             sale.card = card;
 
-            saleResponse response = litle.Sale(sale);
+            var response = litle.Sale(sale);
             Assert.AreEqual("000", response.response);
             Assert.AreEqual("Approved", response.message);
             Assert.AreEqual("44444", response.authCode);
             Assert.AreEqual("12", response.fraudResult.avsResult);
 
-            credit credit = new credit();
+            var credit = new credit();
             credit.litleTxnId = response.litleTxnId;
-            creditResponse creditResponse = litle.Credit(credit);
+            var creditResponse = litle.Credit(credit);
             Assert.AreEqual("000", creditResponse.response);
             Assert.AreEqual("Approved", creditResponse.message);
 
-            voidTxn newvoid = new voidTxn();
+            var newvoid = new voidTxn();
             newvoid.litleTxnId = creditResponse.litleTxnId;
-            litleOnlineResponseTransactionResponseVoidResponse voidResponse = litle.DoVoid(newvoid);
+            var voidResponse = litle.DoVoid(newvoid);
             Assert.AreEqual("000", voidResponse.response);
             Assert.AreEqual("Approved", voidResponse.message);
         }
@@ -530,42 +525,42 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test5Auth()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "5";
             authorization.amount = 50050;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4457010200000007";
             card.expDate = "0512";
             card.cardValidationNum = "463";
             authorization.card = card;
-            fraudCheckType authenticationvalue = new fraudCheckType();
+            var authenticationvalue = new fraudCheckType();
             authenticationvalue.authenticationValue = "BwABBJQ1AgAAAAAgJDUCAAAAAAA=";
             authorization.cardholderAuthentication = authenticationvalue;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("000", response.response);
             Assert.AreEqual("Approved", response.message);
             Assert.AreEqual("55555 ", response.authCode);
             Assert.AreEqual("32", response.fraudResult.avsResult);
             Assert.AreEqual("N", response.fraudResult.cardValidationResult);
 
-            capture capture = new capture();
+            var capture = new capture();
             capture.litleTxnId = response.litleTxnId;
-            captureResponse captureresponse = litle.Capture(capture);
+            var captureresponse = litle.Capture(capture);
             Assert.AreEqual("000", captureresponse.response);
             Assert.AreEqual("Approved", captureresponse.message);
 
-            credit credit = new credit();
+            var credit = new credit();
             credit.litleTxnId = captureresponse.litleTxnId;
-            creditResponse creditResponse = litle.Credit(credit);
+            var creditResponse = litle.Credit(credit);
             Assert.AreEqual("000", creditResponse.response);
             Assert.AreEqual("Approved", creditResponse.message);
 
-            voidTxn newvoid = new voidTxn();
+            var newvoid = new voidTxn();
             newvoid.litleTxnId = creditResponse.litleTxnId;
-            litleOnlineResponseTransactionResponseVoidResponse voidResponse = litle.DoVoid(newvoid);
+            var voidResponse = litle.DoVoid(newvoid);
             Assert.AreEqual("000", voidResponse.response);
             Assert.AreEqual("Approved", voidResponse.message);
         }
@@ -573,21 +568,21 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test5AVS()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "5";
             authorization.amount = 0;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4457010200000007";
             card.expDate = "0512";
             card.cardValidationNum = "463";
             authorization.card = card;
-            fraudCheckType authenticationvalue = new fraudCheckType();
+            var authenticationvalue = new fraudCheckType();
             authenticationvalue.authenticationValue = "BwABBJQ1AgAAAAAgJDUCAAAAAAA=";
             authorization.cardholderAuthentication = authenticationvalue;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("000", response.response);
             Assert.AreEqual("Approved", response.message);
             Assert.AreEqual("55555 ", response.authCode);
@@ -598,36 +593,36 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test5Sale()
         {
-            sale sale = new sale();
+            var sale = new sale();
             sale.orderId = "5";
             sale.amount = 50050;
             sale.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4457010200000007";
             card.expDate = "0512";
             card.cardValidationNum = "463";
             sale.card = card;
-            fraudCheckType authenticationvalue = new fraudCheckType();
+            var authenticationvalue = new fraudCheckType();
             authenticationvalue.authenticationValue = "BwABBJQ1AgAAAAAgJDUCAAAAAAA=";
             sale.cardholderAuthentication = authenticationvalue;
 
-            saleResponse response = litle.Sale(sale);
+            var response = litle.Sale(sale);
             Assert.AreEqual("000", response.response);
             Assert.AreEqual("Approved", response.message);
             Assert.AreEqual("55555 ", response.authCode);
             Assert.AreEqual("32", response.fraudResult.avsResult);
             Assert.AreEqual("N", response.fraudResult.cardValidationResult);
 
-            credit credit = new credit();
+            var credit = new credit();
             credit.litleTxnId = response.litleTxnId;
-            creditResponse creditResponse = litle.Credit(credit);
+            var creditResponse = litle.Credit(credit);
             Assert.AreEqual("000", creditResponse.response);
             Assert.AreEqual("Approved", creditResponse.message);
 
-            voidTxn newvoid = new voidTxn();
+            var newvoid = new voidTxn();
             newvoid.litleTxnId = creditResponse.litleTxnId;
-            litleOnlineResponseTransactionResponseVoidResponse voidResponse = litle.DoVoid(newvoid);
+            var voidResponse = litle.DoVoid(newvoid);
             Assert.AreEqual("000", voidResponse.response);
             Assert.AreEqual("Approved", voidResponse.message);
         }
@@ -635,11 +630,11 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test6Auth()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "6";
             authorization.amount = 60060;
             authorization.orderSource = orderSourceType.ecommerce;
-            contact contact = new contact();
+            var contact = new contact();
             contact.name = "Joe Green";
             contact.addressLine1 = "6 Main St.";
             contact.city = "Derry";
@@ -647,14 +642,14 @@ namespace Litle.Sdk.Test.Certification
             contact.zip = "03038";
             contact.country = countryTypeEnum.US;
             authorization.billToAddress = contact;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4457010100000008";
             card.expDate = "0612";
             card.cardValidationNum = "992";
             authorization.card = card;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("110", response.response);
             Assert.AreEqual("Insufficient Funds", response.message);
             Assert.AreEqual("34", response.fraudResult.avsResult);
@@ -664,11 +659,11 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test6Sale()
         {
-            sale sale = new sale();
+            var sale = new sale();
             sale.orderId = "6";
             sale.amount = 60060;
             sale.orderSource = orderSourceType.ecommerce;
-            contact contact = new contact();
+            var contact = new contact();
             contact.name = "Joe Green";
             contact.addressLine1 = "6 Main St.";
             contact.city = "Derry";
@@ -676,22 +671,22 @@ namespace Litle.Sdk.Test.Certification
             contact.zip = "03038";
             contact.country = countryTypeEnum.US;
             sale.billToAddress = contact;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4457010100000008";
             card.expDate = "0612";
             card.cardValidationNum = "992";
             sale.card = card;
 
-            saleResponse response = litle.Sale(sale);
+            var response = litle.Sale(sale);
             Assert.AreEqual("110", response.response);
             Assert.AreEqual("Insufficient Funds", response.message);
             Assert.AreEqual("34", response.fraudResult.avsResult);
             Assert.AreEqual("P", response.fraudResult.cardValidationResult);
 
-            voidTxn newvoid = new voidTxn();
+            var newvoid = new voidTxn();
             newvoid.litleTxnId = response.litleTxnId;
-            litleOnlineResponseTransactionResponseVoidResponse voidResponse = litle.DoVoid(newvoid);
+            var voidResponse = litle.DoVoid(newvoid);
             Assert.AreEqual("360", voidResponse.response);
             Assert.AreEqual("No transaction found with specified litleTxnId", voidResponse.message);
         }
@@ -699,11 +694,11 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test7Auth()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "7";
             authorization.amount = 70070;
             authorization.orderSource = orderSourceType.ecommerce;
-            contact contact = new contact();
+            var contact = new contact();
             contact.name = "Jane Murray";
             contact.addressLine1 = "7 Main St.";
             contact.city = "Amesbury";
@@ -711,14 +706,14 @@ namespace Litle.Sdk.Test.Certification
             contact.zip = "01913";
             contact.country = countryTypeEnum.US;
             authorization.billToAddress = contact;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.MC;
             card.number = "5112010100000002";
             card.expDate = "0712";
             card.cardValidationNum = "251";
             authorization.card = card;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("301", response.response);
             Assert.AreEqual("Invalid Account Number", response.message);
             Assert.AreEqual("34", response.fraudResult.avsResult);
@@ -728,11 +723,11 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test7AVS()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "7";
             authorization.amount = 0;
             authorization.orderSource = orderSourceType.ecommerce;
-            contact contact = new contact();
+            var contact = new contact();
             contact.name = "Jane Murray";
             contact.addressLine1 = "7 Main St.";
             contact.city = "Amesbury";
@@ -740,14 +735,14 @@ namespace Litle.Sdk.Test.Certification
             contact.zip = "01913";
             contact.country = countryTypeEnum.US;
             authorization.billToAddress = contact;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.MC;
             card.number = "5112010100000002";
             card.expDate = "0712";
             card.cardValidationNum = "251";
             authorization.card = card;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("301", response.response);
             Assert.AreEqual("Invalid Account Number", response.message);
             Assert.AreEqual("34", response.fraudResult.avsResult);
@@ -757,11 +752,11 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test7Sale()
         {
-            sale sale = new sale();
+            var sale = new sale();
             sale.orderId = "7";
             sale.amount = 70070;
             sale.orderSource = orderSourceType.ecommerce;
-            contact contact = new contact();
+            var contact = new contact();
             contact.name = "Jane Murray";
             contact.addressLine1 = "7 Main St.";
             contact.city = "Amesbury";
@@ -769,14 +764,14 @@ namespace Litle.Sdk.Test.Certification
             contact.zip = "01913";
             contact.country = countryTypeEnum.US;
             sale.billToAddress = contact;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.MC;
             card.number = "5112010100000002";
             card.expDate = "0712";
             card.cardValidationNum = "251";
             sale.card = card;
 
-            saleResponse response = litle.Sale(sale);
+            var response = litle.Sale(sale);
             Assert.AreEqual("301", response.response);
             Assert.AreEqual("Invalid Account Number", response.message);
             Assert.AreEqual("34", response.fraudResult.avsResult);
@@ -786,11 +781,11 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test8Auth()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "8";
             authorization.amount = 80080;
             authorization.orderSource = orderSourceType.ecommerce;
-            contact contact = new contact();
+            var contact = new contact();
             contact.name = "Mark Johnson";
             contact.addressLine1 = "8 Main St.";
             contact.city = "Manchester";
@@ -798,14 +793,14 @@ namespace Litle.Sdk.Test.Certification
             contact.zip = "03101";
             contact.country = countryTypeEnum.US;
             authorization.billToAddress = contact;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.DI;
             card.number = "6011010100000002";
             card.expDate = "0812";
             card.cardValidationNum = "184";
             authorization.card = card;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("123", response.response);
             Assert.AreEqual("Call Discover", response.message);
             Assert.AreEqual("34", response.fraudResult.avsResult);
@@ -815,11 +810,11 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test8AVS()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "8";
             authorization.amount = 0;
             authorization.orderSource = orderSourceType.ecommerce;
-            contact contact = new contact();
+            var contact = new contact();
             contact.name = "Mark Johnson";
             contact.addressLine1 = "8 Main St.";
             contact.city = "Manchester";
@@ -827,14 +822,14 @@ namespace Litle.Sdk.Test.Certification
             contact.zip = "03101";
             contact.country = countryTypeEnum.US;
             authorization.billToAddress = contact;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.DI;
             card.number = "6011010100000002";
             card.expDate = "0812";
             card.cardValidationNum = "184";
             authorization.card = card;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("123", response.response);
             Assert.AreEqual("Call Discover", response.message);
             Assert.AreEqual("34", response.fraudResult.avsResult);
@@ -844,11 +839,11 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test8Sale()
         {
-            sale sale = new sale();
+            var sale = new sale();
             sale.orderId = "8";
             sale.amount = 80080;
             sale.orderSource = orderSourceType.ecommerce;
-            contact contact = new contact();
+            var contact = new contact();
             contact.name = "Mark Johnson";
             contact.addressLine1 = "8 Main St.";
             contact.city = "Manchester";
@@ -856,14 +851,14 @@ namespace Litle.Sdk.Test.Certification
             contact.zip = "03101";
             contact.country = countryTypeEnum.US;
             sale.billToAddress = contact;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.DI;
             card.number = "6011010100000002";
             card.expDate = "0812";
             card.cardValidationNum = "184";
             sale.card = card;
 
-            saleResponse response = litle.Sale(sale);
+            var response = litle.Sale(sale);
             Assert.AreEqual("123", response.response);
             Assert.AreEqual("Call Discover", response.message);
             Assert.AreEqual("34", response.fraudResult.avsResult);
@@ -873,11 +868,11 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test9Auth()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "9";
             authorization.amount = 90090;
             authorization.orderSource = orderSourceType.ecommerce;
-            contact contact = new contact();
+            var contact = new contact();
             contact.name = "James Miller";
             contact.addressLine1 = "9 Main St.";
             contact.city = "Boston";
@@ -885,14 +880,14 @@ namespace Litle.Sdk.Test.Certification
             contact.zip = "02134";
             contact.country = countryTypeEnum.US;
             authorization.billToAddress = contact;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.AX;
             card.number = "375001010000003";
             card.expDate = "0912";
             card.cardValidationNum = "0421";
             authorization.card = card;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("303", response.response);
             Assert.AreEqual("Pick Up Card", response.message);
             Assert.AreEqual("34", response.fraudResult.avsResult);
@@ -901,11 +896,11 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test9AVS()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "9";
             authorization.amount = 0;
             authorization.orderSource = orderSourceType.ecommerce;
-            contact contact = new contact();
+            var contact = new contact();
             contact.name = "James Miller";
             contact.addressLine1 = "9 Main St.";
             contact.city = "Boston";
@@ -913,14 +908,14 @@ namespace Litle.Sdk.Test.Certification
             contact.zip = "02134";
             contact.country = countryTypeEnum.US;
             authorization.billToAddress = contact;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.AX;
             card.number = "375001010000003";
             card.expDate = "0912";
             card.cardValidationNum = "0421";
             authorization.card = card;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("303", response.response);
             Assert.AreEqual("Pick Up Card", response.message);
             Assert.AreEqual("34", response.fraudResult.avsResult);
@@ -929,11 +924,11 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test9Sale()
         {
-            sale sale = new sale();
+            var sale = new sale();
             sale.orderId = "9";
             sale.amount = 90090;
             sale.orderSource = orderSourceType.ecommerce;
-            contact contact = new contact();
+            var contact = new contact();
             contact.name = "James Miller";
             contact.addressLine1 = "9 Main St.";
             contact.city = "Boston";
@@ -941,14 +936,14 @@ namespace Litle.Sdk.Test.Certification
             contact.zip = "02134";
             contact.country = countryTypeEnum.US;
             sale.billToAddress = contact;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.AX;
             card.number = "375001010000003";
             card.expDate = "0912";
             card.cardValidationNum = "0421";
             sale.card = card;
 
-            saleResponse response = litle.Sale(sale);
+            var response = litle.Sale(sale);
             Assert.AreEqual("303", response.response);
             Assert.AreEqual("Pick Up Card", response.message);
             Assert.AreEqual("34", response.fraudResult.avsResult);
@@ -957,18 +952,18 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test10()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "10";
             authorization.amount = 40000;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4457010140000141";
             card.expDate = "0912";
             authorization.card = card;
             authorization.allowPartialAuth = true;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("010", response.response);
             Assert.AreEqual("Partially Approved", response.message);
             Assert.AreEqual("32000", response.approvedAmount);
@@ -977,18 +972,18 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test11()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "11";
             authorization.amount = 60000;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.MC;
             card.number = "5112010140000004";
             card.expDate = "1111";
             authorization.card = card;
             authorization.allowPartialAuth = true;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("010", response.response);
             Assert.AreEqual("Partially Approved", response.message);
             Assert.AreEqual("48000", response.approvedAmount);
@@ -997,18 +992,18 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test12()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "12";
             authorization.amount = 50000;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.AX;
             card.number = "375001014000009";
             card.expDate = "0412";
             authorization.card = card;
             authorization.allowPartialAuth = true;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("010", response.response);
             Assert.AreEqual("Partially Approved", response.message);
             Assert.AreEqual("40000", response.approvedAmount);
@@ -1017,23 +1012,21 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test13()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "13";
             authorization.amount = 15000;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.DI;
             card.number = "6011010140000004";
             card.expDate = "0812";
             authorization.card = card;
             authorization.allowPartialAuth = true;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("010", response.response);
             Assert.AreEqual("Partially Approved", response.message);
             Assert.AreEqual("12000", response.approvedAmount);
-
         }
-            
     }
 }

--- a/LitleSdkForNet/LitleSdkForNetTest/Certification/TestCert1Base.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Certification/TestCert1Base.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -10,10 +11,12 @@ namespace Litle.Sdk.Test.Certification
     class TestCert1Base
     {
         private LitleOnline litle;
+        private IDictionary<string, StringBuilder> _memoryCache;
 
         [TestFixtureSetUp]
         public void setUp()
         {
+            _memoryCache = new Dictionary<string, StringBuilder>();
             Dictionary<string, string> config = new Dictionary<string, string>();
             config.Add("url", "https://www.testlitle.com/sandbox/communicator/online");
             config.Add("reportGroup", "Default Report Group");
@@ -27,7 +30,7 @@ namespace Litle.Sdk.Test.Certification
             config.Add("neuterAccountNums", null);
             config.Add("proxyHost", Properties.Settings.Default.proxyHost);
             config.Add("proxyPort", Properties.Settings.Default.proxyPort);
-            litle = new LitleOnline(config);
+            litle = new LitleOnline(_memoryCache, config);
         }
 
 

--- a/LitleSdkForNet/LitleSdkForNetTest/Certification/TestCert2AuthEnhanced.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Certification/TestCert2AuthEnhanced.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -11,10 +12,12 @@ namespace Litle.Sdk.Test.Certification
     {
 
         private LitleOnline litle;
+        private IDictionary<string, StringBuilder> _memoryCache;
 
         [TestFixtureSetUp]
         public void setUp()
         {
+            _memoryCache = new Dictionary<string, StringBuilder>();
             Dictionary<string, string> config = new Dictionary<string, string>();
             config.Add("url", "https://www.testlitle.com/sandbox/communicator/online");
             config.Add("reportGroup", "Default Report Group");
@@ -28,7 +31,7 @@ namespace Litle.Sdk.Test.Certification
             config.Add("neuterAccountNums", null);
             config.Add("proxyHost", Properties.Settings.Default.proxyHost);
             config.Add("proxyPort", Properties.Settings.Default.proxyPort);
-            litle = new LitleOnline(config);
+            litle = new LitleOnline(_memoryCache, config);
         }
 
         [Test]

--- a/LitleSdkForNet/LitleSdkForNetTest/Certification/TestCert2AuthEnhanced.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Certification/TestCert2AuthEnhanced.cs
@@ -1,16 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Text;
+using Litle.Sdk.Properties;
 using NUnit.Framework;
-using Litle.Sdk;
 
 namespace Litle.Sdk.Test.Certification
 {
     [TestFixture]
-    class TestCert2AuthEnhanced
+    internal class TestCert2AuthEnhanced
     {
-
         private LitleOnline litle;
         private IDictionary<string, StringBuilder> _memoryCache;
 
@@ -18,7 +15,7 @@ namespace Litle.Sdk.Test.Certification
         public void setUp()
         {
             _memoryCache = new Dictionary<string, StringBuilder>();
-            Dictionary<string, string> config = new Dictionary<string, string>();
+            var config = new Dictionary<string, string>();
             config.Add("url", "https://www.testlitle.com/sandbox/communicator/online");
             config.Add("reportGroup", "Default Report Group");
             config.Add("username", "DOTNET");
@@ -29,25 +26,25 @@ namespace Litle.Sdk.Test.Certification
             config.Add("printxml", "true");
             config.Add("logFile", null);
             config.Add("neuterAccountNums", null);
-            config.Add("proxyHost", Properties.Settings.Default.proxyHost);
-            config.Add("proxyPort", Properties.Settings.Default.proxyPort);
+            config.Add("proxyHost", Settings.Default.proxyHost);
+            config.Add("proxyPort", Settings.Default.proxyPort);
             litle = new LitleOnline(_memoryCache, config);
         }
 
         [Test]
         public void test14()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "14";
             authorization.amount = 3000;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4457010200000247";
             card.expDate = "0812";
             authorization.card = card;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("000", response.response);
             Assert.AreEqual("Approved", response.message);
             Assert.AreEqual(fundingSourceTypeEnum.PREPAID, response.enhancedAuthResponse.fundingSource.type);
@@ -59,17 +56,17 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test15()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "15";
             authorization.amount = 3000;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.MC;
             card.number = "5500000254444445";
             card.expDate = "0312";
             authorization.card = card;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("000", response.response);
             Assert.AreEqual("Approved", response.message);
             Assert.AreEqual(fundingSourceTypeEnum.PREPAID, response.enhancedAuthResponse.fundingSource.type);
@@ -81,17 +78,17 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test16()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "16";
             authorization.amount = 3000;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.MC;
             card.number = "5592106621450897";
             card.expDate = "0312";
             authorization.card = card;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("000", response.response);
             Assert.AreEqual("Approved", response.message);
             Assert.AreEqual(fundingSourceTypeEnum.PREPAID, response.enhancedAuthResponse.fundingSource.type);
@@ -103,17 +100,17 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test17()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "17";
             authorization.amount = 3000;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.MC;
             card.number = "5590409551104142";
             card.expDate = "0312";
             authorization.card = card;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("000", response.response);
             Assert.AreEqual("Approved", response.message);
             Assert.AreEqual(fundingSourceTypeEnum.PREPAID, response.enhancedAuthResponse.fundingSource.type);
@@ -125,17 +122,17 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test18()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "18";
             authorization.amount = 3000;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.MC;
             card.number = "5587755665222179";
             card.expDate = "0312";
             authorization.card = card;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("000", response.response);
             Assert.AreEqual("Approved", response.message);
             Assert.AreEqual(fundingSourceTypeEnum.PREPAID, response.enhancedAuthResponse.fundingSource.type);
@@ -147,17 +144,17 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test19()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "19";
             authorization.amount = 3000;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.MC;
             card.number = "5445840176552850";
             card.expDate = "0312";
             authorization.card = card;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("000", response.response);
             Assert.AreEqual("Approved", response.message);
             Assert.AreEqual(fundingSourceTypeEnum.PREPAID, response.enhancedAuthResponse.fundingSource.type);
@@ -169,17 +166,17 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test20()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "20";
             authorization.amount = 3000;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.MC;
             card.number = "5390016478904678";
             card.expDate = "0312";
             authorization.card = card;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("000", response.response);
             Assert.AreEqual("Approved", response.message);
             Assert.AreEqual(fundingSourceTypeEnum.PREPAID, response.enhancedAuthResponse.fundingSource.type);
@@ -191,17 +188,17 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test21()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "21";
             authorization.amount = 5000;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4457010201000246";
             card.expDate = "0912";
             authorization.card = card;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("000", response.response);
             Assert.AreEqual("Approved", response.message);
             Assert.AreEqual(affluenceTypeEnum.AFFLUENT, response.enhancedAuthResponse.affluence);
@@ -210,17 +207,17 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test22()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "22";
             authorization.amount = 5000;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4457010202000245";
             card.expDate = "1111";
             authorization.card = card;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("000", response.response);
             Assert.AreEqual("Approved", response.message);
             Assert.AreEqual(affluenceTypeEnum.MASSAFFLUENT, response.enhancedAuthResponse.affluence);
@@ -229,84 +226,81 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test23()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "23";
             authorization.amount = 5000;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.MC;
             card.number = "5112010201000109";
             card.expDate = "0412";
             authorization.card = card;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("000", response.response);
             Assert.AreEqual("Approved", response.message);
             Assert.AreEqual(affluenceTypeEnum.AFFLUENT, response.enhancedAuthResponse.affluence);
-
         }
 
         [Test]
         public void test24()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "24";
             authorization.amount = 5000;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.MC;
             card.number = "5112010202000108";
             card.expDate = "0812";
             authorization.card = card;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("000", response.response);
             Assert.AreEqual("Approved", response.message);
             Assert.AreEqual(affluenceTypeEnum.MASSAFFLUENT, response.enhancedAuthResponse.affluence);
-
         }
 
         [Test]
         public void test25()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "25";
             authorization.amount = 5000;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100204446270000";
             card.expDate = "1112";
             authorization.card = card;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("000", response.response);
             Assert.AreEqual("Approved", response.message);
             Assert.AreEqual("BRA", response.enhancedAuthResponse.issuerCountry);
-
         }
 
         [Test]
         public void test26()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "26";
             authorization.amount = 18698;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.MC;
             card.number = "5194560012341234";
             card.expDate = "1212";
             authorization.card = card;
             authorization.allowPartialAuth = true;
-            healthcareIIAS healthcareiias = new healthcareIIAS();
-            healthcareAmounts healthcareamounts = new healthcareAmounts();
+            var healthcareiias = new healthcareIIAS();
+            var healthcareamounts = new healthcareAmounts();
             healthcareamounts.totalHealthcareAmount = 20000;
             healthcareiias.healthcareAmounts = healthcareamounts;
             healthcareiias.IIASFlag = IIASFlagType.Y;
             authorization.healthcareIIAS = healthcareiias;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("341", response.response);
             Assert.AreEqual("Invalid healthcare amounts", response.message);
         }
@@ -314,25 +308,25 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test27()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "27";
             authorization.amount = 18698;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.MC;
             card.number = "5194560012341234";
             card.expDate = "1212";
             authorization.card = card;
             authorization.allowPartialAuth = true;
-            healthcareIIAS healthcareiias = new healthcareIIAS();
-            healthcareAmounts healthcareamounts = new healthcareAmounts();
+            var healthcareiias = new healthcareIIAS();
+            var healthcareamounts = new healthcareAmounts();
             healthcareamounts.totalHealthcareAmount = 15000;
             healthcareamounts.RxAmount = 16000;
             healthcareiias.healthcareAmounts = healthcareamounts;
             healthcareiias.IIASFlag = IIASFlagType.Y;
             authorization.healthcareIIAS = healthcareiias;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("341", response.response);
             Assert.AreEqual("Invalid healthcare amounts", response.message);
         }
@@ -340,25 +334,25 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test28()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "28";
             authorization.amount = 15000;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.MC;
             card.number = "5194560012341234";
             card.expDate = "1212";
             authorization.card = card;
             authorization.allowPartialAuth = true;
-            healthcareIIAS healthcareiias = new healthcareIIAS();
-            healthcareAmounts healthcareamounts = new healthcareAmounts();
+            var healthcareiias = new healthcareIIAS();
+            var healthcareamounts = new healthcareAmounts();
             healthcareamounts.totalHealthcareAmount = 15000;
             healthcareamounts.RxAmount = 3698;
             healthcareiias.healthcareAmounts = healthcareamounts;
             healthcareiias.IIASFlag = IIASFlagType.Y;
             authorization.healthcareIIAS = healthcareiias;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("000", response.response);
             Assert.AreEqual("Approved", response.message);
         }
@@ -366,18 +360,18 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test29()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "29";
             authorization.amount = 18699;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4024720001231239";
             card.expDate = "1212";
             authorization.card = card;
             authorization.allowPartialAuth = true;
-            healthcareIIAS healthcareiias = new healthcareIIAS();
-            healthcareAmounts healthcareamounts = new healthcareAmounts();
+            var healthcareiias = new healthcareIIAS();
+            var healthcareamounts = new healthcareAmounts();
             healthcareamounts.totalHealthcareAmount = 31000;
             healthcareamounts.RxAmount = 1000;
             healthcareamounts.visionAmount = 19901;
@@ -387,7 +381,7 @@ namespace Litle.Sdk.Test.Certification
             healthcareiias.IIASFlag = IIASFlagType.Y;
             authorization.healthcareIIAS = healthcareiias;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("341", response.response);
             Assert.AreEqual("Invalid healthcare amounts", response.message);
         }
@@ -395,18 +389,18 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test30()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "30";
             authorization.amount = 20000;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4024720001231239";
             card.expDate = "1212";
             authorization.card = card;
             authorization.allowPartialAuth = true;
-            healthcareIIAS healthcareiias = new healthcareIIAS();
-            healthcareAmounts healthcareamounts = new healthcareAmounts();
+            var healthcareiias = new healthcareIIAS();
+            var healthcareamounts = new healthcareAmounts();
             healthcareamounts.totalHealthcareAmount = 20000;
             healthcareamounts.RxAmount = 1000;
             healthcareamounts.visionAmount = 19901;
@@ -416,7 +410,7 @@ namespace Litle.Sdk.Test.Certification
             healthcareiias.IIASFlag = IIASFlagType.Y;
             authorization.healthcareIIAS = healthcareiias;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("341", response.response);
             Assert.AreEqual("Invalid healthcare amounts", response.message);
         }
@@ -424,18 +418,18 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test31()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "31";
             authorization.amount = 25000;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4024720001231239";
             card.expDate = "1212";
             authorization.card = card;
             authorization.allowPartialAuth = true;
-            healthcareIIAS healthcareiias = new healthcareIIAS();
-            healthcareAmounts healthcareamounts = new healthcareAmounts();
+            var healthcareiias = new healthcareIIAS();
+            var healthcareamounts = new healthcareAmounts();
             healthcareamounts.totalHealthcareAmount = 18699;
             healthcareamounts.RxAmount = 1000;
             healthcareamounts.visionAmount = 15099;
@@ -443,11 +437,10 @@ namespace Litle.Sdk.Test.Certification
             healthcareiias.IIASFlag = IIASFlagType.Y;
             authorization.healthcareIIAS = healthcareiias;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("010", response.response);
             Assert.AreEqual("Partially Approved", response.message);
             Assert.AreEqual("18699", response.approvedAmount);
         }
-            
     }
 }

--- a/LitleSdkForNet/LitleSdkForNetTest/Certification/TestCert3AuthReversal.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Certification/TestCert3AuthReversal.cs
@@ -1,14 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Text;
+using Litle.Sdk.Properties;
 using NUnit.Framework;
-using Litle.Sdk;
 
 namespace Litle.Sdk.Test.Certification
 {
     [TestFixture]
-    class TestCert3AuthReversal
+    internal class TestCert3AuthReversal
     {
         private LitleOnline litle;
         private IDictionary<string, StringBuilder> _memoryCache;
@@ -17,7 +15,7 @@ namespace Litle.Sdk.Test.Certification
         public void setUp()
         {
             _memoryCache = new Dictionary<string, StringBuilder>();
-            Dictionary<string, string> config = new Dictionary<string, string>();
+            var config = new Dictionary<string, string>();
             config.Add("url", "https://www.testlitle.com/sandbox/communicator/online");
             config.Add("reportGroup", "Default Report Group");
             config.Add("username", "DOTNET");
@@ -28,19 +26,19 @@ namespace Litle.Sdk.Test.Certification
             config.Add("printxml", "true");
             config.Add("logFile", null);
             config.Add("neuterAccountNums", null);
-            config.Add("proxyHost", Properties.Settings.Default.proxyHost);
-            config.Add("proxyPort", Properties.Settings.Default.proxyPort);
+            config.Add("proxyHost", Settings.Default.proxyHost);
+            config.Add("proxyPort", Settings.Default.proxyPort);
             litle = new LitleOnline(_memoryCache, config);
         }
 
         [Test]
         public void test32()
         {
-            authorization auth = new authorization();
+            var auth = new authorization();
             auth.orderId = "32";
             auth.amount = 10010;
             auth.orderSource = orderSourceType.ecommerce;
-            contact billToAddress = new contact();
+            var billToAddress = new contact();
             billToAddress.name = "John Smith";
             billToAddress.addressLine1 = "1 Main St.";
             billToAddress.city = "Burlington";
@@ -48,30 +46,30 @@ namespace Litle.Sdk.Test.Certification
             billToAddress.zip = "01803-3747";
             billToAddress.country = countryTypeEnum.US;
             auth.billToAddress = billToAddress;
-            cardType card = new cardType();
+            var card = new cardType();
             card.number = "4457010000000009";
             card.expDate = "0112";
             card.cardValidationNum = "349";
             card.type = methodOfPaymentTypeEnum.VI;
             auth.card = card;
 
-            authorizationResponse authorizeResponse = litle.Authorize(auth);
+            var authorizeResponse = litle.Authorize(auth);
             Assert.AreEqual("000", authorizeResponse.response);
             Assert.AreEqual("Approved", authorizeResponse.message);
             Assert.AreEqual("11111 ", authorizeResponse.authCode);
             Assert.AreEqual("01", authorizeResponse.fraudResult.avsResult);
             Assert.AreEqual("M", authorizeResponse.fraudResult.cardValidationResult);
 
-            capture capture = new capture();
+            var capture = new capture();
             capture.litleTxnId = authorizeResponse.litleTxnId;
             capture.amount = 5005;
-            captureResponse captureResponse = litle.Capture(capture);
+            var captureResponse = litle.Capture(capture);
             Assert.AreEqual("000", captureResponse.response);
             Assert.AreEqual("Approved", captureResponse.message);
 
-            authReversal reversal = new authReversal();
+            var reversal = new authReversal();
             reversal.litleTxnId = authorizeResponse.litleTxnId;
-            authReversalResponse reversalResponse = litle.AuthReversal(reversal);
+            var reversalResponse = litle.AuthReversal(reversal);
             Assert.AreEqual("111", reversalResponse.response);
             Assert.AreEqual("Authorization amount has already been depleted", reversalResponse.message);
         }
@@ -79,11 +77,11 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test33()
         {
-            authorization auth = new authorization();
+            var auth = new authorization();
             auth.orderId = "33";
             auth.amount = 20020;
             auth.orderSource = orderSourceType.ecommerce;
-            contact billToAddress = new contact();
+            var billToAddress = new contact();
             billToAddress.name = "Mike J. Hammer";
             billToAddress.addressLine1 = "2 Main St.";
             billToAddress.addressLine2 = "Apt. 222";
@@ -92,26 +90,26 @@ namespace Litle.Sdk.Test.Certification
             billToAddress.zip = "02915";
             billToAddress.country = countryTypeEnum.US;
             auth.billToAddress = billToAddress;
-            cardType card = new cardType();
+            var card = new cardType();
             card.number = "5112010000000003";
             card.expDate = "0212";
             card.cardValidationNum = "261";
             card.type = methodOfPaymentTypeEnum.MC;
             auth.card = card;
-            fraudCheckType fraud = new fraudCheckType();
+            var fraud = new fraudCheckType();
             fraud.authenticationValue = "BwABBJQ1AgAAAAAgJDUCAAAAAAA=";
             auth.cardholderAuthentication = fraud;
 
-            authorizationResponse authorizeResponse = litle.Authorize(auth);
+            var authorizeResponse = litle.Authorize(auth);
             Assert.AreEqual("000", authorizeResponse.response);
             Assert.AreEqual("Approved", authorizeResponse.message);
             Assert.AreEqual("22222", authorizeResponse.authCode);
             Assert.AreEqual("10", authorizeResponse.fraudResult.avsResult);
             Assert.AreEqual("M", authorizeResponse.fraudResult.cardValidationResult);
 
-            authReversal reversal = new authReversal();
+            var reversal = new authReversal();
             reversal.litleTxnId = authorizeResponse.litleTxnId;
-            authReversalResponse reversalResponse = litle.AuthReversal(reversal);
+            var reversalResponse = litle.AuthReversal(reversal);
             Assert.AreEqual("000", reversalResponse.response);
             Assert.AreEqual("Approved", reversalResponse.message);
         }
@@ -119,11 +117,11 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test34()
         {
-            authorization auth = new authorization();
+            var auth = new authorization();
             auth.orderId = "34";
             auth.amount = 30030;
             auth.orderSource = orderSourceType.ecommerce;
-            contact billToAddress = new contact();
+            var billToAddress = new contact();
             billToAddress.name = "Eileen Jones";
             billToAddress.addressLine1 = "3 Main St.";
             billToAddress.city = "Bloomfield";
@@ -131,23 +129,23 @@ namespace Litle.Sdk.Test.Certification
             billToAddress.zip = "06002";
             billToAddress.country = countryTypeEnum.US;
             auth.billToAddress = billToAddress;
-            cardType card = new cardType();
+            var card = new cardType();
             card.number = "6011010000000003";
             card.expDate = "0312";
             card.cardValidationNum = "758";
             card.type = methodOfPaymentTypeEnum.DI;
             auth.card = card;
 
-            authorizationResponse authorizeResponse = litle.Authorize(auth);
+            var authorizeResponse = litle.Authorize(auth);
             Assert.AreEqual("000", authorizeResponse.response);
             Assert.AreEqual("Approved", authorizeResponse.message);
             Assert.AreEqual("33333", authorizeResponse.authCode);
             Assert.AreEqual("10", authorizeResponse.fraudResult.avsResult);
             Assert.AreEqual("M", authorizeResponse.fraudResult.cardValidationResult);
 
-            authReversal reversal = new authReversal();
+            var reversal = new authReversal();
             reversal.litleTxnId = authorizeResponse.litleTxnId;
-            authReversalResponse reversalResponse = litle.AuthReversal(reversal);
+            var reversalResponse = litle.AuthReversal(reversal);
             Assert.AreEqual("000", reversalResponse.response);
             Assert.AreEqual("Approved", reversalResponse.message);
         }
@@ -155,11 +153,11 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test35()
         {
-            authorization auth = new authorization();
+            var auth = new authorization();
             auth.orderId = "35";
             auth.amount = 40040;
             auth.orderSource = orderSourceType.ecommerce;
-            contact billToAddress = new contact();
+            var billToAddress = new contact();
             billToAddress.name = "Bob Black";
             billToAddress.addressLine1 = "4 Main St.";
             billToAddress.city = "Laurel";
@@ -167,29 +165,29 @@ namespace Litle.Sdk.Test.Certification
             billToAddress.zip = "20708";
             billToAddress.country = countryTypeEnum.US;
             auth.billToAddress = billToAddress;
-            cardType card = new cardType();
+            var card = new cardType();
             card.number = "375001000000005";
             card.expDate = "0412";
             card.type = methodOfPaymentTypeEnum.AX;
             auth.card = card;
 
-            authorizationResponse authorizeResponse = litle.Authorize(auth);
+            var authorizeResponse = litle.Authorize(auth);
             Assert.AreEqual("000", authorizeResponse.response);
             Assert.AreEqual("Approved", authorizeResponse.message);
             Assert.AreEqual("44444", authorizeResponse.authCode);
             Assert.AreEqual("12", authorizeResponse.fraudResult.avsResult);
 
-            capture capture = new capture();
+            var capture = new capture();
             capture.litleTxnId = authorizeResponse.litleTxnId;
             capture.amount = 20020;
-            captureResponse captureResponse = litle.Capture(capture);
+            var captureResponse = litle.Capture(capture);
             Assert.AreEqual("000", captureResponse.response);
             Assert.AreEqual("Approved", captureResponse.message);
 
-            authReversal reversal = new authReversal();
+            var reversal = new authReversal();
             reversal.litleTxnId = authorizeResponse.litleTxnId;
             reversal.amount = 20020;
-            authReversalResponse reversalResponse = litle.AuthReversal(reversal);
+            var reversalResponse = litle.AuthReversal(reversal);
             Assert.AreEqual("000", reversalResponse.response);
             Assert.AreEqual("Approved", reversalResponse.message);
         }
@@ -197,26 +195,26 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test36()
         {
-            authorization auth = new authorization();
+            var auth = new authorization();
             auth.orderId = "36";
             auth.amount = 20500;
             auth.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.number = "375000026600004";
             card.expDate = "0512";
             card.type = methodOfPaymentTypeEnum.AX;
             auth.card = card;
 
-            authorizationResponse authorizeResponse = litle.Authorize(auth);
+            var authorizeResponse = litle.Authorize(auth);
             Assert.AreEqual("000", authorizeResponse.response);
             Assert.AreEqual("Approved", authorizeResponse.message);
 
-            authReversal reversal = new authReversal();
+            var reversal = new authReversal();
             reversal.litleTxnId = authorizeResponse.litleTxnId;
             reversal.amount = 10000;
-            authReversalResponse reversalResponse = litle.AuthReversal(reversal);
+            var reversalResponse = litle.AuthReversal(reversal);
             Assert.AreEqual("336", reversalResponse.response);
             Assert.AreEqual("Reversal Amount does not match Authorization amount", reversalResponse.message);
-        }            
+        }
     }
 }

--- a/LitleSdkForNet/LitleSdkForNetTest/Certification/TestCert3AuthReversal.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Certification/TestCert3AuthReversal.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -10,10 +11,12 @@ namespace Litle.Sdk.Test.Certification
     class TestCert3AuthReversal
     {
         private LitleOnline litle;
+        private IDictionary<string, StringBuilder> _memoryCache;
 
         [TestFixtureSetUp]
         public void setUp()
         {
+            _memoryCache = new Dictionary<string, StringBuilder>();
             Dictionary<string, string> config = new Dictionary<string, string>();
             config.Add("url", "https://www.testlitle.com/sandbox/communicator/online");
             config.Add("reportGroup", "Default Report Group");
@@ -27,7 +30,7 @@ namespace Litle.Sdk.Test.Certification
             config.Add("neuterAccountNums", null);
             config.Add("proxyHost", Properties.Settings.Default.proxyHost);
             config.Add("proxyPort", Properties.Settings.Default.proxyPort);
-            litle = new LitleOnline(config);
+            litle = new LitleOnline(_memoryCache, config);
         }
 
         [Test]

--- a/LitleSdkForNet/LitleSdkForNetTest/Certification/TestCert4Echeck.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Certification/TestCert4Echeck.cs
@@ -1,14 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Text;
+using Litle.Sdk.Properties;
 using NUnit.Framework;
-using Litle.Sdk;
 
 namespace Litle.Sdk.Test.Certification
 {
     [TestFixture]
-    class TestCert4Echeck
+    internal class TestCert4Echeck
     {
         private LitleOnline litle;
         private IDictionary<string, StringBuilder> _memoryCache;
@@ -17,7 +15,7 @@ namespace Litle.Sdk.Test.Certification
         public void setUp()
         {
             _memoryCache = new Dictionary<string, StringBuilder>();
-            Dictionary<string, string> config = new Dictionary<string, string>();
+            var config = new Dictionary<string, string>();
             config.Add("url", "https://www.testlitle.com/sandbox/communicator/online");
             config.Add("reportGroup", "Default Report Group");
             config.Add("username", "DOTNET");
@@ -28,29 +26,29 @@ namespace Litle.Sdk.Test.Certification
             config.Add("printxml", "true");
             config.Add("logFile", null);
             config.Add("neuterAccountNums", null);
-            config.Add("proxyHost", Properties.Settings.Default.proxyHost);
-            config.Add("proxyPort", Properties.Settings.Default.proxyPort);
+            config.Add("proxyHost", Settings.Default.proxyHost);
+            config.Add("proxyPort", Settings.Default.proxyPort);
             litle = new LitleOnline(_memoryCache, config);
         }
 
         [Test]
         public void test37()
         {
-            echeckVerification verification = new echeckVerification();
+            var verification = new echeckVerification();
             verification.orderId = "37";
             verification.amount = 3001;
             verification.orderSource = orderSourceType.telephone;
-            contact billToAddress = new contact();
+            var billToAddress = new contact();
             billToAddress.firstName = "Tom";
             billToAddress.lastName = "Black";
             verification.billToAddress = billToAddress;
-            echeckType echeck = new echeckType();
+            var echeck = new echeckType();
             echeck.accNum = "10@BC99999";
             echeck.accType = echeckAccountTypeEnum.Checking;
             echeck.routingNum = "053100300";
             verification.echeck = echeck;
 
-            echeckVerificationResponse response = litle.EcheckVerification(verification);
+            var response = litle.EcheckVerification(verification);
             Assert.AreEqual("301", response.response);
             Assert.AreEqual("Invalid Account Number", response.message);
         }
@@ -58,22 +56,22 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test38()
         {
-            echeckVerification verification = new echeckVerification();
+            var verification = new echeckVerification();
             verification.orderId = "38";
             verification.amount = 3002;
             verification.orderSource = orderSourceType.telephone;
-            contact billToAddress = new contact();
+            var billToAddress = new contact();
             billToAddress.firstName = "John";
             billToAddress.lastName = "Smith";
             billToAddress.phone = "999-999-9999";
             verification.billToAddress = billToAddress;
-            echeckType echeck = new echeckType();
+            var echeck = new echeckType();
             echeck.accNum = "1099999999";
             echeck.accType = echeckAccountTypeEnum.Checking;
             echeck.routingNum = "053000219";
             verification.echeck = echeck;
 
-            echeckVerificationResponse response = litle.EcheckVerification(verification);
+            var response = litle.EcheckVerification(verification);
             Assert.AreEqual("000", response.response);
             Assert.AreEqual("Approved", response.message);
         }
@@ -81,23 +79,23 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test39()
         {
-            echeckVerification verification = new echeckVerification();
+            var verification = new echeckVerification();
             verification.orderId = "39";
             verification.amount = 3003;
             verification.orderSource = orderSourceType.telephone;
-            contact billToAddress = new contact();
+            var billToAddress = new contact();
             billToAddress.firstName = "Robert";
             billToAddress.lastName = "Jones";
             billToAddress.companyName = "Good Goods Inc";
             billToAddress.phone = "9999999999";
             verification.billToAddress = billToAddress;
-            echeckType echeck = new echeckType();
+            var echeck = new echeckType();
             echeck.accNum = "3099999999";
             echeck.accType = echeckAccountTypeEnum.Corporate;
             echeck.routingNum = "053100300";
             verification.echeck = echeck;
 
-            echeckVerificationResponse response = litle.EcheckVerification(verification);
+            var response = litle.EcheckVerification(verification);
             Assert.AreEqual("950", response.response);
             Assert.AreEqual("Declined - Negative Information on File", response.message);
         }
@@ -105,23 +103,23 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test40()
         {
-            echeckVerification verification = new echeckVerification();
+            var verification = new echeckVerification();
             verification.orderId = "40";
             verification.amount = 3004;
             verification.orderSource = orderSourceType.telephone;
-            contact billToAddress = new contact();
+            var billToAddress = new contact();
             billToAddress.firstName = "Peter";
             billToAddress.lastName = "Green";
             billToAddress.companyName = "Green Co";
             billToAddress.phone = "9999999999";
             verification.billToAddress = billToAddress;
-            echeckType echeck = new echeckType();
+            var echeck = new echeckType();
             echeck.accNum = "8099999999";
             echeck.accType = echeckAccountTypeEnum.Corporate;
             echeck.routingNum = "063102152";
             verification.echeck = echeck;
 
-            echeckVerificationResponse response = litle.EcheckVerification(verification);
+            var response = litle.EcheckVerification(verification);
             Assert.AreEqual("951", response.response);
             Assert.AreEqual("Absolute Decline", response.message);
         }
@@ -129,22 +127,22 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test41()
         {
-            echeckSale sale = new echeckSale();
+            var sale = new echeckSale();
             sale.orderId = "41";
             sale.amount = 2008;
             sale.orderSource = orderSourceType.telephone;
-            contact billToAddress = new contact();
+            var billToAddress = new contact();
             billToAddress.firstName = "Mike";
             billToAddress.middleInitial = "J";
             billToAddress.lastName = "Hammer";
             sale.billToAddress = billToAddress;
-            echeckType echeck = new echeckType();
+            var echeck = new echeckType();
             echeck.accNum = "10@BC99999";
             echeck.accType = echeckAccountTypeEnum.Checking;
             echeck.routingNum = "053100300";
             sale.echeck = echeck;
 
-            echeckSalesResponse response = litle.EcheckSale(sale);
+            var response = litle.EcheckSale(sale);
             Assert.AreEqual("301", response.response);
             Assert.AreEqual("Invalid Account Number", response.message);
         }
@@ -152,21 +150,21 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test42()
         {
-            echeckSale sale = new echeckSale();
+            var sale = new echeckSale();
             sale.orderId = "42";
             sale.amount = 2004;
             sale.orderSource = orderSourceType.telephone;
-            contact billToAddress = new contact();
+            var billToAddress = new contact();
             billToAddress.firstName = "Tom";
             billToAddress.lastName = "Black";
             sale.billToAddress = billToAddress;
-            echeckType echeck = new echeckType();
+            var echeck = new echeckType();
             echeck.accNum = "4099999992";
             echeck.accType = echeckAccountTypeEnum.Checking;
             echeck.routingNum = "211370545";
             sale.echeck = echeck;
 
-            echeckSalesResponse response = litle.EcheckSale(sale);
+            var response = litle.EcheckSale(sale);
             Assert.AreEqual("000", response.response);
             Assert.AreEqual("Approved", response.message);
         }
@@ -174,22 +172,22 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test43()
         {
-            echeckSale sale = new echeckSale();
+            var sale = new echeckSale();
             sale.orderId = "43";
             sale.amount = 2007;
             sale.orderSource = orderSourceType.telephone;
-            contact billToAddress = new contact();
+            var billToAddress = new contact();
             billToAddress.firstName = "Peter";
             billToAddress.lastName = "Green";
             billToAddress.companyName = "Green Co";
             sale.billToAddress = billToAddress;
-            echeckType echeck = new echeckType();
+            var echeck = new echeckType();
             echeck.accNum = "6099999992";
             echeck.accType = echeckAccountTypeEnum.Corporate;
             echeck.routingNum = "211370545";
             sale.echeck = echeck;
 
-            echeckSalesResponse response = litle.EcheckSale(sale);
+            var response = litle.EcheckSale(sale);
             Assert.AreEqual("000", response.response);
             Assert.AreEqual("Approved", response.message);
         }
@@ -197,22 +195,22 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test44()
         {
-            echeckSale sale = new echeckSale();
+            var sale = new echeckSale();
             sale.orderId = "44";
             sale.amount = 2009;
             sale.orderSource = orderSourceType.telephone;
-            contact billToAddress = new contact();
+            var billToAddress = new contact();
             billToAddress.firstName = "Peter";
             billToAddress.lastName = "Green";
             billToAddress.companyName = "Green Co";
             sale.billToAddress = billToAddress;
-            echeckType echeck = new echeckType();
+            var echeck = new echeckType();
             echeck.accNum = "9099999992";
             echeck.accType = echeckAccountTypeEnum.Corporate;
             echeck.routingNum = "053133052";
             sale.echeck = echeck;
 
-            echeckSalesResponse response = litle.EcheckSale(sale);
+            var response = litle.EcheckSale(sale);
             Assert.AreEqual("900", response.response);
             Assert.AreEqual("Invalid Bank Routing Number", response.message);
         }
@@ -220,21 +218,21 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test45()
         {
-            echeckCredit credit = new echeckCredit();
+            var credit = new echeckCredit();
             credit.orderId = "45";
             credit.amount = 1001;
             credit.orderSource = orderSourceType.telephone;
-            contact billToAddress = new contact();
+            var billToAddress = new contact();
             billToAddress.firstName = "John";
             billToAddress.lastName = "Smith";
             credit.billToAddress = billToAddress;
-            echeckType echeck = new echeckType();
+            var echeck = new echeckType();
             echeck.accNum = "10@BC99999";
             echeck.accType = echeckAccountTypeEnum.Checking;
             echeck.routingNum = "053100300";
             credit.echeck = echeck;
 
-            echeckCreditResponse response = litle.EcheckCredit(credit);
+            var response = litle.EcheckCredit(credit);
             Assert.AreEqual("301", response.response);
             Assert.AreEqual("Invalid Account Number", response.message);
         }
@@ -242,22 +240,22 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test46()
         {
-            echeckCredit credit = new echeckCredit();
+            var credit = new echeckCredit();
             credit.orderId = "46";
             credit.amount = 1003;
             credit.orderSource = orderSourceType.telephone;
-            contact billToAddress = new contact();
+            var billToAddress = new contact();
             billToAddress.firstName = "Robert";
             billToAddress.lastName = "Jones";
             billToAddress.companyName = "Widget Inc";
             credit.billToAddress = billToAddress;
-            echeckType echeck = new echeckType();
+            var echeck = new echeckType();
             echeck.accNum = "3099999999";
             echeck.accType = echeckAccountTypeEnum.Corporate;
             echeck.routingNum = "063102152";
             credit.echeck = echeck;
 
-            echeckCreditResponse response = litle.EcheckCredit(credit);
+            var response = litle.EcheckCredit(credit);
             Assert.AreEqual("000", response.response);
             Assert.AreEqual("Approved", response.message);
         }
@@ -265,22 +263,22 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test47()
         {
-            echeckCredit credit = new echeckCredit();
+            var credit = new echeckCredit();
             credit.orderId = "47";
             credit.amount = 1007;
             credit.orderSource = orderSourceType.telephone;
-            contact billToAddress = new contact();
+            var billToAddress = new contact();
             billToAddress.firstName = "Peter";
             billToAddress.lastName = "Green";
             billToAddress.companyName = "Green Co";
             credit.billToAddress = billToAddress;
-            echeckType echeck = new echeckType();
+            var echeck = new echeckType();
             echeck.accNum = "6099999993";
             echeck.accType = echeckAccountTypeEnum.Corporate;
             echeck.routingNum = "211370545";
             credit.echeck = echeck;
 
-            echeckCreditResponse response = litle.EcheckCredit(credit);
+            var response = litle.EcheckCredit(credit);
             Assert.AreEqual("000", response.response);
             Assert.AreEqual("Approved", response.message);
         }
@@ -288,10 +286,10 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test48()
         {
-            echeckCredit credit = new echeckCredit();
+            var credit = new echeckCredit();
             credit.litleTxnId = 430000000000000001L;
 
-            echeckCreditResponse response = litle.EcheckCredit(credit);
+            var response = litle.EcheckCredit(credit);
             Assert.AreEqual("000", response.response);
             Assert.AreEqual("Approved", response.message);
         }
@@ -299,13 +297,12 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test49()
         {
-            echeckCredit credit = new echeckCredit();
+            var credit = new echeckCredit();
             credit.litleTxnId = 2L;
 
-            echeckCreditResponse response = litle.EcheckCredit(credit);
+            var response = litle.EcheckCredit(credit);
             Assert.AreEqual("360", response.response);
             Assert.AreEqual("No transaction found with specified litleTxnId", response.message);
         }
-            
     }
 }

--- a/LitleSdkForNet/LitleSdkForNetTest/Certification/TestCert4Echeck.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Certification/TestCert4Echeck.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -10,10 +11,12 @@ namespace Litle.Sdk.Test.Certification
     class TestCert4Echeck
     {
         private LitleOnline litle;
+        private IDictionary<string, StringBuilder> _memoryCache;
 
         [TestFixtureSetUp]
         public void setUp()
         {
+            _memoryCache = new Dictionary<string, StringBuilder>();
             Dictionary<string, string> config = new Dictionary<string, string>();
             config.Add("url", "https://www.testlitle.com/sandbox/communicator/online");
             config.Add("reportGroup", "Default Report Group");
@@ -27,7 +30,7 @@ namespace Litle.Sdk.Test.Certification
             config.Add("neuterAccountNums", null);
             config.Add("proxyHost", Properties.Settings.Default.proxyHost);
             config.Add("proxyPort", Properties.Settings.Default.proxyPort);
-            litle = new LitleOnline(config);
+            litle = new LitleOnline(_memoryCache, config);
         }
 
         [Test]

--- a/LitleSdkForNet/LitleSdkForNetTest/Certification/TestCert5Token.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Certification/TestCert5Token.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -10,10 +11,12 @@ namespace Litle.Sdk.Test.Certification
     class TestCert5Token
     {
         private LitleOnline litle;
+        private IDictionary<string, StringBuilder> _memoryCache;
 
         [TestFixtureSetUp]
         public void setUp()
         {
+            _memoryCache = new Dictionary<string, StringBuilder>();
             Dictionary<string, string> config = new Dictionary<string, string>();
             config.Add("url", "https://www.testlitle.com/sandbox/communicator/online");
             config.Add("reportGroup", "Default Report Group");
@@ -27,7 +30,7 @@ namespace Litle.Sdk.Test.Certification
             config.Add("neuterAccountNums", null);
             config.Add("proxyHost", Properties.Settings.Default.proxyHost);
             config.Add("proxyPort", Properties.Settings.Default.proxyPort);
-            litle = new LitleOnline(config);
+            litle = new LitleOnline(_memoryCache, config);
         }
 
         [Test]

--- a/LitleSdkForNet/LitleSdkForNetTest/Certification/TestCert5Token.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Certification/TestCert5Token.cs
@@ -1,14 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Text;
+using Litle.Sdk.Properties;
 using NUnit.Framework;
-using Litle.Sdk;
 
 namespace Litle.Sdk.Test.Certification
 {
     [TestFixture]
-    class TestCert5Token
+    internal class TestCert5Token
     {
         private LitleOnline litle;
         private IDictionary<string, StringBuilder> _memoryCache;
@@ -17,7 +15,7 @@ namespace Litle.Sdk.Test.Certification
         public void setUp()
         {
             _memoryCache = new Dictionary<string, StringBuilder>();
-            Dictionary<string, string> config = new Dictionary<string, string>();
+            var config = new Dictionary<string, string>();
             config.Add("url", "https://www.testlitle.com/sandbox/communicator/online");
             config.Add("reportGroup", "Default Report Group");
             config.Add("username", "DOTNET");
@@ -28,19 +26,19 @@ namespace Litle.Sdk.Test.Certification
             config.Add("printxml", "true");
             config.Add("logFile", null);
             config.Add("neuterAccountNums", null);
-            config.Add("proxyHost", Properties.Settings.Default.proxyHost);
-            config.Add("proxyPort", Properties.Settings.Default.proxyPort);
+            config.Add("proxyHost", Settings.Default.proxyHost);
+            config.Add("proxyPort", Settings.Default.proxyPort);
             litle = new LitleOnline(_memoryCache, config);
         }
 
         [Test]
         public void test50()
         {
-            registerTokenRequestType request = new registerTokenRequestType();
+            var request = new registerTokenRequestType();
             request.orderId = "50";
             request.accountNumber = "4457119922390123";
 
-            registerTokenResponse response = litle.RegisterToken(request);
+            var response = litle.RegisterToken(request);
             Assert.AreEqual("445711", response.bin);
             Assert.AreEqual(methodOfPaymentTypeEnum.VI, response.type);
             Assert.AreEqual("801", response.response);
@@ -51,11 +49,11 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test51()
         {
-            registerTokenRequestType request = new registerTokenRequestType();
+            var request = new registerTokenRequestType();
             request.orderId = "51";
             request.accountNumber = "4457119999999999";
 
-            registerTokenResponse response = litle.RegisterToken(request);
+            var response = litle.RegisterToken(request);
             Assert.AreEqual("820", response.response);
             Assert.AreEqual("Credit card number was invalid", response.message);
         }
@@ -63,11 +61,11 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test52()
         {
-            registerTokenRequestType request = new registerTokenRequestType();
+            var request = new registerTokenRequestType();
             request.orderId = "52";
             request.accountNumber = "4457119922390123";
 
-            registerTokenResponse response = litle.RegisterToken(request);
+            var response = litle.RegisterToken(request);
             Assert.AreEqual("445711", response.bin);
             Assert.AreEqual(methodOfPaymentTypeEnum.VI, response.type);
             Assert.AreEqual("802", response.response);
@@ -78,14 +76,15 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test53()
         {
-            registerTokenRequestType request = new registerTokenRequestType();
+            var request = new registerTokenRequestType();
             request.orderId = "53";
-            echeckForTokenType echeck = new echeckForTokenType();
+            var echeck = new echeckForTokenType();
             echeck.accNum = "1099999998";
             echeck.routingNum = "114567895";
-            request.echeckForToken = echeck; ;
+            request.echeckForToken = echeck;
+            ;
 
-            registerTokenResponse response = litle.RegisterToken(request);
+            var response = litle.RegisterToken(request);
             Assert.AreEqual(methodOfPaymentTypeEnum.EC, response.type);
             Assert.AreEqual("998", response.eCheckAccountSuffix);
             Assert.AreEqual("801", response.response);
@@ -96,14 +95,15 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test54()
         {
-            registerTokenRequestType request = new registerTokenRequestType();
+            var request = new registerTokenRequestType();
             request.orderId = "54";
-            echeckForTokenType echeck = new echeckForTokenType();
+            var echeck = new echeckForTokenType();
             echeck.accNum = "1022222102";
             echeck.routingNum = "1145_7895";
-            request.echeckForToken = echeck; ;
+            request.echeckForToken = echeck;
+            ;
 
-            registerTokenResponse response = litle.RegisterToken(request);
+            var response = litle.RegisterToken(request);
             Assert.AreEqual("900", response.response);
             Assert.AreEqual("Invalid bank routing number", response.message);
         }
@@ -111,18 +111,18 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test55()
         {
-            authorization auth = new authorization();
+            var auth = new authorization();
             auth.orderId = "55";
             auth.amount = 15000;
             auth.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.number = "5435101234510196";
             card.expDate = "1112";
             card.cardValidationNum = "987";
             card.type = methodOfPaymentTypeEnum.MC;
             auth.card = card;
 
-            authorizationResponse response = litle.Authorize(auth);
+            var response = litle.Authorize(auth);
             Assert.AreEqual("000", response.response);
             Assert.AreEqual("Approved", response.message);
             Assert.AreEqual("801", response.tokenResponse.tokenResponseCode);
@@ -134,18 +134,18 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test56()
         {
-            authorization auth = new authorization();
+            var auth = new authorization();
             auth.orderId = "56";
             auth.amount = 15000;
             auth.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.number = "5435109999999999";
             card.expDate = "1112";
             card.cardValidationNum = "987";
             card.type = methodOfPaymentTypeEnum.MC;
             auth.card = card;
 
-            authorizationResponse response = litle.Authorize(auth);
+            var response = litle.Authorize(auth);
             Assert.AreEqual("301", response.response);
             Assert.AreEqual("Invalid account number", response.message);
         }
@@ -153,18 +153,18 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test57()
         {
-            authorization auth = new authorization();
+            var auth = new authorization();
             auth.orderId = "57";
             auth.amount = 15000;
             auth.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.number = "5435101234510196";
             card.expDate = "1112";
             card.cardValidationNum = "987";
             card.type = methodOfPaymentTypeEnum.MC;
             auth.card = card;
 
-            authorizationResponse response = litle.Authorize(auth);
+            var response = litle.Authorize(auth);
             Assert.AreEqual("000", response.response);
             Assert.AreEqual("Approved", response.message);
             Assert.AreEqual("802", response.tokenResponse.tokenResponseCode);
@@ -176,16 +176,16 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test59()
         {
-            authorization auth = new authorization();
+            var auth = new authorization();
             auth.orderId = "59";
             auth.amount = 15000;
             auth.orderSource = orderSourceType.ecommerce;
-            cardTokenType token = new cardTokenType();
+            var token = new cardTokenType();
             token.litleToken = "1712990000040196";
             token.expDate = "1112";
             auth.token = token;
 
-            authorizationResponse response = litle.Authorize(auth);
+            var response = litle.Authorize(auth);
             Assert.AreEqual("822", response.response);
             Assert.AreEqual("Token was not found", response.message);
         }
@@ -193,16 +193,16 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test60()
         {
-            authorization auth = new authorization();
+            var auth = new authorization();
             auth.orderId = "60";
             auth.amount = 15000;
             auth.orderSource = orderSourceType.ecommerce;
-            cardTokenType token = new cardTokenType();
+            var token = new cardTokenType();
             token.litleToken = "1712999999999999";
             token.expDate = "1112";
             auth.token = token;
 
-            authorizationResponse response = litle.Authorize(auth);
+            var response = litle.Authorize(auth);
             Assert.AreEqual("823", response.response);
             Assert.AreEqual("Token was invalid", response.message);
         }
@@ -210,21 +210,22 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test61()
         {
-            echeckSale sale = new echeckSale();
+            var sale = new echeckSale();
             sale.orderId = "61";
             sale.amount = 15000;
             sale.orderSource = orderSourceType.ecommerce;
-            contact billToAddress = new contact();
+            var billToAddress = new contact();
             billToAddress.firstName = "Tom";
             billToAddress.lastName = "Black";
             sale.billToAddress = billToAddress;
-            echeckType echeck = new echeckType();
-            echeck.accType = echeckAccountTypeEnum.Checking; ;
+            var echeck = new echeckType();
+            echeck.accType = echeckAccountTypeEnum.Checking;
+            ;
             echeck.accNum = "1099999003";
             echeck.routingNum = "114567895";
             sale.echeck = echeck;
 
-            echeckSalesResponse response = litle.EcheckSale(sale);
+            var response = litle.EcheckSale(sale);
             Assert.AreEqual("801", response.tokenResponse.tokenResponseCode);
             Assert.AreEqual("Account number was successfully registered", response.tokenResponse.tokenMessage);
             Assert.AreEqual(methodOfPaymentTypeEnum.EC, response.tokenResponse.type);
@@ -234,21 +235,22 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test62()
         {
-            echeckSale sale = new echeckSale();
+            var sale = new echeckSale();
             sale.orderId = "62";
             sale.amount = 15000;
             sale.orderSource = orderSourceType.ecommerce;
-            contact billToAddress = new contact();
+            var billToAddress = new contact();
             billToAddress.firstName = "Tom";
             billToAddress.lastName = "Black";
             sale.billToAddress = billToAddress;
-            echeckType echeck = new echeckType();
-            echeck.accType = echeckAccountTypeEnum.Checking; ;
+            var echeck = new echeckType();
+            echeck.accType = echeckAccountTypeEnum.Checking;
+            ;
             echeck.accNum = "1099999999";
             echeck.routingNum = "114567895";
             sale.echeck = echeck;
 
-            echeckSalesResponse response = litle.EcheckSale(sale);
+            var response = litle.EcheckSale(sale);
             Assert.AreEqual("801", response.tokenResponse.tokenResponseCode);
             Assert.AreEqual("Account number was successfully registered", response.tokenResponse.tokenMessage);
             Assert.AreEqual(methodOfPaymentTypeEnum.EC, response.tokenResponse.type);
@@ -259,27 +261,27 @@ namespace Litle.Sdk.Test.Certification
         [Test]
         public void test63()
         {
-            echeckSale sale = new echeckSale();
+            var sale = new echeckSale();
             sale.orderId = "63";
             sale.amount = 15000;
             sale.orderSource = orderSourceType.ecommerce;
-            contact billToAddress = new contact();
+            var billToAddress = new contact();
             billToAddress.firstName = "Tom";
             billToAddress.lastName = "Black";
             sale.billToAddress = billToAddress;
-            echeckType echeck = new echeckType();
-            echeck.accType = echeckAccountTypeEnum.Checking; ;
+            var echeck = new echeckType();
+            echeck.accType = echeckAccountTypeEnum.Checking;
+            ;
             echeck.accNum = "1099999999";
             echeck.routingNum = "214567892";
             sale.echeck = echeck;
 
-            echeckSalesResponse response = litle.EcheckSale(sale);
+            var response = litle.EcheckSale(sale);
             Assert.AreEqual("801", response.tokenResponse.tokenResponseCode);
             Assert.AreEqual("Account number was successfully registered", response.tokenResponse.tokenMessage);
             Assert.AreEqual(methodOfPaymentTypeEnum.EC, response.tokenResponse.type);
             Assert.AreEqual("999", response.tokenResponse.eCheckAccountSuffix);
             Assert.AreEqual("111922223333555999", response.tokenResponse.litleToken);
         }
-            
     }
 }

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestAuth.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestAuth.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -11,10 +12,12 @@ namespace Litle.Sdk.Test.Functional
     {
         private LitleOnline litle;
         private Dictionary<string, string> config;
+        private IDictionary<string, StringBuilder> _memoryCache;
 
         [TestFixtureSetUp]
         public void SetUpLitle()
         {
+            _memoryCache = new Dictionary<string, StringBuilder>();
             config = new Dictionary<string, string>();
             config.Add("url", "https://www.testlitle.com/sandbox/communicator/online");
             config.Add("reportGroup", "Default Report Group");
@@ -28,7 +31,7 @@ namespace Litle.Sdk.Test.Functional
             config.Add("proxyPort", Properties.Settings.Default.proxyPort);
             config.Add("logFile", Properties.Settings.Default.logFile);
             config.Add("neuterAccountNums", "true");
-            litle = new LitleOnline(config);
+            litle = new LitleOnline(_memoryCache, config);
         }
 
         [Test]

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestAuth.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestAuth.cs
@@ -1,14 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Text;
+using Litle.Sdk.Properties;
 using NUnit.Framework;
-using Litle.Sdk;
 
 namespace Litle.Sdk.Test.Functional
 {
     [TestFixture]
-    class TestAuth
+    internal class TestAuth
     {
         private LitleOnline litle;
         private Dictionary<string, string> config;
@@ -27,9 +25,9 @@ namespace Litle.Sdk.Test.Functional
             config.Add("merchantId", "101");
             config.Add("password", "TESTCASE");
             config.Add("printxml", "true");
-            config.Add("proxyHost", Properties.Settings.Default.proxyHost);
-            config.Add("proxyPort", Properties.Settings.Default.proxyPort);
-            config.Add("logFile", Properties.Settings.Default.logFile);
+            config.Add("proxyHost", Settings.Default.proxyHost);
+            config.Add("proxyPort", Settings.Default.proxyPort);
+            config.Add("logFile", Settings.Default.logFile);
             config.Add("neuterAccountNums", "true");
             litle = new LitleOnline(_memoryCache, config);
         }
@@ -37,51 +35,54 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void SimpleAuthWithCard()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.reportGroup = "Planets";
             authorization.orderId = "12344";
             authorization.amount = 106;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "414100000000000000";
             card.expDate = "1210";
             authorization.card = card; //This needs to compile
 
-            customBilling cb = new customBilling();
+            var cb = new customBilling();
             cb.phone = "1112223333"; //This needs to compile too            
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("000", response.response);
         }
+
         [Test]
         public void SimpleAuthWithMpos()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.reportGroup = "Planets";
             authorization.orderId = "12344";
             authorization.amount = 200;
             authorization.orderSource = orderSourceType.ecommerce;
-            mposType mpos = new mposType();
+            var mpos = new mposType();
             mpos.ksn = "77853211300008E00016";
-            mpos.encryptedTrack = "CASE1E185EADD6AFE78C9A214B21313DCD836FDD555FBE3A6C48D141FE80AB9172B963265AFF72111895FE415DEDA162CE8CB7AC4D91EDB611A2AB756AA9CB1A000000000000000000000000000000005A7AAF5E8885A9DB88ECD2430C497003F2646619A2382FFF205767492306AC804E8E64E8EA6981DD";
+            mpos.encryptedTrack =
+                "CASE1E185EADD6AFE78C9A214B21313DCD836FDD555FBE3A6C48D141FE80AB9172B963265AFF72111895FE415DEDA162CE8CB7AC4D91EDB611A2AB756AA9CB1A000000000000000000000000000000005A7AAF5E8885A9DB88ECD2430C497003F2646619A2382FFF205767492306AC804E8E64E8EA6981DD";
             mpos.formatId = "30";
             mpos.track1Status = 0;
             mpos.track2Status = 0;
             authorization.mpos = mpos; //This needs to compile
-       
 
-            authorizationResponse response = litle.Authorize(authorization);
+
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("000", response.response);
         }
-         [Test]
+
+        [Test]
         public void AuthWithAmpersand()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "1";
             authorization.amount = 10010;
             authorization.orderSource = orderSourceType.ecommerce;
-            contact contact = new contact();
+            var contact = new contact();
             contact.name = "John & Jane Smith";
             contact.addressLine1 = "1 Main St.";
             contact.city = "Burlington";
@@ -89,47 +90,48 @@ namespace Litle.Sdk.Test.Functional
             contact.zip = "01803-3747";
             contact.country = countryTypeEnum.US;
             authorization.billToAddress = contact;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4457010000000009";
             card.expDate = "0112";
-             card.cardValidationNum = "349";
-             authorization.card = card;
-             authorizationResponse response = litle.Authorize(authorization);
+            card.cardValidationNum = "349";
+            authorization.card = card;
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("000", response.response);
-         }
+        }
+
         [Test]
         public void simpleAuthWithPaypal()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.reportGroup = "Planets";
             authorization.orderId = "123456";
             authorization.amount = 106;
             authorization.orderSource = orderSourceType.ecommerce;
-            payPal paypal = new payPal();
+            var paypal = new payPal();
             paypal.payerId = "1234";
             paypal.token = "1234";
             paypal.transactionId = "123456";
             authorization.paypal = paypal; //This needs to compile
 
-            customBilling cb = new customBilling();
+            var cb = new customBilling();
             cb.phone = "1112223333"; //This needs to compile too            
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("Approved", response.message);
         }
 
         [Test]
         public void simpleAuthWithApplepayAndSecondaryAmountAndWallet()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.reportGroup = "Planets";
             authorization.orderId = "123456";
             authorization.amount = 110;
             authorization.secondaryAmount = 50;
             authorization.orderSource = orderSourceType.applepay;
-            applepayType applepay = new applepayType();
-            applepayHeaderType applepayHeaderType = new applepayHeaderType();
+            var applepay = new applepayType();
+            var applepayHeaderType = new applepayHeaderType();
             applepayHeaderType.applicationData = "454657413164";
             applepayHeaderType.ephemeralPublicKey = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
             applepayHeaderType.publicKeyHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
@@ -140,12 +142,12 @@ namespace Litle.Sdk.Test.Functional
             applepay.version = "1";
             authorization.applepay = applepay;
 
-            wallet wallet = new wallet();
+            var wallet = new wallet();
             wallet.walletSourceTypeId = "123";
             wallet.walletSourceType = walletWalletSourceType.MasterPass;
             authorization.wallet = wallet;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("Insufficient Funds", response.message);
             Assert.AreEqual("110", response.applepayResponse.transactionAmount);
         }
@@ -153,21 +155,21 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void posWithoutCapabilityAndEntryMode()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.reportGroup = "Planets";
             authorization.orderId = "12344";
             authorization.amount = 106;
             authorization.orderSource = orderSourceType.ecommerce;
-            pos pos = new pos();
+            var pos = new pos();
             pos.cardholderId = posCardholderIdTypeEnum.pin;
             authorization.pos = pos;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000002";
             card.expDate = "1210";
             authorization.card = card; //This needs to compile
 
-            customBilling cb = new customBilling();
+            var cb = new customBilling();
             cb.phone = "1112223333"; //This needs to compile too            
 
             try
@@ -184,46 +186,46 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void trackData()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.id = "AX54321678";
             authorization.reportGroup = "RG27";
             authorization.orderId = "12z58743y1";
             authorization.amount = 12522L;
             authorization.orderSource = orderSourceType.retail;
-            contact billToAddress = new contact();
+            var billToAddress = new contact();
             billToAddress.zip = "95032";
             authorization.billToAddress = billToAddress;
-            cardType card = new cardType();
+            var card = new cardType();
             card.track = "%B40000001^Doe/JohnP^06041...?;40001=0604101064200?";
             authorization.card = card;
-            pos pos = new pos();
+            var pos = new pos();
             pos.capability = posCapabilityTypeEnum.magstripe;
             pos.entryMode = posEntryModeTypeEnum.completeread;
             pos.cardholderId = posCardholderIdTypeEnum.signature;
             authorization.pos = pos;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("Approved", response.message);
         }
 
         [Test]
         public void testAuthHandleSpecialCharacters()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.reportGroup = "<'&\">";
             authorization.orderId = "123456";
             authorization.amount = 106;
             authorization.orderSource = orderSourceType.ecommerce;
-            payPal paypal = new payPal();
+            var paypal = new payPal();
             paypal.payerId = "1234";
             paypal.token = "1234";
             paypal.transactionId = "123456";
             authorization.paypal = paypal; //This needs to compile
 
-            customBilling cb = new customBilling();
+            var cb = new customBilling();
             cb.phone = "<'&\">"; //This needs to compile too            
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("Approved", response.message);
         }
 
@@ -232,18 +234,18 @@ namespace Litle.Sdk.Test.Functional
         {
             config.Remove("logFile");
 
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.reportGroup = "Planets";
             authorization.orderId = "12344";
             authorization.amount = 106;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "414100000000000000";
             card.expDate = "1210";
             authorization.card = card;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("000", response.response);
         }
 
@@ -252,18 +254,18 @@ namespace Litle.Sdk.Test.Functional
         {
             config.Remove("neuterAccountNums");
 
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.reportGroup = "Planets";
             authorization.orderId = "12344";
             authorization.amount = 106;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "414100000000000000";
             card.expDate = "1210";
             authorization.card = card;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("000", response.response);
         }
 
@@ -272,18 +274,18 @@ namespace Litle.Sdk.Test.Functional
         {
             config.Remove("printxml");
 
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.reportGroup = "Planets";
             authorization.orderId = "12344";
             authorization.amount = 106;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "414100000000000000";
             card.expDate = "1210";
             authorization.card = card;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("000", response.response);
         }
 
@@ -292,17 +294,17 @@ namespace Litle.Sdk.Test.Functional
         {
             config.Remove("printxml");
 
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.reportGroup = "Planets";
             authorization.orderId = "12344";
             authorization.amount = 106;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "414100000000000000";
             card.expDate = "1210";
             authorization.card = card;
-            advancedFraudChecksType advancedFraudChecks = new advancedFraudChecksType();
+            var advancedFraudChecks = new advancedFraudChecksType();
             advancedFraudChecks.threatMetrixSessionId = "800";
             advancedFraudChecks.customAttribute1 = "testAttribute1";
             advancedFraudChecks.customAttribute2 = "testAttribute2";
@@ -311,7 +313,7 @@ namespace Litle.Sdk.Test.Functional
             advancedFraudChecks.customAttribute5 = "testAttribute5";
             authorization.advancedFraudChecks = advancedFraudChecks;
 
-            authorizationResponse response = litle.Authorize(authorization);
+            var response = litle.Authorize(authorization);
             Assert.AreEqual("000", response.response);
         }
     }

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestAuthReversal.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestAuthReversal.cs
@@ -1,14 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Text;
+using Litle.Sdk.Properties;
 using NUnit.Framework;
-using Litle.Sdk;
 
 namespace Litle.Sdk.Test.Functional
 {
     [TestFixture]
-    class TestAuthReversal
+    internal class TestAuthReversal
     {
         private LitleOnline litle;
         private IDictionary<string, StringBuilder> _memoryCache;
@@ -17,7 +15,7 @@ namespace Litle.Sdk.Test.Functional
         public void SetUpLitle()
         {
             _memoryCache = new Dictionary<string, StringBuilder>();
-            Dictionary<string, string> config = new Dictionary<string, string>();
+            var config = new Dictionary<string, string>();
             config.Add("url", "https://www.testlitle.com/sandbox/communicator/online");
             config.Add("reportGroup", "Default Report Group");
             config.Add("username", "DOTNET");
@@ -26,9 +24,9 @@ namespace Litle.Sdk.Test.Functional
             config.Add("merchantId", "101");
             config.Add("password", "TESTCASE");
             config.Add("printxml", "true");
-            config.Add("proxyHost", Properties.Settings.Default.proxyHost);
-            config.Add("proxyPort", Properties.Settings.Default.proxyPort);
-            config.Add("logFile", Properties.Settings.Default.logFile);
+            config.Add("proxyHost", Settings.Default.proxyHost);
+            config.Add("proxyPort", Settings.Default.proxyPort);
+            config.Add("logFile", Settings.Default.logFile);
             config.Add("neuterAccountNums", "true");
             litle = new LitleOnline(_memoryCache, config);
         }
@@ -36,25 +34,25 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void SimpleAuthReversal()
         {
-            authReversal reversal = new authReversal();
+            var reversal = new authReversal();
             reversal.litleTxnId = 12345678000L;
             reversal.amount = 106;
             reversal.payPalNotes = "Notes";
 
-            authReversalResponse response = litle.AuthReversal(reversal);
+            var response = litle.AuthReversal(reversal);
             Assert.AreEqual("Approved", response.message);
         }
-            
+
         [Test]
         public void testAuthReversalHandleSpecialCharacters()
         {
-            authReversal reversal = new authReversal();
+            var reversal = new authReversal();
             reversal.litleTxnId = 12345678000L;
             reversal.amount = 106;
             reversal.payPalNotes = "<'&\">";
 
-            authReversalResponse response = litle.AuthReversal(reversal);
+            var response = litle.AuthReversal(reversal);
             Assert.AreEqual("Approved", response.message);
-    }
+        }
     }
 }

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestAuthReversal.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestAuthReversal.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -10,10 +11,12 @@ namespace Litle.Sdk.Test.Functional
     class TestAuthReversal
     {
         private LitleOnline litle;
+        private IDictionary<string, StringBuilder> _memoryCache;
 
         [TestFixtureSetUp]
         public void SetUpLitle()
         {
+            _memoryCache = new Dictionary<string, StringBuilder>();
             Dictionary<string, string> config = new Dictionary<string, string>();
             config.Add("url", "https://www.testlitle.com/sandbox/communicator/online");
             config.Add("reportGroup", "Default Report Group");
@@ -27,7 +30,7 @@ namespace Litle.Sdk.Test.Functional
             config.Add("proxyPort", Properties.Settings.Default.proxyPort);
             config.Add("logFile", Properties.Settings.Default.logFile);
             config.Add("neuterAccountNums", "true");
-            litle = new LitleOnline(config);
+            litle = new LitleOnline(_memoryCache, config);
         }
 
         [Test]

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestBatch.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestBatch.cs
@@ -1,18 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Litle.Sdk.Properties;
 using NUnit.Framework;
-using Litle.Sdk;
-using System.IO;
 
 namespace Litle.Sdk.Test.Functional
 {
     [TestFixture]
-    class TestBatch
+    internal class TestBatch
     {
         private litleRequest litle;
-        private Dictionary<String, String> invalidConfig;
-        private Dictionary<String, String> invalidSftpConfig;
+        private Dictionary<string, string> invalidConfig;
+        private Dictionary<string, string> invalidSftpConfig;
         private IDictionary<string, StringBuilder> memoryStreams;
 
         [TestFixtureSetUp]
@@ -20,41 +19,40 @@ namespace Litle.Sdk.Test.Functional
         {
             memoryStreams = new Dictionary<string, StringBuilder>();
 
-            invalidConfig = new Dictionary<String, String>();
-            invalidConfig["url"] = Properties.Settings.Default.url;
-            invalidConfig["reportGroup"] = Properties.Settings.Default.reportGroup;
+            invalidConfig = new Dictionary<string, string>();
+            invalidConfig["url"] = Settings.Default.url;
+            invalidConfig["reportGroup"] = Settings.Default.reportGroup;
             invalidConfig["username"] = "badUsername";
-            invalidConfig["printxml"] = Properties.Settings.Default.printxml;
-            invalidConfig["timeout"] = Properties.Settings.Default.timeout;
-            invalidConfig["proxyHost"] = Properties.Settings.Default.proxyHost;
-            invalidConfig["merchantId"] = Properties.Settings.Default.merchantId;
+            invalidConfig["printxml"] = Settings.Default.printxml;
+            invalidConfig["timeout"] = Settings.Default.timeout;
+            invalidConfig["proxyHost"] = Settings.Default.proxyHost;
+            invalidConfig["merchantId"] = Settings.Default.merchantId;
             invalidConfig["password"] = "badPassword";
-            invalidConfig["proxyPort"] = Properties.Settings.Default.proxyPort;
-            invalidConfig["sftpUrl"] = Properties.Settings.Default.sftpUrl;
-            invalidConfig["sftpUsername"] = Properties.Settings.Default.sftpUsername;
-            invalidConfig["sftpPassword"] = Properties.Settings.Default.sftpPassword;
-            invalidConfig["knownHostsFile"] = Properties.Settings.Default.knownHostsFile;
-            invalidConfig["requestDirectory"] = Properties.Settings.Default.requestDirectory;
-            invalidConfig["responseDirectory"] = Properties.Settings.Default.responseDirectory;
-           
+            invalidConfig["proxyPort"] = Settings.Default.proxyPort;
+            invalidConfig["sftpUrl"] = Settings.Default.sftpUrl;
+            invalidConfig["sftpUsername"] = Settings.Default.sftpUsername;
+            invalidConfig["sftpPassword"] = Settings.Default.sftpPassword;
+            invalidConfig["knownHostsFile"] = Settings.Default.knownHostsFile;
+            invalidConfig["requestDirectory"] = Settings.Default.requestDirectory;
+            invalidConfig["responseDirectory"] = Settings.Default.responseDirectory;
 
-            invalidSftpConfig = new Dictionary<String, String>();
-            invalidSftpConfig["url"] = Properties.Settings.Default.url;
-            invalidSftpConfig["reportGroup"] = Properties.Settings.Default.reportGroup;
-            invalidSftpConfig["username"] = Properties.Settings.Default.username;
-            invalidSftpConfig["printxml"] = Properties.Settings.Default.printxml;
-            invalidSftpConfig["timeout"] = Properties.Settings.Default.timeout;
-            invalidSftpConfig["proxyHost"] = Properties.Settings.Default.proxyHost;
-            invalidSftpConfig["merchantId"] = Properties.Settings.Default.merchantId;
-            invalidSftpConfig["password"] = Properties.Settings.Default.password;
-            invalidSftpConfig["proxyPort"] = Properties.Settings.Default.proxyPort;
-            invalidSftpConfig["sftpUrl"] = Properties.Settings.Default.sftpUrl;
+
+            invalidSftpConfig = new Dictionary<string, string>();
+            invalidSftpConfig["url"] = Settings.Default.url;
+            invalidSftpConfig["reportGroup"] = Settings.Default.reportGroup;
+            invalidSftpConfig["username"] = Settings.Default.username;
+            invalidSftpConfig["printxml"] = Settings.Default.printxml;
+            invalidSftpConfig["timeout"] = Settings.Default.timeout;
+            invalidSftpConfig["proxyHost"] = Settings.Default.proxyHost;
+            invalidSftpConfig["merchantId"] = Settings.Default.merchantId;
+            invalidSftpConfig["password"] = Settings.Default.password;
+            invalidSftpConfig["proxyPort"] = Settings.Default.proxyPort;
+            invalidSftpConfig["sftpUrl"] = Settings.Default.sftpUrl;
             invalidSftpConfig["sftpUsername"] = "badSftpUsername";
             invalidSftpConfig["sftpPassword"] = "badSftpPassword";
-            invalidSftpConfig["knownHostsFile"] = Properties.Settings.Default.knownHostsFile;
-            invalidSftpConfig["requestDirectory"] = Properties.Settings.Default.requestDirectory;
-            invalidSftpConfig["responseDirectory"] = Properties.Settings.Default.responseDirectory;
-
+            invalidSftpConfig["knownHostsFile"] = Settings.Default.knownHostsFile;
+            invalidSftpConfig["requestDirectory"] = Settings.Default.requestDirectory;
+            invalidSftpConfig["responseDirectory"] = Settings.Default.responseDirectory;
         }
 
         [SetUp]
@@ -66,14 +64,14 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void SimpleBatch()
         {
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
 
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.reportGroup = "Planets";
             authorization.orderId = "12344";
             authorization.amount = 106;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000001";
             card.expDate = "1210";
@@ -81,52 +79,52 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addAuthorization(authorization);
 
-            authorization authorization2 = new authorization();
+            var authorization2 = new authorization();
             authorization2.reportGroup = "Planets";
             authorization2.orderId = "12345";
             authorization2.amount = 106;
             authorization2.orderSource = orderSourceType.ecommerce;
-            cardType card2 = new cardType();
+            var card2 = new cardType();
             card2.type = methodOfPaymentTypeEnum.VI;
             card2.number = "4242424242424242";
             card2.expDate = "1210";
             authorization2.card = card2;
 
             litleBatchRequest.addAuthorization(authorization2);
-            
-            authReversal reversal = new authReversal();
+
+            var reversal = new authReversal();
             reversal.litleTxnId = 12345678000L;
             reversal.amount = 106;
             reversal.payPalNotes = "Notes";
 
             litleBatchRequest.addAuthReversal(reversal);
 
-            authReversal reversal2 = new authReversal();
+            var reversal2 = new authReversal();
             reversal2.litleTxnId = 12345678900L;
             reversal2.amount = 106;
             reversal2.payPalNotes = "Notes";
 
             litleBatchRequest.addAuthReversal(reversal2);
 
-            capture capture = new capture();
+            var capture = new capture();
             capture.litleTxnId = 123456000;
             capture.amount = 106;
             capture.payPalNotes = "Notes";
 
             litleBatchRequest.addCapture(capture);
 
-            capture capture2 = new capture();
+            var capture2 = new capture();
             capture2.litleTxnId = 123456700;
             capture2.amount = 106;
             capture2.payPalNotes = "Notes";
 
             litleBatchRequest.addCapture(capture2);
 
-            captureGivenAuth capturegivenauth = new captureGivenAuth();
+            var capturegivenauth = new captureGivenAuth();
             capturegivenauth.amount = 106;
             capturegivenauth.orderId = "12344";
-            authInformation authInfo = new authInformation();
-            DateTime authDate = new DateTime(2002, 10, 9);
+            var authInfo = new authInformation();
+            var authDate = new DateTime(2002, 10, 9);
             authInfo.authDate = authDate;
             authInfo.authCode = "543216";
             authInfo.authAmount = 12345;
@@ -136,10 +134,10 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addCaptureGivenAuth(capturegivenauth);
 
-            captureGivenAuth capturegivenauth2 = new captureGivenAuth();
+            var capturegivenauth2 = new captureGivenAuth();
             capturegivenauth2.amount = 106;
             capturegivenauth2.orderId = "12344";
-            authInformation authInfo2 = new authInformation();
+            var authInfo2 = new authInformation();
             authDate = new DateTime(2003, 10, 9);
             authInfo2.authDate = authDate;
             authInfo2.authCode = "543216";
@@ -150,7 +148,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addCaptureGivenAuth(capturegivenauth2);
 
-            credit creditObj = new credit();
+            var creditObj = new credit();
             creditObj.amount = 106;
             creditObj.orderId = "2111";
             creditObj.orderSource = orderSourceType.ecommerce;
@@ -158,7 +156,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addCredit(creditObj);
 
-            credit creditObj2 = new credit();
+            var creditObj2 = new credit();
             creditObj2.amount = 106;
             creditObj2.orderId = "2111";
             creditObj2.orderSource = orderSourceType.ecommerce;
@@ -166,17 +164,17 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addCredit(creditObj2);
 
-            echeckCredit echeckcredit = new echeckCredit();
+            var echeckcredit = new echeckCredit();
             echeckcredit.amount = 12L;
             echeckcredit.orderId = "12345";
             echeckcredit.orderSource = orderSourceType.ecommerce;
-            echeckType echeck = new echeckType();
+            var echeck = new echeckType();
             echeck.accType = echeckAccountTypeEnum.Checking;
             echeck.accNum = "1099999903";
             echeck.routingNum = "011201995";
             echeck.checkNum = "123455";
             echeckcredit.echeck = echeck;
-            contact billToAddress = new contact();
+            var billToAddress = new contact();
             billToAddress.name = "Bob";
             billToAddress.city = "Lowell";
             billToAddress.state = "MA";
@@ -185,17 +183,17 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addEcheckCredit(echeckcredit);
 
-            echeckCredit echeckcredit2 = new echeckCredit();
+            var echeckcredit2 = new echeckCredit();
             echeckcredit2.amount = 12L;
             echeckcredit2.orderId = "12346";
             echeckcredit2.orderSource = orderSourceType.ecommerce;
-            echeckType echeck2 = new echeckType();
+            var echeck2 = new echeckType();
             echeck2.accType = echeckAccountTypeEnum.Checking;
             echeck2.accNum = "1099999903";
             echeck2.routingNum = "011201995";
             echeck2.checkNum = "123456";
             echeckcredit2.echeck = echeck2;
-            contact billToAddress2 = new contact();
+            var billToAddress2 = new contact();
             billToAddress2.name = "Mike";
             billToAddress2.city = "Lowell";
             billToAddress2.state = "MA";
@@ -204,19 +202,19 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addEcheckCredit(echeckcredit2);
 
-            echeckRedeposit echeckredeposit = new echeckRedeposit();
+            var echeckredeposit = new echeckRedeposit();
             echeckredeposit.litleTxnId = 123456;
             echeckredeposit.echeck = echeck;
 
             litleBatchRequest.addEcheckRedeposit(echeckredeposit);
 
-            echeckRedeposit echeckredeposit2 = new echeckRedeposit();
+            var echeckredeposit2 = new echeckRedeposit();
             echeckredeposit2.litleTxnId = 123457;
             echeckredeposit2.echeck = echeck2;
 
             litleBatchRequest.addEcheckRedeposit(echeckredeposit2);
 
-            echeckSale echeckSaleObj = new echeckSale();
+            var echeckSaleObj = new echeckSale();
             echeckSaleObj.amount = 123456;
             echeckSaleObj.orderId = "12345";
             echeckSaleObj.orderSource = orderSourceType.ecommerce;
@@ -225,7 +223,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addEcheckSale(echeckSaleObj);
 
-            echeckSale echeckSaleObj2 = new echeckSale();
+            var echeckSaleObj2 = new echeckSale();
             echeckSaleObj2.amount = 123456;
             echeckSaleObj2.orderId = "12346";
             echeckSaleObj2.orderSource = orderSourceType.ecommerce;
@@ -234,7 +232,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addEcheckSale(echeckSaleObj2);
 
-            echeckPreNoteSale echeckPreNoteSaleObj1 = new echeckPreNoteSale();
+            var echeckPreNoteSaleObj1 = new echeckPreNoteSale();
             echeckPreNoteSaleObj1.orderId = "12345";
             echeckPreNoteSaleObj1.orderSource = orderSourceType.ecommerce;
             echeckPreNoteSaleObj1.echeck = echeck;
@@ -242,7 +240,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addEcheckPreNoteSale(echeckPreNoteSaleObj1);
 
-            echeckPreNoteSale echeckPreNoteSaleObj2 = new echeckPreNoteSale();
+            var echeckPreNoteSaleObj2 = new echeckPreNoteSale();
             echeckPreNoteSaleObj2.orderId = "12345";
             echeckPreNoteSaleObj2.orderSource = orderSourceType.ecommerce;
             echeckPreNoteSaleObj2.echeck = echeck2;
@@ -250,7 +248,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addEcheckPreNoteSale(echeckPreNoteSaleObj2);
 
-            echeckPreNoteCredit echeckPreNoteCreditObj1 = new echeckPreNoteCredit();
+            var echeckPreNoteCreditObj1 = new echeckPreNoteCredit();
             echeckPreNoteCreditObj1.orderId = "12345";
             echeckPreNoteCreditObj1.orderSource = orderSourceType.ecommerce;
             echeckPreNoteCreditObj1.echeck = echeck;
@@ -258,13 +256,13 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addEcheckPreNoteCredit(echeckPreNoteCreditObj1);
 
-            echeckPreNoteCredit echeckPreNoteCreditObj2 = new echeckPreNoteCredit();
+            var echeckPreNoteCreditObj2 = new echeckPreNoteCredit();
             echeckPreNoteCreditObj2.orderId = "12345";
             echeckPreNoteCreditObj2.orderSource = orderSourceType.ecommerce;
             echeckPreNoteCreditObj2.echeck = echeck2;
             echeckPreNoteCreditObj2.billToAddress = billToAddress2;
 
-            echeckVerification echeckVerificationObject = new echeckVerification();
+            var echeckVerificationObject = new echeckVerification();
             echeckVerificationObject.amount = 123456;
             echeckVerificationObject.orderId = "12345";
             echeckVerificationObject.orderSource = orderSourceType.ecommerce;
@@ -273,7 +271,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addEcheckVerification(echeckVerificationObject);
 
-            echeckVerification echeckVerificationObject2 = new echeckVerification();
+            var echeckVerificationObject2 = new echeckVerification();
             echeckVerificationObject2.amount = 123456;
             echeckVerificationObject2.orderId = "12346";
             echeckVerificationObject2.orderSource = orderSourceType.ecommerce;
@@ -282,7 +280,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addEcheckVerification(echeckVerificationObject2);
 
-            forceCapture forcecapture = new forceCapture();
+            var forcecapture = new forceCapture();
             forcecapture.amount = 106;
             forcecapture.orderId = "12344";
             forcecapture.orderSource = orderSourceType.ecommerce;
@@ -290,7 +288,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addForceCapture(forcecapture);
 
-            forceCapture forcecapture2 = new forceCapture();
+            var forcecapture2 = new forceCapture();
             forcecapture2.amount = 106;
             forcecapture2.orderId = "12345";
             forcecapture2.orderSource = orderSourceType.ecommerce;
@@ -298,7 +296,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addForceCapture(forcecapture2);
 
-            sale saleObj = new sale();
+            var saleObj = new sale();
             saleObj.amount = 106;
             saleObj.litleTxnId = 123456;
             saleObj.orderId = "12344";
@@ -307,7 +305,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addSale(saleObj);
 
-            sale saleObj2 = new sale();
+            var saleObj2 = new sale();
             saleObj2.amount = 106;
             saleObj2.litleTxnId = 123456;
             saleObj2.orderId = "12345";
@@ -316,28 +314,28 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addSale(saleObj2);
 
-            registerTokenRequestType registerTokenRequest = new registerTokenRequestType();
+            var registerTokenRequest = new registerTokenRequestType();
             registerTokenRequest.orderId = "12344";
             registerTokenRequest.accountNumber = "1233456789103801";
             registerTokenRequest.reportGroup = "Planets";
 
             litleBatchRequest.addRegisterTokenRequest(registerTokenRequest);
 
-            registerTokenRequestType registerTokenRequest2 = new registerTokenRequestType();
+            var registerTokenRequest2 = new registerTokenRequestType();
             registerTokenRequest2.orderId = "12345";
             registerTokenRequest2.accountNumber = "1233456789103801";
             registerTokenRequest2.reportGroup = "Planets";
 
             litleBatchRequest.addRegisterTokenRequest(registerTokenRequest2);
 
-            updateCardValidationNumOnToken updateCardValidationNumOnToken = new updateCardValidationNumOnToken();
+            var updateCardValidationNumOnToken = new updateCardValidationNumOnToken();
             updateCardValidationNumOnToken.orderId = "12344";
             updateCardValidationNumOnToken.cardValidationNum = "123";
             updateCardValidationNumOnToken.litleToken = "4100000000000001";
 
             litleBatchRequest.addUpdateCardValidationNumOnToken(updateCardValidationNumOnToken);
 
-            updateCardValidationNumOnToken updateCardValidationNumOnToken2 = new updateCardValidationNumOnToken();
+            var updateCardValidationNumOnToken2 = new updateCardValidationNumOnToken();
             updateCardValidationNumOnToken2.orderId = "12345";
             updateCardValidationNumOnToken2.cardValidationNum = "123";
             updateCardValidationNumOnToken2.litleToken = "4242424242424242";
@@ -345,20 +343,20 @@ namespace Litle.Sdk.Test.Functional
             litleBatchRequest.addUpdateCardValidationNumOnToken(updateCardValidationNumOnToken2);
             litle.addBatch(litleBatchRequest);
 
-            string batchName = litle.sendToLitle();
+            var batchName = litle.sendToLitle();
 
-            litle.blockAndWaitForResponse(batchName, estimatedResponseTime(2 * 2, 10 * 2));
+            litle.blockAndWaitForResponse(batchName, estimatedResponseTime(2*2, 10*2));
 
-            litleResponse litleResponse = litle.receiveFromLitle(batchName);
+            var litleResponse = litle.receiveFromLitle(batchName);
 
             Assert.NotNull(litleResponse);
             Assert.AreEqual("0", litleResponse.response);
             Assert.AreEqual("Valid Format", litleResponse.message);
 
-            batchResponse litleBatchResponse = litleResponse.nextBatchResponse();
+            var litleBatchResponse = litleResponse.nextBatchResponse();
             while (litleBatchResponse != null)
             {
-                authorizationResponse authorizationResponse = litleBatchResponse.nextAuthorizationResponse();
+                var authorizationResponse = litleBatchResponse.nextAuthorizationResponse();
                 while (authorizationResponse != null)
                 {
                     Assert.AreEqual("000", authorizationResponse.response);
@@ -366,7 +364,7 @@ namespace Litle.Sdk.Test.Functional
                     authorizationResponse = litleBatchResponse.nextAuthorizationResponse();
                 }
 
-                authReversalResponse authReversalResponse = litleBatchResponse.nextAuthReversalResponse();
+                var authReversalResponse = litleBatchResponse.nextAuthReversalResponse();
                 while (authReversalResponse != null)
                 {
                     Assert.AreEqual("360", authReversalResponse.response);
@@ -374,7 +372,7 @@ namespace Litle.Sdk.Test.Functional
                     authReversalResponse = litleBatchResponse.nextAuthReversalResponse();
                 }
 
-                captureResponse captureResponse = litleBatchResponse.nextCaptureResponse();
+                var captureResponse = litleBatchResponse.nextCaptureResponse();
                 while (captureResponse != null)
                 {
                     Assert.AreEqual("360", captureResponse.response);
@@ -382,7 +380,7 @@ namespace Litle.Sdk.Test.Functional
                     captureResponse = litleBatchResponse.nextCaptureResponse();
                 }
 
-                captureGivenAuthResponse captureGivenAuthResponse = litleBatchResponse.nextCaptureGivenAuthResponse();
+                var captureGivenAuthResponse = litleBatchResponse.nextCaptureGivenAuthResponse();
                 while (captureGivenAuthResponse != null)
                 {
                     Assert.AreEqual("000", captureGivenAuthResponse.response);
@@ -390,7 +388,7 @@ namespace Litle.Sdk.Test.Functional
                     captureGivenAuthResponse = litleBatchResponse.nextCaptureGivenAuthResponse();
                 }
 
-                creditResponse creditResponse = litleBatchResponse.nextCreditResponse();
+                var creditResponse = litleBatchResponse.nextCreditResponse();
                 while (creditResponse != null)
                 {
                     Assert.AreEqual("000", creditResponse.response);
@@ -398,7 +396,7 @@ namespace Litle.Sdk.Test.Functional
                     creditResponse = litleBatchResponse.nextCreditResponse();
                 }
 
-                echeckCreditResponse echeckCreditResponse = litleBatchResponse.nextEcheckCreditResponse();
+                var echeckCreditResponse = litleBatchResponse.nextEcheckCreditResponse();
                 while (echeckCreditResponse != null)
                 {
                     Assert.AreEqual("000", echeckCreditResponse.response);
@@ -406,7 +404,7 @@ namespace Litle.Sdk.Test.Functional
                     echeckCreditResponse = litleBatchResponse.nextEcheckCreditResponse();
                 }
 
-                echeckRedepositResponse echeckRedepositResponse = litleBatchResponse.nextEcheckRedepositResponse();
+                var echeckRedepositResponse = litleBatchResponse.nextEcheckRedepositResponse();
                 while (echeckRedepositResponse != null)
                 {
                     Assert.AreEqual("360", echeckRedepositResponse.response);
@@ -414,7 +412,7 @@ namespace Litle.Sdk.Test.Functional
                     echeckRedepositResponse = litleBatchResponse.nextEcheckRedepositResponse();
                 }
 
-                echeckSalesResponse echeckSalesResponse = litleBatchResponse.nextEcheckSalesResponse();
+                var echeckSalesResponse = litleBatchResponse.nextEcheckSalesResponse();
                 while (echeckSalesResponse != null)
                 {
                     Assert.AreEqual("000", echeckSalesResponse.response);
@@ -422,7 +420,7 @@ namespace Litle.Sdk.Test.Functional
                     echeckSalesResponse = litleBatchResponse.nextEcheckSalesResponse();
                 }
 
-                echeckPreNoteSaleResponse echeckPreNoteSaleResponse = litleBatchResponse.nextEcheckPreNoteSaleResponse();
+                var echeckPreNoteSaleResponse = litleBatchResponse.nextEcheckPreNoteSaleResponse();
                 while (echeckPreNoteSaleResponse != null)
                 {
                     Assert.AreEqual("000", echeckPreNoteSaleResponse.response);
@@ -430,7 +428,7 @@ namespace Litle.Sdk.Test.Functional
                     echeckPreNoteSaleResponse = litleBatchResponse.nextEcheckPreNoteSaleResponse();
                 }
 
-                echeckPreNoteCreditResponse echeckPreNoteCreditResponse = litleBatchResponse.nextEcheckPreNoteCreditResponse();
+                var echeckPreNoteCreditResponse = litleBatchResponse.nextEcheckPreNoteCreditResponse();
                 while (echeckPreNoteCreditResponse != null)
                 {
                     Assert.AreEqual("000", echeckPreNoteCreditResponse.response);
@@ -438,7 +436,7 @@ namespace Litle.Sdk.Test.Functional
                     echeckPreNoteCreditResponse = litleBatchResponse.nextEcheckPreNoteCreditResponse();
                 }
 
-                echeckVerificationResponse echeckVerificationResponse = litleBatchResponse.nextEcheckVerificationResponse();
+                var echeckVerificationResponse = litleBatchResponse.nextEcheckVerificationResponse();
                 while (echeckVerificationResponse != null)
                 {
                     Assert.AreEqual("957", echeckVerificationResponse.response);
@@ -446,7 +444,7 @@ namespace Litle.Sdk.Test.Functional
                     echeckVerificationResponse = litleBatchResponse.nextEcheckVerificationResponse();
                 }
 
-                forceCaptureResponse forceCaptureResponse = litleBatchResponse.nextForceCaptureResponse();
+                var forceCaptureResponse = litleBatchResponse.nextForceCaptureResponse();
                 while (forceCaptureResponse != null)
                 {
                     Assert.AreEqual("000", forceCaptureResponse.response);
@@ -454,7 +452,7 @@ namespace Litle.Sdk.Test.Functional
                     forceCaptureResponse = litleBatchResponse.nextForceCaptureResponse();
                 }
 
-                registerTokenResponse registerTokenResponse = litleBatchResponse.nextRegisterTokenResponse();
+                var registerTokenResponse = litleBatchResponse.nextRegisterTokenResponse();
                 while (registerTokenResponse != null)
                 {
                     Assert.AreEqual("820", registerTokenResponse.response);
@@ -462,7 +460,7 @@ namespace Litle.Sdk.Test.Functional
                     registerTokenResponse = litleBatchResponse.nextRegisterTokenResponse();
                 }
 
-                saleResponse saleResponse = litleBatchResponse.nextSaleResponse();
+                var saleResponse = litleBatchResponse.nextSaleResponse();
                 while (saleResponse != null)
                 {
                     Assert.AreEqual("000", saleResponse.response);
@@ -470,12 +468,14 @@ namespace Litle.Sdk.Test.Functional
                     saleResponse = litleBatchResponse.nextSaleResponse();
                 }
 
-                updateCardValidationNumOnTokenResponse updateCardValidationNumOnTokenResponse = litleBatchResponse.nextUpdateCardValidationNumOnTokenResponse();
+                var updateCardValidationNumOnTokenResponse =
+                    litleBatchResponse.nextUpdateCardValidationNumOnTokenResponse();
                 while (updateCardValidationNumOnTokenResponse != null)
                 {
                     Assert.AreEqual("823", updateCardValidationNumOnTokenResponse.response);
 
-                    updateCardValidationNumOnTokenResponse = litleBatchResponse.nextUpdateCardValidationNumOnTokenResponse();
+                    updateCardValidationNumOnTokenResponse =
+                        litleBatchResponse.nextUpdateCardValidationNumOnTokenResponse();
                 }
 
                 litleBatchResponse = litleResponse.nextBatchResponse();
@@ -485,11 +485,11 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void accountUpdateBatch()
         {
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
 
-            accountUpdate accountUpdate1 = new accountUpdate();
+            var accountUpdate1 = new accountUpdate();
             accountUpdate1.orderId = "1111";
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "414100000000000000";
             card.expDate = "1210";
@@ -497,27 +497,27 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addAccountUpdate(accountUpdate1);
 
-            accountUpdate accountUpdate2 = new accountUpdate();
+            var accountUpdate2 = new accountUpdate();
             accountUpdate2.orderId = "1112";
             accountUpdate2.card = card;
 
             litleBatchRequest.addAccountUpdate(accountUpdate2);
 
             litle.addBatch(litleBatchRequest);
-            string batchName = litle.sendToLitle();
+            var batchName = litle.sendToLitle();
 
-            litle.blockAndWaitForResponse(batchName, estimatedResponseTime(0, 1 * 2));
+            litle.blockAndWaitForResponse(batchName, estimatedResponseTime(0, 1*2));
 
-            litleResponse litleResponse = litle.receiveFromLitle(batchName);
+            var litleResponse = litle.receiveFromLitle(batchName);
 
             Assert.NotNull(litleResponse);
             Assert.AreEqual("0", litleResponse.response);
             Assert.AreEqual("Valid Format", litleResponse.message);
 
-            batchResponse litleBatchResponse = litleResponse.nextBatchResponse();
+            var litleBatchResponse = litleResponse.nextBatchResponse();
             while (litleBatchResponse != null)
             {
-                accountUpdateResponse accountUpdateResponse = litleBatchResponse.nextAccountUpdateResponse();
+                var accountUpdateResponse = litleBatchResponse.nextAccountUpdateResponse();
                 while (accountUpdateResponse != null)
                 {
                     Assert.AreEqual("301", accountUpdateResponse.response);
@@ -531,12 +531,12 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void RFRBatch()
         {
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
             litleBatchRequest.id = "1234567A";
 
-            accountUpdate accountUpdate1 = new accountUpdate();
+            var accountUpdate1 = new accountUpdate();
             accountUpdate1.orderId = "1111";
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4242424242424242";
             card.expDate = "1210";
@@ -544,24 +544,24 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addAccountUpdate(accountUpdate1);
 
-            accountUpdate accountUpdate2 = new accountUpdate();
+            var accountUpdate2 = new accountUpdate();
             accountUpdate2.orderId = "1112";
             accountUpdate2.card = card;
 
             litleBatchRequest.addAccountUpdate(accountUpdate2);
             litle.addBatch(litleBatchRequest);
 
-            string batchName = litle.sendToLitle();
-            litle.blockAndWaitForResponse(batchName, estimatedResponseTime(0, 1 * 2));
-            litleResponse litleResponse = litle.receiveFromLitle(batchName);
+            var batchName = litle.sendToLitle();
+            litle.blockAndWaitForResponse(batchName, estimatedResponseTime(0, 1*2));
+            var litleResponse = litle.receiveFromLitle(batchName);
 
             Assert.NotNull(litleResponse);
 
-            batchResponse litleBatchResponse = litleResponse.nextBatchResponse();
+            var litleBatchResponse = litleResponse.nextBatchResponse();
             Assert.NotNull(litleBatchResponse);
             while (litleBatchResponse != null)
             {
-                accountUpdateResponse accountUpdateResponse = litleBatchResponse.nextAccountUpdateResponse();
+                var accountUpdateResponse = litleBatchResponse.nextAccountUpdateResponse();
                 Assert.NotNull(accountUpdateResponse);
                 while (accountUpdateResponse != null)
                 {
@@ -572,28 +572,29 @@ namespace Litle.Sdk.Test.Functional
                 litleBatchResponse = litleResponse.nextBatchResponse();
             }
 
-            litleRequest litleRfr = new litleRequest(memoryStreams);
-            RFRRequest rfrRequest = new RFRRequest(memoryStreams);
-            accountUpdateFileRequestData accountUpdateFileRequestData = new accountUpdateFileRequestData();
-            accountUpdateFileRequestData.merchantId = Properties.Settings.Default.merchantId;
+            var litleRfr = new litleRequest(memoryStreams);
+            var rfrRequest = new RFRRequest(memoryStreams);
+            var accountUpdateFileRequestData = new accountUpdateFileRequestData();
+            accountUpdateFileRequestData.merchantId = Settings.Default.merchantId;
             accountUpdateFileRequestData.postDay = DateTime.Now;
             rfrRequest.accountUpdateFileRequestData = accountUpdateFileRequestData;
 
             litleRfr.addRFRRequest(rfrRequest);
 
-            string rfrBatchName = litleRfr.sendToLitle();
-            
+            var rfrBatchName = litleRfr.sendToLitle();
+
             try
             {
                 litle.blockAndWaitForResponse(rfrBatchName, 120000);
-                litleResponse litleRfrResponse = litle.receiveFromLitle(rfrBatchName);
+                var litleRfrResponse = litle.receiveFromLitle(rfrBatchName);
                 Assert.NotNull(litleRfrResponse);
-                RFRResponse rfrResponse = litleRfrResponse.nextRFRResponse();
+                var rfrResponse = litleRfrResponse.nextRFRResponse();
                 Assert.NotNull(rfrResponse);
                 while (rfrResponse != null)
                 {
                     Assert.AreEqual("1", rfrResponse.response);
-                    Assert.AreEqual("The account update file is not ready yet.  Please try again later.", rfrResponse.message);
+                    Assert.AreEqual("The account update file is not ready yet.  Please try again later.",
+                        rfrResponse.message);
                     rfrResponse = litleResponse.nextRFRResponse();
                 }
             }
@@ -605,14 +606,14 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void nullBatchData()
         {
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
 
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.reportGroup = "Planets";
             authorization.orderId = "12344";
             authorization.amount = 106;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "414100000000000000";
             card.expDate = "1210";
@@ -623,12 +624,12 @@ namespace Litle.Sdk.Test.Functional
             {
                 litleBatchRequest.addAuthorization(null);
             }
-            catch (System.NullReferenceException e)
+            catch (NullReferenceException e)
             {
                 Assert.AreEqual("Object reference not set to an instance of an object.", e.Message);
             }
 
-            authReversal reversal = new authReversal();
+            var reversal = new authReversal();
             reversal.litleTxnId = 12345678000L;
             reversal.amount = 106;
             reversal.payPalNotes = "Notes";
@@ -638,12 +639,12 @@ namespace Litle.Sdk.Test.Functional
             {
                 litleBatchRequest.addAuthReversal(null);
             }
-            catch (System.NullReferenceException e)
+            catch (NullReferenceException e)
             {
                 Assert.AreEqual("Object reference not set to an instance of an object.", e.Message);
             }
 
-            capture capture = new capture();
+            var capture = new capture();
             capture.litleTxnId = 123456000;
             capture.amount = 106;
             capture.payPalNotes = "Notes";
@@ -653,16 +654,16 @@ namespace Litle.Sdk.Test.Functional
             {
                 litleBatchRequest.addCapture(null);
             }
-            catch (System.NullReferenceException e)
+            catch (NullReferenceException e)
             {
                 Assert.AreEqual("Object reference not set to an instance of an object.", e.Message);
             }
 
-            captureGivenAuth capturegivenauth = new captureGivenAuth();
+            var capturegivenauth = new captureGivenAuth();
             capturegivenauth.amount = 106;
             capturegivenauth.orderId = "12344";
-            authInformation authInfo = new authInformation();
-            DateTime authDate = new DateTime(2002, 10, 9);
+            var authInfo = new authInformation();
+            var authDate = new DateTime(2002, 10, 9);
             authInfo.authDate = authDate;
             authInfo.authCode = "543216";
             authInfo.authAmount = 12345;
@@ -675,12 +676,12 @@ namespace Litle.Sdk.Test.Functional
             {
                 litleBatchRequest.addCaptureGivenAuth(null);
             }
-            catch (System.NullReferenceException e)
+            catch (NullReferenceException e)
             {
                 Assert.AreEqual("Object reference not set to an instance of an object.", e.Message);
             }
 
-            credit creditObj = new credit();
+            var creditObj = new credit();
             creditObj.amount = 106;
             creditObj.orderId = "2111";
             creditObj.orderSource = orderSourceType.ecommerce;
@@ -691,22 +692,22 @@ namespace Litle.Sdk.Test.Functional
             {
                 litleBatchRequest.addCredit(null);
             }
-            catch (System.NullReferenceException e)
+            catch (NullReferenceException e)
             {
                 Assert.AreEqual("Object reference not set to an instance of an object.", e.Message);
             }
 
-            echeckCredit echeckcredit = new echeckCredit();
+            var echeckcredit = new echeckCredit();
             echeckcredit.amount = 12L;
             echeckcredit.orderId = "12345";
             echeckcredit.orderSource = orderSourceType.ecommerce;
-            echeckType echeck = new echeckType();
+            var echeck = new echeckType();
             echeck.accType = echeckAccountTypeEnum.Checking;
             echeck.accNum = "12345657890";
             echeck.routingNum = "011201995";
             echeck.checkNum = "123455";
             echeckcredit.echeck = echeck;
-            contact billToAddress = new contact();
+            var billToAddress = new contact();
             billToAddress.name = "Bob";
             billToAddress.city = "Lowell";
             billToAddress.state = "MA";
@@ -718,12 +719,12 @@ namespace Litle.Sdk.Test.Functional
             {
                 litleBatchRequest.addEcheckCredit(null);
             }
-            catch (System.NullReferenceException e)
+            catch (NullReferenceException e)
             {
                 Assert.AreEqual("Object reference not set to an instance of an object.", e.Message);
             }
 
-            echeckRedeposit echeckredeposit = new echeckRedeposit();
+            var echeckredeposit = new echeckRedeposit();
             echeckredeposit.litleTxnId = 123456;
             echeckredeposit.echeck = echeck;
 
@@ -732,12 +733,12 @@ namespace Litle.Sdk.Test.Functional
             {
                 litleBatchRequest.addEcheckRedeposit(null);
             }
-            catch (System.NullReferenceException e)
+            catch (NullReferenceException e)
             {
                 Assert.AreEqual("Object reference not set to an instance of an object.", e.Message);
             }
 
-            echeckSale echeckSaleObj = new echeckSale();
+            var echeckSaleObj = new echeckSale();
             echeckSaleObj.amount = 123456;
             echeckSaleObj.orderId = "12345";
             echeckSaleObj.orderSource = orderSourceType.ecommerce;
@@ -749,12 +750,12 @@ namespace Litle.Sdk.Test.Functional
             {
                 litleBatchRequest.addEcheckSale(null);
             }
-            catch (System.NullReferenceException e)
+            catch (NullReferenceException e)
             {
                 Assert.AreEqual("Object reference not set to an instance of an object.", e.Message);
             }
 
-            echeckVerification echeckVerificationObject = new echeckVerification();
+            var echeckVerificationObject = new echeckVerification();
             echeckVerificationObject.amount = 123456;
             echeckVerificationObject.orderId = "12345";
             echeckVerificationObject.orderSource = orderSourceType.ecommerce;
@@ -766,12 +767,12 @@ namespace Litle.Sdk.Test.Functional
             {
                 litleBatchRequest.addEcheckVerification(null);
             }
-            catch (System.NullReferenceException e)
+            catch (NullReferenceException e)
             {
                 Assert.AreEqual("Object reference not set to an instance of an object.", e.Message);
             }
 
-            forceCapture forcecapture = new forceCapture();
+            var forcecapture = new forceCapture();
             forcecapture.amount = 106;
             forcecapture.orderId = "12344";
             forcecapture.orderSource = orderSourceType.ecommerce;
@@ -782,12 +783,12 @@ namespace Litle.Sdk.Test.Functional
             {
                 litleBatchRequest.addForceCapture(null);
             }
-            catch (System.NullReferenceException e)
+            catch (NullReferenceException e)
             {
                 Assert.AreEqual("Object reference not set to an instance of an object.", e.Message);
             }
 
-            sale saleObj = new sale();
+            var saleObj = new sale();
             saleObj.amount = 106;
             saleObj.litleTxnId = 123456;
             saleObj.orderId = "12344";
@@ -799,12 +800,12 @@ namespace Litle.Sdk.Test.Functional
             {
                 litleBatchRequest.addSale(null);
             }
-            catch (System.NullReferenceException e)
+            catch (NullReferenceException e)
             {
                 Assert.AreEqual("Object reference not set to an instance of an object.", e.Message);
             }
 
-            registerTokenRequestType registerTokenRequest = new registerTokenRequestType();
+            var registerTokenRequest = new registerTokenRequestType();
             registerTokenRequest.orderId = "12344";
             registerTokenRequest.accountNumber = "1233456789103801";
             registerTokenRequest.reportGroup = "Planets";
@@ -814,7 +815,7 @@ namespace Litle.Sdk.Test.Functional
             {
                 litleBatchRequest.addRegisterTokenRequest(null);
             }
-            catch (System.NullReferenceException e)
+            catch (NullReferenceException e)
             {
                 Assert.AreEqual("Object reference not set to an instance of an object.", e.Message);
             }
@@ -823,7 +824,7 @@ namespace Litle.Sdk.Test.Functional
             {
                 litle.addBatch(litleBatchRequest);
             }
-            catch (System.NullReferenceException e)
+            catch (NullReferenceException e)
             {
                 Assert.AreEqual("Object reference not set to an instance of an object.", e.Message);
             }
@@ -832,16 +833,16 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void InvalidCredientialsBatch()
         {
-            litleRequest litleIC = new litleRequest(memoryStreams, invalidConfig);
+            var litleIC = new litleRequest(memoryStreams, invalidConfig);
 
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
 
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.reportGroup = "Planets";
             authorization.orderId = "12344";
             authorization.amount = 106;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000001";
             card.expDate = "1210";
@@ -849,12 +850,12 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addAuthorization(authorization);
 
-            authorization authorization2 = new authorization();
+            var authorization2 = new authorization();
             authorization2.reportGroup = "Planets";
             authorization2.orderId = "12345";
             authorization2.amount = 106;
             authorization2.orderSource = orderSourceType.ecommerce;
-            cardType card2 = new cardType();
+            var card2 = new cardType();
             card2.type = methodOfPaymentTypeEnum.VI;
             card2.number = "4242424242424242";
             card2.expDate = "1210";
@@ -862,39 +863,39 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addAuthorization(authorization2);
 
-            authReversal reversal = new authReversal();
+            var reversal = new authReversal();
             reversal.litleTxnId = 12345678000L;
             reversal.amount = 106;
             reversal.payPalNotes = "Notes";
 
             litleBatchRequest.addAuthReversal(reversal);
 
-            authReversal reversal2 = new authReversal();
+            var reversal2 = new authReversal();
             reversal2.litleTxnId = 12345678900L;
             reversal2.amount = 106;
             reversal2.payPalNotes = "Notes";
 
             litleBatchRequest.addAuthReversal(reversal2);
 
-            capture capture = new capture();
+            var capture = new capture();
             capture.litleTxnId = 123456000;
             capture.amount = 106;
             capture.payPalNotes = "Notes";
 
             litleBatchRequest.addCapture(capture);
 
-            capture capture2 = new capture();
+            var capture2 = new capture();
             capture2.litleTxnId = 123456700;
             capture2.amount = 106;
             capture2.payPalNotes = "Notes";
 
             litleBatchRequest.addCapture(capture2);
 
-            captureGivenAuth capturegivenauth = new captureGivenAuth();
+            var capturegivenauth = new captureGivenAuth();
             capturegivenauth.amount = 106;
             capturegivenauth.orderId = "12344";
-            authInformation authInfo = new authInformation();
-            DateTime authDate = new DateTime(2002, 10, 9);
+            var authInfo = new authInformation();
+            var authDate = new DateTime(2002, 10, 9);
             authInfo.authDate = authDate;
             authInfo.authCode = "543216";
             authInfo.authAmount = 12345;
@@ -904,10 +905,10 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addCaptureGivenAuth(capturegivenauth);
 
-            captureGivenAuth capturegivenauth2 = new captureGivenAuth();
+            var capturegivenauth2 = new captureGivenAuth();
             capturegivenauth2.amount = 106;
             capturegivenauth2.orderId = "12344";
-            authInformation authInfo2 = new authInformation();
+            var authInfo2 = new authInformation();
             authDate = new DateTime(2003, 10, 9);
             authInfo2.authDate = authDate;
             authInfo2.authCode = "543216";
@@ -918,7 +919,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addCaptureGivenAuth(capturegivenauth2);
 
-            credit creditObj = new credit();
+            var creditObj = new credit();
             creditObj.amount = 106;
             creditObj.orderId = "2111";
             creditObj.orderSource = orderSourceType.ecommerce;
@@ -926,7 +927,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addCredit(creditObj);
 
-            credit creditObj2 = new credit();
+            var creditObj2 = new credit();
             creditObj2.amount = 106;
             creditObj2.orderId = "2111";
             creditObj2.orderSource = orderSourceType.ecommerce;
@@ -934,17 +935,17 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addCredit(creditObj2);
 
-            echeckCredit echeckcredit = new echeckCredit();
+            var echeckcredit = new echeckCredit();
             echeckcredit.amount = 12L;
             echeckcredit.orderId = "12345";
             echeckcredit.orderSource = orderSourceType.ecommerce;
-            echeckType echeck = new echeckType();
+            var echeck = new echeckType();
             echeck.accType = echeckAccountTypeEnum.Checking;
             echeck.accNum = "1099999903";
             echeck.routingNum = "011201995";
             echeck.checkNum = "123455";
             echeckcredit.echeck = echeck;
-            contact billToAddress = new contact();
+            var billToAddress = new contact();
             billToAddress.name = "Bob";
             billToAddress.city = "Lowell";
             billToAddress.state = "MA";
@@ -953,17 +954,17 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addEcheckCredit(echeckcredit);
 
-            echeckCredit echeckcredit2 = new echeckCredit();
+            var echeckcredit2 = new echeckCredit();
             echeckcredit2.amount = 12L;
             echeckcredit2.orderId = "12346";
             echeckcredit2.orderSource = orderSourceType.ecommerce;
-            echeckType echeck2 = new echeckType();
+            var echeck2 = new echeckType();
             echeck2.accType = echeckAccountTypeEnum.Checking;
             echeck2.accNum = "1099999903";
             echeck2.routingNum = "011201995";
             echeck2.checkNum = "123456";
             echeckcredit2.echeck = echeck2;
-            contact billToAddress2 = new contact();
+            var billToAddress2 = new contact();
             billToAddress2.name = "Mike";
             billToAddress2.city = "Lowell";
             billToAddress2.state = "MA";
@@ -972,19 +973,19 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addEcheckCredit(echeckcredit2);
 
-            echeckRedeposit echeckredeposit = new echeckRedeposit();
+            var echeckredeposit = new echeckRedeposit();
             echeckredeposit.litleTxnId = 123456;
             echeckredeposit.echeck = echeck;
 
             litleBatchRequest.addEcheckRedeposit(echeckredeposit);
 
-            echeckRedeposit echeckredeposit2 = new echeckRedeposit();
+            var echeckredeposit2 = new echeckRedeposit();
             echeckredeposit2.litleTxnId = 123457;
             echeckredeposit2.echeck = echeck2;
 
             litleBatchRequest.addEcheckRedeposit(echeckredeposit2);
 
-            echeckSale echeckSaleObj = new echeckSale();
+            var echeckSaleObj = new echeckSale();
             echeckSaleObj.amount = 123456;
             echeckSaleObj.orderId = "12345";
             echeckSaleObj.orderSource = orderSourceType.ecommerce;
@@ -993,7 +994,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addEcheckSale(echeckSaleObj);
 
-            echeckSale echeckSaleObj2 = new echeckSale();
+            var echeckSaleObj2 = new echeckSale();
             echeckSaleObj2.amount = 123456;
             echeckSaleObj2.orderId = "12346";
             echeckSaleObj2.orderSource = orderSourceType.ecommerce;
@@ -1002,7 +1003,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addEcheckSale(echeckSaleObj2);
 
-            echeckVerification echeckVerificationObject = new echeckVerification();
+            var echeckVerificationObject = new echeckVerification();
             echeckVerificationObject.amount = 123456;
             echeckVerificationObject.orderId = "12345";
             echeckVerificationObject.orderSource = orderSourceType.ecommerce;
@@ -1011,7 +1012,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addEcheckVerification(echeckVerificationObject);
 
-            echeckVerification echeckVerificationObject2 = new echeckVerification();
+            var echeckVerificationObject2 = new echeckVerification();
             echeckVerificationObject2.amount = 123456;
             echeckVerificationObject2.orderId = "12346";
             echeckVerificationObject2.orderSource = orderSourceType.ecommerce;
@@ -1020,7 +1021,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addEcheckVerification(echeckVerificationObject2);
 
-            forceCapture forcecapture = new forceCapture();
+            var forcecapture = new forceCapture();
             forcecapture.amount = 106;
             forcecapture.orderId = "12344";
             forcecapture.orderSource = orderSourceType.ecommerce;
@@ -1028,7 +1029,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addForceCapture(forcecapture);
 
-            forceCapture forcecapture2 = new forceCapture();
+            var forcecapture2 = new forceCapture();
             forcecapture2.amount = 106;
             forcecapture2.orderId = "12345";
             forcecapture2.orderSource = orderSourceType.ecommerce;
@@ -1036,7 +1037,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addForceCapture(forcecapture2);
 
-            sale saleObj = new sale();
+            var saleObj = new sale();
             saleObj.amount = 106;
             saleObj.litleTxnId = 123456;
             saleObj.orderId = "12344";
@@ -1045,7 +1046,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addSale(saleObj);
 
-            sale saleObj2 = new sale();
+            var saleObj2 = new sale();
             saleObj2.amount = 106;
             saleObj2.litleTxnId = 123456;
             saleObj2.orderId = "12345";
@@ -1054,14 +1055,14 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addSale(saleObj2);
 
-            registerTokenRequestType registerTokenRequest = new registerTokenRequestType();
+            var registerTokenRequest = new registerTokenRequestType();
             registerTokenRequest.orderId = "12344";
             registerTokenRequest.accountNumber = "1233456789103801";
             registerTokenRequest.reportGroup = "Planets";
 
             litleBatchRequest.addRegisterTokenRequest(registerTokenRequest);
 
-            registerTokenRequestType registerTokenRequest2 = new registerTokenRequestType();
+            var registerTokenRequest2 = new registerTokenRequestType();
             registerTokenRequest2.orderId = "12345";
             registerTokenRequest2.accountNumber = "1233456789103801";
             registerTokenRequest2.reportGroup = "Planets";
@@ -1070,13 +1071,13 @@ namespace Litle.Sdk.Test.Functional
 
             litleIC.addBatch(litleBatchRequest);
 
-            string batchName = litleIC.sendToLitle();
+            var batchName = litleIC.sendToLitle();
 
             litleIC.blockAndWaitForResponse(batchName, 60*1000*5);
 
             try
             {
-                litleResponse litleResponse = litleIC.receiveFromLitle(batchName);
+                var litleResponse = litleIC.receiveFromLitle(batchName);
                 Assert.Fail("Fail to throw a connection exception");
             }
             catch (LitleOnlineException e)
@@ -1088,16 +1089,16 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void InvalidSftpCredientialsBatch()
         {
-            litleRequest litleISC = new litleRequest(memoryStreams, invalidSftpConfig);
+            var litleISC = new litleRequest(memoryStreams, invalidSftpConfig);
 
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
 
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.reportGroup = "Planets";
             authorization.orderId = "12344";
             authorization.amount = 106;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000001";
             card.expDate = "1210";
@@ -1105,12 +1106,12 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addAuthorization(authorization);
 
-            authorization authorization2 = new authorization();
+            var authorization2 = new authorization();
             authorization2.reportGroup = "Planets";
             authorization2.orderId = "12345";
             authorization2.amount = 106;
             authorization2.orderSource = orderSourceType.ecommerce;
-            cardType card2 = new cardType();
+            var card2 = new cardType();
             card2.type = methodOfPaymentTypeEnum.VI;
             card2.number = "4242424242424242";
             card2.expDate = "1210";
@@ -1118,39 +1119,39 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addAuthorization(authorization2);
 
-            authReversal reversal = new authReversal();
+            var reversal = new authReversal();
             reversal.litleTxnId = 12345678000L;
             reversal.amount = 106;
             reversal.payPalNotes = "Notes";
 
             litleBatchRequest.addAuthReversal(reversal);
 
-            authReversal reversal2 = new authReversal();
+            var reversal2 = new authReversal();
             reversal2.litleTxnId = 12345678900L;
             reversal2.amount = 106;
             reversal2.payPalNotes = "Notes";
 
             litleBatchRequest.addAuthReversal(reversal2);
 
-            capture capture = new capture();
+            var capture = new capture();
             capture.litleTxnId = 123456000;
             capture.amount = 106;
             capture.payPalNotes = "Notes";
 
             litleBatchRequest.addCapture(capture);
 
-            capture capture2 = new capture();
+            var capture2 = new capture();
             capture2.litleTxnId = 123456700;
             capture2.amount = 106;
             capture2.payPalNotes = "Notes";
 
             litleBatchRequest.addCapture(capture2);
 
-            captureGivenAuth capturegivenauth = new captureGivenAuth();
+            var capturegivenauth = new captureGivenAuth();
             capturegivenauth.amount = 106;
             capturegivenauth.orderId = "12344";
-            authInformation authInfo = new authInformation();
-            DateTime authDate = new DateTime(2002, 10, 9);
+            var authInfo = new authInformation();
+            var authDate = new DateTime(2002, 10, 9);
             authInfo.authDate = authDate;
             authInfo.authCode = "543216";
             authInfo.authAmount = 12345;
@@ -1160,10 +1161,10 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addCaptureGivenAuth(capturegivenauth);
 
-            captureGivenAuth capturegivenauth2 = new captureGivenAuth();
+            var capturegivenauth2 = new captureGivenAuth();
             capturegivenauth2.amount = 106;
             capturegivenauth2.orderId = "12344";
-            authInformation authInfo2 = new authInformation();
+            var authInfo2 = new authInformation();
             authDate = new DateTime(2003, 10, 9);
             authInfo2.authDate = authDate;
             authInfo2.authCode = "543216";
@@ -1174,7 +1175,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addCaptureGivenAuth(capturegivenauth2);
 
-            credit creditObj = new credit();
+            var creditObj = new credit();
             creditObj.amount = 106;
             creditObj.orderId = "2111";
             creditObj.orderSource = orderSourceType.ecommerce;
@@ -1182,7 +1183,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addCredit(creditObj);
 
-            credit creditObj2 = new credit();
+            var creditObj2 = new credit();
             creditObj2.amount = 106;
             creditObj2.orderId = "2111";
             creditObj2.orderSource = orderSourceType.ecommerce;
@@ -1190,17 +1191,17 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addCredit(creditObj2);
 
-            echeckCredit echeckcredit = new echeckCredit();
+            var echeckcredit = new echeckCredit();
             echeckcredit.amount = 12L;
             echeckcredit.orderId = "12345";
             echeckcredit.orderSource = orderSourceType.ecommerce;
-            echeckType echeck = new echeckType();
+            var echeck = new echeckType();
             echeck.accType = echeckAccountTypeEnum.Checking;
             echeck.accNum = "1099999903";
             echeck.routingNum = "011201995";
             echeck.checkNum = "123455";
             echeckcredit.echeck = echeck;
-            contact billToAddress = new contact();
+            var billToAddress = new contact();
             billToAddress.name = "Bob";
             billToAddress.city = "Lowell";
             billToAddress.state = "MA";
@@ -1209,17 +1210,17 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addEcheckCredit(echeckcredit);
 
-            echeckCredit echeckcredit2 = new echeckCredit();
+            var echeckcredit2 = new echeckCredit();
             echeckcredit2.amount = 12L;
             echeckcredit2.orderId = "12346";
             echeckcredit2.orderSource = orderSourceType.ecommerce;
-            echeckType echeck2 = new echeckType();
+            var echeck2 = new echeckType();
             echeck2.accType = echeckAccountTypeEnum.Checking;
             echeck2.accNum = "1099999903";
             echeck2.routingNum = "011201995";
             echeck2.checkNum = "123456";
             echeckcredit2.echeck = echeck2;
-            contact billToAddress2 = new contact();
+            var billToAddress2 = new contact();
             billToAddress2.name = "Mike";
             billToAddress2.city = "Lowell";
             billToAddress2.state = "MA";
@@ -1228,19 +1229,19 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addEcheckCredit(echeckcredit2);
 
-            echeckRedeposit echeckredeposit = new echeckRedeposit();
+            var echeckredeposit = new echeckRedeposit();
             echeckredeposit.litleTxnId = 123456;
             echeckredeposit.echeck = echeck;
 
             litleBatchRequest.addEcheckRedeposit(echeckredeposit);
 
-            echeckRedeposit echeckredeposit2 = new echeckRedeposit();
+            var echeckredeposit2 = new echeckRedeposit();
             echeckredeposit2.litleTxnId = 123457;
             echeckredeposit2.echeck = echeck2;
 
             litleBatchRequest.addEcheckRedeposit(echeckredeposit2);
 
-            echeckSale echeckSaleObj = new echeckSale();
+            var echeckSaleObj = new echeckSale();
             echeckSaleObj.amount = 123456;
             echeckSaleObj.orderId = "12345";
             echeckSaleObj.orderSource = orderSourceType.ecommerce;
@@ -1249,7 +1250,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addEcheckSale(echeckSaleObj);
 
-            echeckSale echeckSaleObj2 = new echeckSale();
+            var echeckSaleObj2 = new echeckSale();
             echeckSaleObj2.amount = 123456;
             echeckSaleObj2.orderId = "12346";
             echeckSaleObj2.orderSource = orderSourceType.ecommerce;
@@ -1258,7 +1259,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addEcheckSale(echeckSaleObj2);
 
-            echeckVerification echeckVerificationObject = new echeckVerification();
+            var echeckVerificationObject = new echeckVerification();
             echeckVerificationObject.amount = 123456;
             echeckVerificationObject.orderId = "12345";
             echeckVerificationObject.orderSource = orderSourceType.ecommerce;
@@ -1267,7 +1268,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addEcheckVerification(echeckVerificationObject);
 
-            echeckVerification echeckVerificationObject2 = new echeckVerification();
+            var echeckVerificationObject2 = new echeckVerification();
             echeckVerificationObject2.amount = 123456;
             echeckVerificationObject2.orderId = "12346";
             echeckVerificationObject2.orderSource = orderSourceType.ecommerce;
@@ -1276,7 +1277,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addEcheckVerification(echeckVerificationObject2);
 
-            forceCapture forcecapture = new forceCapture();
+            var forcecapture = new forceCapture();
             forcecapture.amount = 106;
             forcecapture.orderId = "12344";
             forcecapture.orderSource = orderSourceType.ecommerce;
@@ -1284,7 +1285,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addForceCapture(forcecapture);
 
-            forceCapture forcecapture2 = new forceCapture();
+            var forcecapture2 = new forceCapture();
             forcecapture2.amount = 106;
             forcecapture2.orderId = "12345";
             forcecapture2.orderSource = orderSourceType.ecommerce;
@@ -1292,7 +1293,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addForceCapture(forcecapture2);
 
-            sale saleObj = new sale();
+            var saleObj = new sale();
             saleObj.amount = 106;
             saleObj.litleTxnId = 123456;
             saleObj.orderId = "12344";
@@ -1301,7 +1302,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addSale(saleObj);
 
-            sale saleObj2 = new sale();
+            var saleObj2 = new sale();
             saleObj2.amount = 106;
             saleObj2.litleTxnId = 123456;
             saleObj2.orderId = "12345";
@@ -1310,14 +1311,14 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addSale(saleObj2);
 
-            registerTokenRequestType registerTokenRequest = new registerTokenRequestType();
+            var registerTokenRequest = new registerTokenRequestType();
             registerTokenRequest.orderId = "12344";
             registerTokenRequest.accountNumber = "1233456789103801";
             registerTokenRequest.reportGroup = "Planets";
 
             litleBatchRequest.addRegisterTokenRequest(registerTokenRequest);
 
-            registerTokenRequestType registerTokenRequest2 = new registerTokenRequestType();
+            var registerTokenRequest2 = new registerTokenRequestType();
             registerTokenRequest2.orderId = "12345";
             registerTokenRequest2.accountNumber = "1233456789103801";
             registerTokenRequest2.reportGroup = "Planets";
@@ -1328,7 +1329,7 @@ namespace Litle.Sdk.Test.Functional
 
             try
             {
-                string batchName = litleISC.sendToLitle();
+                var batchName = litleISC.sendToLitle();
                 Assert.Fail("Fail to throw a connection exception");
             }
             catch (LitleOnlineException e)
@@ -1340,14 +1341,14 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void SimpleBatchWithSpecialCharacters()
         {
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
 
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.reportGroup = "<ReportGroup>";
             authorization.orderId = "12344&'\"";
             authorization.amount = 106;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000001";
             card.expDate = "1210";
@@ -1357,20 +1358,20 @@ namespace Litle.Sdk.Test.Functional
 
             litle.addBatch(litleBatchRequest);
 
-            string batchName = litle.sendToLitle();
+            var batchName = litle.sendToLitle();
 
-            litle.blockAndWaitForResponse(batchName, estimatedResponseTime(2 * 2, 10 * 2));
+            litle.blockAndWaitForResponse(batchName, estimatedResponseTime(2*2, 10*2));
 
-            litleResponse litleResponse = litle.receiveFromLitle(batchName);
+            var litleResponse = litle.receiveFromLitle(batchName);
 
             Assert.NotNull(litleResponse);
             Assert.AreEqual("0", litleResponse.response);
             Assert.AreEqual("Valid Format", litleResponse.message);
 
-            batchResponse litleBatchResponse = litleResponse.nextBatchResponse();
+            var litleBatchResponse = litleResponse.nextBatchResponse();
             while (litleBatchResponse != null)
             {
-                authorizationResponse authorizationResponse = litleBatchResponse.nextAuthorizationResponse();
+                var authorizationResponse = litleBatchResponse.nextAuthorizationResponse();
                 while (authorizationResponse != null)
                 {
                     Assert.AreEqual("000", authorizationResponse.response);
@@ -1384,7 +1385,7 @@ namespace Litle.Sdk.Test.Functional
 
         private int estimatedResponseTime(int numAuthsAndSales, int numRest)
         {
-            return (int)(5 * 60 * 1000 + 2.5 * 1000 + numAuthsAndSales * (1 / 5) * 1000 + numRest * (1 / 50) * 1000) * 5;
+            return (int) (5*60*1000 + 2.5*1000 + numAuthsAndSales*(1/5)*1000 + numRest*(1/50)*1000)*5;
         }
     }
 }

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestBatch.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestBatch.cs
@@ -13,10 +13,13 @@ namespace Litle.Sdk.Test.Functional
         private litleRequest litle;
         private Dictionary<String, String> invalidConfig;
         private Dictionary<String, String> invalidSftpConfig;
+        private IDictionary<string, StringBuilder> memoryStreams;
 
         [TestFixtureSetUp]
         public void setUp()
         {
+            memoryStreams = new Dictionary<string, StringBuilder>();
+
             invalidConfig = new Dictionary<String, String>();
             invalidConfig["url"] = Properties.Settings.Default.url;
             invalidConfig["reportGroup"] = Properties.Settings.Default.reportGroup;
@@ -57,13 +60,13 @@ namespace Litle.Sdk.Test.Functional
         [SetUp]
         public void setUpBeforeTest()
         {
-            litle = new litleRequest();
+            litle = new litleRequest(memoryStreams);
         }
 
         [Test]
         public void SimpleBatch()
         {
-            batchRequest litleBatchRequest = new batchRequest();
+            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
 
             authorization authorization = new authorization();
             authorization.reportGroup = "Planets";
@@ -482,7 +485,7 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void accountUpdateBatch()
         {
-            batchRequest litleBatchRequest = new batchRequest();
+            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
 
             accountUpdate accountUpdate1 = new accountUpdate();
             accountUpdate1.orderId = "1111";
@@ -528,7 +531,7 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void RFRBatch()
         {
-            batchRequest litleBatchRequest = new batchRequest();
+            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
             litleBatchRequest.id = "1234567A";
 
             accountUpdate accountUpdate1 = new accountUpdate();
@@ -569,8 +572,8 @@ namespace Litle.Sdk.Test.Functional
                 litleBatchResponse = litleResponse.nextBatchResponse();
             }
 
-            litleRequest litleRfr = new litleRequest();
-            RFRRequest rfrRequest = new RFRRequest();
+            litleRequest litleRfr = new litleRequest(memoryStreams);
+            RFRRequest rfrRequest = new RFRRequest(memoryStreams);
             accountUpdateFileRequestData accountUpdateFileRequestData = new accountUpdateFileRequestData();
             accountUpdateFileRequestData.merchantId = Properties.Settings.Default.merchantId;
             accountUpdateFileRequestData.postDay = DateTime.Now;
@@ -602,7 +605,7 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void nullBatchData()
         {
-            batchRequest litleBatchRequest = new batchRequest();
+            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
 
             authorization authorization = new authorization();
             authorization.reportGroup = "Planets";
@@ -829,9 +832,9 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void InvalidCredientialsBatch()
         {
-            litleRequest litleIC = new litleRequest(invalidConfig);
+            litleRequest litleIC = new litleRequest(memoryStreams, invalidConfig);
 
-            batchRequest litleBatchRequest = new batchRequest();
+            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
 
             authorization authorization = new authorization();
             authorization.reportGroup = "Planets";
@@ -1085,9 +1088,9 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void InvalidSftpCredientialsBatch()
         {
-            litleRequest litleISC = new litleRequest(invalidSftpConfig);
+            litleRequest litleISC = new litleRequest(memoryStreams, invalidSftpConfig);
 
-            batchRequest litleBatchRequest = new batchRequest();
+            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
 
             authorization authorization = new authorization();
             authorization.reportGroup = "Planets";
@@ -1337,7 +1340,7 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void SimpleBatchWithSpecialCharacters()
         {
-            batchRequest litleBatchRequest = new batchRequest();
+            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
 
             authorization authorization = new authorization();
             authorization.reportGroup = "<ReportGroup>";

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestBatchStream.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestBatchStream.cs
@@ -1069,7 +1069,27 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void EcheckPreNoteTestAll()
         {
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var memoryStream = new Dictionary<string, StringBuilder>();
+
+            Dictionary<string, string> configOverride = new Dictionary<string, string>();
+            configOverride["url"] = Properties.Settings.Default.url;
+            configOverride["reportGroup"] = Properties.Settings.Default.reportGroup;
+            configOverride["username"] = "BATCHSDKA";
+            configOverride["printxml"] = Properties.Settings.Default.printxml;
+            configOverride["timeout"] = Properties.Settings.Default.timeout;
+            configOverride["proxyHost"] = Properties.Settings.Default.proxyHost;
+            configOverride["merchantId"] = "0180";
+            configOverride["password"] = "certpass";
+            configOverride["proxyPort"] = Properties.Settings.Default.proxyPort;
+            configOverride["sftpUrl"] = Properties.Settings.Default.sftpUrl;
+            configOverride["sftpUsername"] = Properties.Settings.Default.sftpUsername;
+            configOverride["sftpPassword"] = Properties.Settings.Default.sftpPassword;
+            configOverride["knownHostsFile"] = Properties.Settings.Default.knownHostsFile;
+            configOverride["onlineBatchUrl"] = Properties.Settings.Default.onlineBatchUrl;
+            configOverride["onlineBatchPort"] = Properties.Settings.Default.onlineBatchPort;
+            configOverride["requestDirectory"] = Properties.Settings.Default.requestDirectory;
+            configOverride["responseDirectory"] = Properties.Settings.Default.responseDirectory;
+            batchRequest litleBatchRequest = new batchRequest(memoryStreams, configOverride);
 
             contact billToAddress = new contact();
             billToAddress.name = "Mike";

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestBatchStream.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestBatchStream.cs
@@ -1069,27 +1069,7 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void EcheckPreNoteTestAll()
         {
-            var memoryStream = new Dictionary<string, StringBuilder>();
-
-            Dictionary<string, string> configOverride = new Dictionary<string, string>();
-            configOverride["url"] = Properties.Settings.Default.url;
-            configOverride["reportGroup"] = Properties.Settings.Default.reportGroup;
-            configOverride["username"] = "BATCHSDKA";
-            configOverride["printxml"] = Properties.Settings.Default.printxml;
-            configOverride["timeout"] = Properties.Settings.Default.timeout;
-            configOverride["proxyHost"] = Properties.Settings.Default.proxyHost;
-            configOverride["merchantId"] = "0180";
-            configOverride["password"] = "certpass";
-            configOverride["proxyPort"] = Properties.Settings.Default.proxyPort;
-            configOverride["sftpUrl"] = Properties.Settings.Default.sftpUrl;
-            configOverride["sftpUsername"] = Properties.Settings.Default.sftpUsername;
-            configOverride["sftpPassword"] = Properties.Settings.Default.sftpPassword;
-            configOverride["knownHostsFile"] = Properties.Settings.Default.knownHostsFile;
-            configOverride["onlineBatchUrl"] = Properties.Settings.Default.onlineBatchUrl;
-            configOverride["onlineBatchPort"] = Properties.Settings.Default.onlineBatchPort;
-            configOverride["requestDirectory"] = Properties.Settings.Default.requestDirectory;
-            configOverride["responseDirectory"] = Properties.Settings.Default.responseDirectory;
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams, configOverride);
+            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
 
             contact billToAddress = new contact();
             billToAddress.name = "Mike";

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestBatchStream.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestBatchStream.cs
@@ -1,56 +1,53 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Litle.Sdk.Properties;
 using NUnit.Framework;
-using Litle.Sdk;
-using System.IO;
-using System.Xml;
 
 namespace Litle.Sdk.Test.Functional
 {
     [TestFixture]
-    class TestBatchStream
+    internal class TestBatchStream
     {
         private litleRequest litle;
-        private Dictionary<String, String> invalidConfig;
-        private Dictionary<String, String> invalidSftpConfig;
-        private Dictionary<String, StringBuilder> memoryStreams;
+        private Dictionary<string, string> invalidConfig;
+        private Dictionary<string, string> invalidSftpConfig;
+        private Dictionary<string, StringBuilder> memoryStreams;
 
         [TestFixtureSetUp]
         public void setUp()
         {
             memoryStreams = new Dictionary<string, StringBuilder>();
-            invalidConfig = new Dictionary<String, String>();
-            invalidConfig["url"] = Properties.Settings.Default.url;
-            invalidConfig["reportGroup"] = Properties.Settings.Default.reportGroup;
+            invalidConfig = new Dictionary<string, string>();
+            invalidConfig["url"] = Settings.Default.url;
+            invalidConfig["reportGroup"] = Settings.Default.reportGroup;
             invalidConfig["username"] = "badUsername";
-            invalidConfig["printxml"] = Properties.Settings.Default.printxml;
-            invalidConfig["timeout"] = Properties.Settings.Default.timeout;
-            invalidConfig["proxyHost"] = Properties.Settings.Default.proxyHost;
-            invalidConfig["merchantId"] = Properties.Settings.Default.merchantId;
+            invalidConfig["printxml"] = Settings.Default.printxml;
+            invalidConfig["timeout"] = Settings.Default.timeout;
+            invalidConfig["proxyHost"] = Settings.Default.proxyHost;
+            invalidConfig["merchantId"] = Settings.Default.merchantId;
             invalidConfig["password"] = "badPassword";
-            invalidConfig["proxyPort"] = Properties.Settings.Default.proxyPort;
-            invalidConfig["sftpUrl"] = Properties.Settings.Default.sftpUrl;
-            invalidConfig["sftpUsername"] = Properties.Settings.Default.sftpUrl;
-            invalidConfig["sftpPassword"] = Properties.Settings.Default.sftpPassword;
-            invalidConfig["knownHostsFile"] = Properties.Settings.Default.knownHostsFile;
-            
+            invalidConfig["proxyPort"] = Settings.Default.proxyPort;
+            invalidConfig["sftpUrl"] = Settings.Default.sftpUrl;
+            invalidConfig["sftpUsername"] = Settings.Default.sftpUrl;
+            invalidConfig["sftpPassword"] = Settings.Default.sftpPassword;
+            invalidConfig["knownHostsFile"] = Settings.Default.knownHostsFile;
 
-            invalidSftpConfig = new Dictionary<String, String>();
-            invalidSftpConfig["url"] = Properties.Settings.Default.url;
-            invalidSftpConfig["reportGroup"] = Properties.Settings.Default.reportGroup;
-            invalidSftpConfig["username"] = Properties.Settings.Default.username;
-            invalidSftpConfig["printxml"] = Properties.Settings.Default.printxml;
-            invalidSftpConfig["timeout"] = Properties.Settings.Default.timeout;
-            invalidSftpConfig["proxyHost"] = Properties.Settings.Default.proxyHost;
-            invalidSftpConfig["merchantId"] = Properties.Settings.Default.merchantId;
-            invalidSftpConfig["password"] = Properties.Settings.Default.password;
-            invalidSftpConfig["proxyPort"] = Properties.Settings.Default.proxyPort;
-            invalidSftpConfig["sftpUrl"] = Properties.Settings.Default.sftpUrl;
+
+            invalidSftpConfig = new Dictionary<string, string>();
+            invalidSftpConfig["url"] = Settings.Default.url;
+            invalidSftpConfig["reportGroup"] = Settings.Default.reportGroup;
+            invalidSftpConfig["username"] = Settings.Default.username;
+            invalidSftpConfig["printxml"] = Settings.Default.printxml;
+            invalidSftpConfig["timeout"] = Settings.Default.timeout;
+            invalidSftpConfig["proxyHost"] = Settings.Default.proxyHost;
+            invalidSftpConfig["merchantId"] = Settings.Default.merchantId;
+            invalidSftpConfig["password"] = Settings.Default.password;
+            invalidSftpConfig["proxyPort"] = Settings.Default.proxyPort;
+            invalidSftpConfig["sftpUrl"] = Settings.Default.sftpUrl;
             invalidSftpConfig["sftpUsername"] = "badSftpUsername";
             invalidSftpConfig["sftpPassword"] = "badSftpPassword";
-            invalidSftpConfig["knownHostsFile"] = Properties.Settings.Default.knownHostsFile;
-            
+            invalidSftpConfig["knownHostsFile"] = Settings.Default.knownHostsFile;
         }
 
         [SetUp]
@@ -63,67 +60,67 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void SimpleBatch()
         {
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
 
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.reportGroup = "Planets";
             authorization.orderId = "12344";
             authorization.amount = 106;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000001";
             card.expDate = "1210";
-            authorization.card = card;       
+            authorization.card = card;
 
             litleBatchRequest.addAuthorization(authorization);
 
-            authorization authorization2 = new authorization();
+            var authorization2 = new authorization();
             authorization2.reportGroup = "Planets";
             authorization2.orderId = "12345";
             authorization2.amount = 106;
             authorization2.orderSource = orderSourceType.ecommerce;
-            cardType card2 = new cardType();
+            var card2 = new cardType();
             card2.type = methodOfPaymentTypeEnum.VI;
             card2.number = "4242424242424242";
             card2.expDate = "1210";
-            authorization2.card = card2; 
+            authorization2.card = card2;
 
             litleBatchRequest.addAuthorization(authorization2);
 
-            authReversal reversal = new authReversal();
+            var reversal = new authReversal();
             reversal.litleTxnId = 12345678000L;
             reversal.amount = 106;
             reversal.payPalNotes = "Notes";
 
             litleBatchRequest.addAuthReversal(reversal);
 
-            authReversal reversal2 = new authReversal();
+            var reversal2 = new authReversal();
             reversal2.litleTxnId = 12345678900L;
             reversal2.amount = 106;
             reversal2.payPalNotes = "Notes";
 
             litleBatchRequest.addAuthReversal(reversal2);
 
-            capture capture = new capture();
+            var capture = new capture();
             capture.litleTxnId = 123456000;
             capture.amount = 106;
             capture.payPalNotes = "Notes";
 
             litleBatchRequest.addCapture(capture);
 
-            capture capture2 = new capture();
+            var capture2 = new capture();
             capture2.litleTxnId = 123456700;
             capture2.amount = 106;
             capture2.payPalNotes = "Notes";
 
             litleBatchRequest.addCapture(capture2);
 
-            captureGivenAuth capturegivenauth = new captureGivenAuth();
+            var capturegivenauth = new captureGivenAuth();
             capturegivenauth.amount = 106;
             capturegivenauth.orderId = "12344";
-            authInformation authInfo = new authInformation();
-            DateTime authDate = new DateTime(2002, 10, 9);
+            var authInfo = new authInformation();
+            var authDate = new DateTime(2002, 10, 9);
             authInfo.authDate = authDate;
             authInfo.authCode = "543216";
             authInfo.authAmount = 12345;
@@ -133,10 +130,10 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addCaptureGivenAuth(capturegivenauth);
 
-            captureGivenAuth capturegivenauth2 = new captureGivenAuth();
+            var capturegivenauth2 = new captureGivenAuth();
             capturegivenauth2.amount = 106;
             capturegivenauth2.orderId = "12344";
-            authInformation authInfo2 = new authInformation();
+            var authInfo2 = new authInformation();
             authDate = new DateTime(2003, 10, 9);
             authInfo2.authDate = authDate;
             authInfo2.authCode = "543216";
@@ -147,7 +144,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addCaptureGivenAuth(capturegivenauth2);
 
-            credit creditObj = new credit();
+            var creditObj = new credit();
             creditObj.amount = 106;
             creditObj.orderId = "2111";
             creditObj.orderSource = orderSourceType.ecommerce;
@@ -155,7 +152,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addCredit(creditObj);
 
-            credit creditObj2 = new credit();
+            var creditObj2 = new credit();
             creditObj2.amount = 106;
             creditObj2.orderId = "2111";
             creditObj2.orderSource = orderSourceType.ecommerce;
@@ -163,17 +160,17 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addCredit(creditObj2);
 
-            echeckCredit echeckcredit = new echeckCredit();
+            var echeckcredit = new echeckCredit();
             echeckcredit.amount = 12L;
             echeckcredit.orderId = "12345";
             echeckcredit.orderSource = orderSourceType.ecommerce;
-            echeckType echeck = new echeckType();
+            var echeck = new echeckType();
             echeck.accType = echeckAccountTypeEnum.Checking;
             echeck.accNum = "1099999903";
             echeck.routingNum = "011201995";
             echeck.checkNum = "123455";
             echeckcredit.echeck = echeck;
-            contact billToAddress = new contact();
+            var billToAddress = new contact();
             billToAddress.name = "Bob";
             billToAddress.city = "Lowell";
             billToAddress.state = "MA";
@@ -182,17 +179,17 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addEcheckCredit(echeckcredit);
 
-            echeckCredit echeckcredit2 = new echeckCredit();
+            var echeckcredit2 = new echeckCredit();
             echeckcredit2.amount = 12L;
             echeckcredit2.orderId = "12346";
             echeckcredit2.orderSource = orderSourceType.ecommerce;
-            echeckType echeck2 = new echeckType();
+            var echeck2 = new echeckType();
             echeck2.accType = echeckAccountTypeEnum.Checking;
             echeck2.accNum = "1099999903";
             echeck2.routingNum = "011201995";
             echeck2.checkNum = "123456";
             echeckcredit2.echeck = echeck2;
-            contact billToAddress2 = new contact();
+            var billToAddress2 = new contact();
             billToAddress2.name = "Mike";
             billToAddress2.city = "Lowell";
             billToAddress2.state = "MA";
@@ -201,19 +198,19 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addEcheckCredit(echeckcredit2);
 
-            echeckRedeposit echeckredeposit = new echeckRedeposit();
+            var echeckredeposit = new echeckRedeposit();
             echeckredeposit.litleTxnId = 123456;
             echeckredeposit.echeck = echeck;
 
             litleBatchRequest.addEcheckRedeposit(echeckredeposit);
 
-            echeckRedeposit echeckredeposit2 = new echeckRedeposit();
+            var echeckredeposit2 = new echeckRedeposit();
             echeckredeposit2.litleTxnId = 123457;
             echeckredeposit2.echeck = echeck2;
 
             litleBatchRequest.addEcheckRedeposit(echeckredeposit2);
 
-            echeckSale echeckSaleObj = new echeckSale();
+            var echeckSaleObj = new echeckSale();
             echeckSaleObj.amount = 123456;
             echeckSaleObj.orderId = "12345";
             echeckSaleObj.orderSource = orderSourceType.ecommerce;
@@ -222,7 +219,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addEcheckSale(echeckSaleObj);
 
-            echeckSale echeckSaleObj2 = new echeckSale();
+            var echeckSaleObj2 = new echeckSale();
             echeckSaleObj2.amount = 123456;
             echeckSaleObj2.orderId = "12346";
             echeckSaleObj2.orderSource = orderSourceType.ecommerce;
@@ -231,7 +228,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addEcheckSale(echeckSaleObj2);
 
-            echeckPreNoteSale echeckPreNoteSaleObj1 = new echeckPreNoteSale();
+            var echeckPreNoteSaleObj1 = new echeckPreNoteSale();
             echeckPreNoteSaleObj1.orderId = "12345";
             echeckPreNoteSaleObj1.orderSource = orderSourceType.ecommerce;
             echeckPreNoteSaleObj1.echeck = echeck;
@@ -239,7 +236,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addEcheckPreNoteSale(echeckPreNoteSaleObj1);
 
-            echeckPreNoteSale echeckPreNoteSaleObj2 = new echeckPreNoteSale();
+            var echeckPreNoteSaleObj2 = new echeckPreNoteSale();
             echeckPreNoteSaleObj2.orderId = "12345";
             echeckPreNoteSaleObj2.orderSource = orderSourceType.ecommerce;
             echeckPreNoteSaleObj2.echeck = echeck2;
@@ -247,7 +244,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addEcheckPreNoteSale(echeckPreNoteSaleObj2);
 
-            echeckPreNoteCredit echeckPreNoteCreditObj1 = new echeckPreNoteCredit();
+            var echeckPreNoteCreditObj1 = new echeckPreNoteCredit();
             echeckPreNoteCreditObj1.orderId = "12345";
             echeckPreNoteCreditObj1.orderSource = orderSourceType.ecommerce;
             echeckPreNoteCreditObj1.echeck = echeck;
@@ -255,7 +252,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addEcheckPreNoteCredit(echeckPreNoteCreditObj1);
 
-            echeckPreNoteCredit echeckPreNoteCreditObj2 = new echeckPreNoteCredit();
+            var echeckPreNoteCreditObj2 = new echeckPreNoteCredit();
             echeckPreNoteCreditObj2.orderId = "12345";
             echeckPreNoteCreditObj2.orderSource = orderSourceType.ecommerce;
             echeckPreNoteCreditObj2.echeck = echeck2;
@@ -263,7 +260,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addEcheckPreNoteCredit(echeckPreNoteCreditObj2);
 
-            echeckVerification echeckVerificationObject = new echeckVerification();
+            var echeckVerificationObject = new echeckVerification();
             echeckVerificationObject.amount = 123456;
             echeckVerificationObject.orderId = "12345";
             echeckVerificationObject.orderSource = orderSourceType.ecommerce;
@@ -272,7 +269,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addEcheckVerification(echeckVerificationObject);
 
-            echeckVerification echeckVerificationObject2 = new echeckVerification();
+            var echeckVerificationObject2 = new echeckVerification();
             echeckVerificationObject2.amount = 123456;
             echeckVerificationObject2.orderId = "12346";
             echeckVerificationObject2.orderSource = orderSourceType.ecommerce;
@@ -281,7 +278,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addEcheckVerification(echeckVerificationObject2);
 
-            forceCapture forcecapture = new forceCapture();
+            var forcecapture = new forceCapture();
             forcecapture.amount = 106;
             forcecapture.orderId = "12344";
             forcecapture.orderSource = orderSourceType.ecommerce;
@@ -289,7 +286,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addForceCapture(forcecapture);
 
-            forceCapture forcecapture2 = new forceCapture();
+            var forcecapture2 = new forceCapture();
             forcecapture2.amount = 106;
             forcecapture2.orderId = "12345";
             forcecapture2.orderSource = orderSourceType.ecommerce;
@@ -297,7 +294,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addForceCapture(forcecapture2);
 
-            sale saleObj = new sale();
+            var saleObj = new sale();
             saleObj.amount = 106;
             saleObj.litleTxnId = 123456;
             saleObj.orderId = "12344";
@@ -306,7 +303,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addSale(saleObj);
 
-            sale saleObj2 = new sale();
+            var saleObj2 = new sale();
             saleObj2.amount = 106;
             saleObj2.litleTxnId = 123456;
             saleObj2.orderId = "12345";
@@ -315,28 +312,28 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addSale(saleObj2);
 
-            registerTokenRequestType registerTokenRequest = new registerTokenRequestType();
+            var registerTokenRequest = new registerTokenRequestType();
             registerTokenRequest.orderId = "12344";
             registerTokenRequest.accountNumber = "1233456789103801";
             registerTokenRequest.reportGroup = "Planets";
 
             litleBatchRequest.addRegisterTokenRequest(registerTokenRequest);
 
-            registerTokenRequestType registerTokenRequest2 = new registerTokenRequestType();
+            var registerTokenRequest2 = new registerTokenRequestType();
             registerTokenRequest2.orderId = "12345";
             registerTokenRequest2.accountNumber = "1233456789103801";
             registerTokenRequest2.reportGroup = "Planets";
 
             litleBatchRequest.addRegisterTokenRequest(registerTokenRequest2);
 
-            updateCardValidationNumOnToken updateCardValidationNumOnToken = new updateCardValidationNumOnToken();
+            var updateCardValidationNumOnToken = new updateCardValidationNumOnToken();
             updateCardValidationNumOnToken.orderId = "12344";
             updateCardValidationNumOnToken.cardValidationNum = "123";
             updateCardValidationNumOnToken.litleToken = "4100000000000001";
 
             litleBatchRequest.addUpdateCardValidationNumOnToken(updateCardValidationNumOnToken);
 
-            updateCardValidationNumOnToken updateCardValidationNumOnToken2 = new updateCardValidationNumOnToken();
+            var updateCardValidationNumOnToken2 = new updateCardValidationNumOnToken();
             updateCardValidationNumOnToken2.orderId = "12345";
             updateCardValidationNumOnToken2.cardValidationNum = "123";
             updateCardValidationNumOnToken2.litleToken = "4242424242424242";
@@ -344,16 +341,16 @@ namespace Litle.Sdk.Test.Functional
             litleBatchRequest.addUpdateCardValidationNumOnToken(updateCardValidationNumOnToken2);
             litle.addBatch(litleBatchRequest);
 
-            litleResponse litleResponse = litle.sendToLitleWithStream();
+            var litleResponse = litle.sendToLitleWithStream();
 
             Assert.NotNull(litleResponse);
             Assert.AreEqual("0", litleResponse.response);
             Assert.AreEqual("Valid Format", litleResponse.message);
 
-            batchResponse litleBatchResponse = litleResponse.nextBatchResponse();
+            var litleBatchResponse = litleResponse.nextBatchResponse();
             while (litleBatchResponse != null)
             {
-                authorizationResponse authorizationResponse = litleBatchResponse.nextAuthorizationResponse();
+                var authorizationResponse = litleBatchResponse.nextAuthorizationResponse();
                 while (authorizationResponse != null)
                 {
                     Assert.AreEqual("000", authorizationResponse.response);
@@ -361,7 +358,7 @@ namespace Litle.Sdk.Test.Functional
                     authorizationResponse = litleBatchResponse.nextAuthorizationResponse();
                 }
 
-                authReversalResponse authReversalResponse = litleBatchResponse.nextAuthReversalResponse();
+                var authReversalResponse = litleBatchResponse.nextAuthReversalResponse();
                 while (authReversalResponse != null)
                 {
                     Assert.AreEqual("360", authReversalResponse.response);
@@ -369,7 +366,7 @@ namespace Litle.Sdk.Test.Functional
                     authReversalResponse = litleBatchResponse.nextAuthReversalResponse();
                 }
 
-                captureResponse captureResponse = litleBatchResponse.nextCaptureResponse();
+                var captureResponse = litleBatchResponse.nextCaptureResponse();
                 while (captureResponse != null)
                 {
                     Assert.AreEqual("360", captureResponse.response);
@@ -377,7 +374,7 @@ namespace Litle.Sdk.Test.Functional
                     captureResponse = litleBatchResponse.nextCaptureResponse();
                 }
 
-                captureGivenAuthResponse captureGivenAuthResponse = litleBatchResponse.nextCaptureGivenAuthResponse();
+                var captureGivenAuthResponse = litleBatchResponse.nextCaptureGivenAuthResponse();
                 while (captureGivenAuthResponse != null)
                 {
                     Assert.AreEqual("000", captureGivenAuthResponse.response);
@@ -385,7 +382,7 @@ namespace Litle.Sdk.Test.Functional
                     captureGivenAuthResponse = litleBatchResponse.nextCaptureGivenAuthResponse();
                 }
 
-                creditResponse creditResponse = litleBatchResponse.nextCreditResponse();
+                var creditResponse = litleBatchResponse.nextCreditResponse();
                 while (creditResponse != null)
                 {
                     Assert.AreEqual("000", creditResponse.response);
@@ -393,7 +390,7 @@ namespace Litle.Sdk.Test.Functional
                     creditResponse = litleBatchResponse.nextCreditResponse();
                 }
 
-                echeckCreditResponse echeckCreditResponse = litleBatchResponse.nextEcheckCreditResponse();
+                var echeckCreditResponse = litleBatchResponse.nextEcheckCreditResponse();
                 while (echeckCreditResponse != null)
                 {
                     Assert.AreEqual("000", echeckCreditResponse.response);
@@ -401,7 +398,7 @@ namespace Litle.Sdk.Test.Functional
                     echeckCreditResponse = litleBatchResponse.nextEcheckCreditResponse();
                 }
 
-                echeckRedepositResponse echeckRedepositResponse = litleBatchResponse.nextEcheckRedepositResponse();
+                var echeckRedepositResponse = litleBatchResponse.nextEcheckRedepositResponse();
                 while (echeckRedepositResponse != null)
                 {
                     Assert.AreEqual("360", echeckRedepositResponse.response);
@@ -409,7 +406,7 @@ namespace Litle.Sdk.Test.Functional
                     echeckRedepositResponse = litleBatchResponse.nextEcheckRedepositResponse();
                 }
 
-                echeckSalesResponse echeckSalesResponse = litleBatchResponse.nextEcheckSalesResponse();
+                var echeckSalesResponse = litleBatchResponse.nextEcheckSalesResponse();
                 while (echeckSalesResponse != null)
                 {
                     Assert.AreEqual("000", echeckSalesResponse.response);
@@ -417,7 +414,7 @@ namespace Litle.Sdk.Test.Functional
                     echeckSalesResponse = litleBatchResponse.nextEcheckSalesResponse();
                 }
 
-                echeckPreNoteSaleResponse echeckPreNoteSaleResponse = litleBatchResponse.nextEcheckPreNoteSaleResponse();
+                var echeckPreNoteSaleResponse = litleBatchResponse.nextEcheckPreNoteSaleResponse();
                 while (echeckPreNoteSaleResponse != null)
                 {
                     Assert.AreEqual("000", echeckPreNoteSaleResponse.response);
@@ -425,7 +422,7 @@ namespace Litle.Sdk.Test.Functional
                     echeckPreNoteSaleResponse = litleBatchResponse.nextEcheckPreNoteSaleResponse();
                 }
 
-                echeckPreNoteCreditResponse echeckPreNoteCreditResponse = litleBatchResponse.nextEcheckPreNoteCreditResponse();
+                var echeckPreNoteCreditResponse = litleBatchResponse.nextEcheckPreNoteCreditResponse();
                 while (echeckPreNoteCreditResponse != null)
                 {
                     Assert.AreEqual("000", echeckPreNoteCreditResponse.response);
@@ -433,7 +430,7 @@ namespace Litle.Sdk.Test.Functional
                     echeckPreNoteCreditResponse = litleBatchResponse.nextEcheckPreNoteCreditResponse();
                 }
 
-                echeckVerificationResponse echeckVerificationResponse = litleBatchResponse.nextEcheckVerificationResponse();
+                var echeckVerificationResponse = litleBatchResponse.nextEcheckVerificationResponse();
                 while (echeckVerificationResponse != null)
                 {
                     Assert.AreEqual("957", echeckVerificationResponse.response);
@@ -441,7 +438,7 @@ namespace Litle.Sdk.Test.Functional
                     echeckVerificationResponse = litleBatchResponse.nextEcheckVerificationResponse();
                 }
 
-                forceCaptureResponse forceCaptureResponse = litleBatchResponse.nextForceCaptureResponse();
+                var forceCaptureResponse = litleBatchResponse.nextForceCaptureResponse();
                 while (forceCaptureResponse != null)
                 {
                     Assert.AreEqual("000", forceCaptureResponse.response);
@@ -449,7 +446,7 @@ namespace Litle.Sdk.Test.Functional
                     forceCaptureResponse = litleBatchResponse.nextForceCaptureResponse();
                 }
 
-                registerTokenResponse registerTokenResponse = litleBatchResponse.nextRegisterTokenResponse();
+                var registerTokenResponse = litleBatchResponse.nextRegisterTokenResponse();
                 while (registerTokenResponse != null)
                 {
                     Assert.AreEqual("820", registerTokenResponse.response);
@@ -457,7 +454,7 @@ namespace Litle.Sdk.Test.Functional
                     registerTokenResponse = litleBatchResponse.nextRegisterTokenResponse();
                 }
 
-                saleResponse saleResponse = litleBatchResponse.nextSaleResponse();
+                var saleResponse = litleBatchResponse.nextSaleResponse();
                 while (saleResponse != null)
                 {
                     Assert.AreEqual("000", saleResponse.response);
@@ -465,12 +462,14 @@ namespace Litle.Sdk.Test.Functional
                     saleResponse = litleBatchResponse.nextSaleResponse();
                 }
 
-                updateCardValidationNumOnTokenResponse updateCardValidationNumOnTokenResponse = litleBatchResponse.nextUpdateCardValidationNumOnTokenResponse();
+                var updateCardValidationNumOnTokenResponse =
+                    litleBatchResponse.nextUpdateCardValidationNumOnTokenResponse();
                 while (updateCardValidationNumOnTokenResponse != null)
                 {
                     Assert.AreEqual("823", updateCardValidationNumOnTokenResponse.response);
 
-                    updateCardValidationNumOnTokenResponse = litleBatchResponse.nextUpdateCardValidationNumOnTokenResponse();
+                    updateCardValidationNumOnTokenResponse =
+                        litleBatchResponse.nextUpdateCardValidationNumOnTokenResponse();
                 }
 
                 litleBatchResponse = litleResponse.nextBatchResponse();
@@ -480,11 +479,11 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void accountUpdateBatch()
         {
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
 
-            accountUpdate accountUpdate1 = new accountUpdate();
+            var accountUpdate1 = new accountUpdate();
             accountUpdate1.orderId = "1111";
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "414100000000000000";
             card.expDate = "1210";
@@ -492,23 +491,23 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addAccountUpdate(accountUpdate1);
 
-            accountUpdate accountUpdate2 = new accountUpdate();
+            var accountUpdate2 = new accountUpdate();
             accountUpdate2.orderId = "1112";
             accountUpdate2.card = card;
 
             litleBatchRequest.addAccountUpdate(accountUpdate2);
 
             litle.addBatch(litleBatchRequest);
-            litleResponse litleResponse = litle.sendToLitleWithStream();
+            var litleResponse = litle.sendToLitleWithStream();
 
             Assert.NotNull(litleResponse);
             Assert.AreEqual("0", litleResponse.response);
             Assert.AreEqual("Valid Format", litleResponse.message);
 
-            batchResponse litleBatchResponse = litleResponse.nextBatchResponse();
+            var litleBatchResponse = litleResponse.nextBatchResponse();
             while (litleBatchResponse != null)
             {
-                accountUpdateResponse accountUpdateResponse = litleBatchResponse.nextAccountUpdateResponse();
+                var accountUpdateResponse = litleBatchResponse.nextAccountUpdateResponse();
                 Assert.NotNull(accountUpdateResponse);
                 while (accountUpdateResponse != null)
                 {
@@ -523,12 +522,12 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void RFRBatch()
         {
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
             litleBatchRequest.id = "1234567A";
 
-            accountUpdate accountUpdate1 = new accountUpdate();
+            var accountUpdate1 = new accountUpdate();
             accountUpdate1.orderId = "1111";
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4242424242424242";
             card.expDate = "1210";
@@ -536,22 +535,22 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addAccountUpdate(accountUpdate1);
 
-            accountUpdate accountUpdate2 = new accountUpdate();
+            var accountUpdate2 = new accountUpdate();
             accountUpdate2.orderId = "1112";
             accountUpdate2.card = card;
 
             litleBatchRequest.addAccountUpdate(accountUpdate2);
 
             litle.addBatch(litleBatchRequest);
-            litleResponse litleResponse = litle.sendToLitleWithStream();
+            var litleResponse = litle.sendToLitleWithStream();
 
             Assert.NotNull(litleResponse);
 
-            batchResponse litleBatchResponse = litleResponse.nextBatchResponse();
+            var litleBatchResponse = litleResponse.nextBatchResponse();
             Assert.NotNull(litleBatchResponse);
             while (litleBatchResponse != null)
             {
-                accountUpdateResponse accountUpdateResponse = litleBatchResponse.nextAccountUpdateResponse();
+                var accountUpdateResponse = litleBatchResponse.nextAccountUpdateResponse();
                 Assert.NotNull(accountUpdateResponse);
                 while (accountUpdateResponse != null)
                 {
@@ -562,26 +561,27 @@ namespace Litle.Sdk.Test.Functional
                 litleBatchResponse = litleResponse.nextBatchResponse();
             }
 
-            litleRequest litleRfr = new litleRequest(memoryStreams);
-            RFRRequest rfrRequest = new RFRRequest(memoryStreams);
-            accountUpdateFileRequestData accountUpdateFileRequestData = new accountUpdateFileRequestData();
-            accountUpdateFileRequestData.merchantId = Properties.Settings.Default.merchantId;
+            var litleRfr = new litleRequest(memoryStreams);
+            var rfrRequest = new RFRRequest(memoryStreams);
+            var accountUpdateFileRequestData = new accountUpdateFileRequestData();
+            accountUpdateFileRequestData.merchantId = Settings.Default.merchantId;
             accountUpdateFileRequestData.postDay = DateTime.Now;
             rfrRequest.accountUpdateFileRequestData = accountUpdateFileRequestData;
 
-            litleRfr.addRFRRequest(rfrRequest);            
+            litleRfr.addRFRRequest(rfrRequest);
 
             try
             {
-                litleResponse litleRfrResponse = litleRfr.sendToLitleWithStream();
+                var litleRfrResponse = litleRfr.sendToLitleWithStream();
                 Assert.NotNull(litleRfrResponse);
 
-                RFRResponse rfrResponse = litleRfrResponse.nextRFRResponse();
+                var rfrResponse = litleRfrResponse.nextRFRResponse();
                 Assert.NotNull(rfrResponse);
                 while (rfrResponse != null)
                 {
                     Assert.AreEqual("1", rfrResponse.response);
-                    Assert.AreEqual("The account update file is not ready yet.  Please try again later.", rfrResponse.message);
+                    Assert.AreEqual("The account update file is not ready yet.  Please try again later.",
+                        rfrResponse.message);
                     rfrResponse = litleResponse.nextRFRResponse();
                 }
             }
@@ -593,14 +593,14 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void nullBatchData()
         {
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
 
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.reportGroup = "Planets";
             authorization.orderId = "12344";
             authorization.amount = 106;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "414100000000000000";
             card.expDate = "1210";
@@ -611,12 +611,12 @@ namespace Litle.Sdk.Test.Functional
             {
                 litleBatchRequest.addAuthorization(null);
             }
-            catch (System.NullReferenceException e)
+            catch (NullReferenceException e)
             {
                 Assert.AreEqual("Object reference not set to an instance of an object.", e.Message);
             }
 
-            authReversal reversal = new authReversal();
+            var reversal = new authReversal();
             reversal.litleTxnId = 12345678000L;
             reversal.amount = 106;
             reversal.payPalNotes = "Notes";
@@ -626,12 +626,12 @@ namespace Litle.Sdk.Test.Functional
             {
                 litleBatchRequest.addAuthReversal(null);
             }
-            catch (System.NullReferenceException e)
+            catch (NullReferenceException e)
             {
                 Assert.AreEqual("Object reference not set to an instance of an object.", e.Message);
             }
 
-            capture capture = new capture();
+            var capture = new capture();
             capture.litleTxnId = 123456000;
             capture.amount = 106;
             capture.payPalNotes = "Notes";
@@ -641,16 +641,16 @@ namespace Litle.Sdk.Test.Functional
             {
                 litleBatchRequest.addCapture(null);
             }
-            catch (System.NullReferenceException e)
+            catch (NullReferenceException e)
             {
                 Assert.AreEqual("Object reference not set to an instance of an object.", e.Message);
             }
 
-            captureGivenAuth capturegivenauth = new captureGivenAuth();
+            var capturegivenauth = new captureGivenAuth();
             capturegivenauth.amount = 106;
             capturegivenauth.orderId = "12344";
-            authInformation authInfo = new authInformation();
-            DateTime authDate = new DateTime(2002, 10, 9);
+            var authInfo = new authInformation();
+            var authDate = new DateTime(2002, 10, 9);
             authInfo.authDate = authDate;
             authInfo.authCode = "543216";
             authInfo.authAmount = 12345;
@@ -663,12 +663,12 @@ namespace Litle.Sdk.Test.Functional
             {
                 litleBatchRequest.addCaptureGivenAuth(null);
             }
-            catch (System.NullReferenceException e)
+            catch (NullReferenceException e)
             {
                 Assert.AreEqual("Object reference not set to an instance of an object.", e.Message);
             }
 
-            credit creditObj = new credit();
+            var creditObj = new credit();
             creditObj.amount = 106;
             creditObj.orderId = "2111";
             creditObj.orderSource = orderSourceType.ecommerce;
@@ -679,22 +679,22 @@ namespace Litle.Sdk.Test.Functional
             {
                 litleBatchRequest.addCredit(null);
             }
-            catch (System.NullReferenceException e)
+            catch (NullReferenceException e)
             {
                 Assert.AreEqual("Object reference not set to an instance of an object.", e.Message);
             }
 
-            echeckCredit echeckcredit = new echeckCredit();
+            var echeckcredit = new echeckCredit();
             echeckcredit.amount = 12L;
             echeckcredit.orderId = "12345";
             echeckcredit.orderSource = orderSourceType.ecommerce;
-            echeckType echeck = new echeckType();
+            var echeck = new echeckType();
             echeck.accType = echeckAccountTypeEnum.Checking;
             echeck.accNum = "12345657890";
             echeck.routingNum = "011201995";
             echeck.checkNum = "123455";
             echeckcredit.echeck = echeck;
-            contact billToAddress = new contact();
+            var billToAddress = new contact();
             billToAddress.name = "Bob";
             billToAddress.city = "Lowell";
             billToAddress.state = "MA";
@@ -706,12 +706,12 @@ namespace Litle.Sdk.Test.Functional
             {
                 litleBatchRequest.addEcheckCredit(null);
             }
-            catch (System.NullReferenceException e)
+            catch (NullReferenceException e)
             {
                 Assert.AreEqual("Object reference not set to an instance of an object.", e.Message);
             }
 
-            echeckRedeposit echeckredeposit = new echeckRedeposit();
+            var echeckredeposit = new echeckRedeposit();
             echeckredeposit.litleTxnId = 123456;
             echeckredeposit.echeck = echeck;
 
@@ -720,12 +720,12 @@ namespace Litle.Sdk.Test.Functional
             {
                 litleBatchRequest.addEcheckRedeposit(null);
             }
-            catch (System.NullReferenceException e)
+            catch (NullReferenceException e)
             {
                 Assert.AreEqual("Object reference not set to an instance of an object.", e.Message);
             }
 
-            echeckSale echeckSaleObj = new echeckSale();
+            var echeckSaleObj = new echeckSale();
             echeckSaleObj.amount = 123456;
             echeckSaleObj.orderId = "12345";
             echeckSaleObj.orderSource = orderSourceType.ecommerce;
@@ -737,12 +737,12 @@ namespace Litle.Sdk.Test.Functional
             {
                 litleBatchRequest.addEcheckSale(null);
             }
-            catch (System.NullReferenceException e)
+            catch (NullReferenceException e)
             {
                 Assert.AreEqual("Object reference not set to an instance of an object.", e.Message);
             }
 
-            echeckVerification echeckVerificationObject = new echeckVerification();
+            var echeckVerificationObject = new echeckVerification();
             echeckVerificationObject.amount = 123456;
             echeckVerificationObject.orderId = "12345";
             echeckVerificationObject.orderSource = orderSourceType.ecommerce;
@@ -754,12 +754,12 @@ namespace Litle.Sdk.Test.Functional
             {
                 litleBatchRequest.addEcheckVerification(null);
             }
-            catch (System.NullReferenceException e)
+            catch (NullReferenceException e)
             {
                 Assert.AreEqual("Object reference not set to an instance of an object.", e.Message);
             }
 
-            forceCapture forcecapture = new forceCapture();
+            var forcecapture = new forceCapture();
             forcecapture.amount = 106;
             forcecapture.orderId = "12344";
             forcecapture.orderSource = orderSourceType.ecommerce;
@@ -770,12 +770,12 @@ namespace Litle.Sdk.Test.Functional
             {
                 litleBatchRequest.addForceCapture(null);
             }
-            catch (System.NullReferenceException e)
+            catch (NullReferenceException e)
             {
                 Assert.AreEqual("Object reference not set to an instance of an object.", e.Message);
             }
 
-            sale saleObj = new sale();
+            var saleObj = new sale();
             saleObj.amount = 106;
             saleObj.litleTxnId = 123456;
             saleObj.orderId = "12344";
@@ -787,12 +787,12 @@ namespace Litle.Sdk.Test.Functional
             {
                 litleBatchRequest.addSale(null);
             }
-            catch (System.NullReferenceException e)
+            catch (NullReferenceException e)
             {
                 Assert.AreEqual("Object reference not set to an instance of an object.", e.Message);
             }
 
-            registerTokenRequestType registerTokenRequest = new registerTokenRequestType();
+            var registerTokenRequest = new registerTokenRequestType();
             registerTokenRequest.orderId = "12344";
             registerTokenRequest.accountNumber = "1233456789103801";
             registerTokenRequest.reportGroup = "Planets";
@@ -802,7 +802,7 @@ namespace Litle.Sdk.Test.Functional
             {
                 litleBatchRequest.addRegisterTokenRequest(null);
             }
-            catch (System.NullReferenceException e)
+            catch (NullReferenceException e)
             {
                 Assert.AreEqual("Object reference not set to an instance of an object.", e.Message);
             }
@@ -811,7 +811,7 @@ namespace Litle.Sdk.Test.Functional
             {
                 litle.addBatch(litleBatchRequest);
             }
-            catch (System.NullReferenceException e)
+            catch (NullReferenceException e)
             {
                 Assert.AreEqual("Object reference not set to an instance of an object.", e.Message);
             }
@@ -820,67 +820,67 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void InvalidCredientialsBatch()
         {
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
 
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.reportGroup = "Planets";
             authorization.orderId = "12344";
             authorization.amount = 106;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000001";
             card.expDate = "1210";
-            authorization.card = card;     
+            authorization.card = card;
 
             litleBatchRequest.addAuthorization(authorization);
 
-            authorization authorization2 = new authorization();
+            var authorization2 = new authorization();
             authorization2.reportGroup = "Planets";
             authorization2.orderId = "12345";
             authorization2.amount = 106;
             authorization2.orderSource = orderSourceType.ecommerce;
-            cardType card2 = new cardType();
+            var card2 = new cardType();
             card2.type = methodOfPaymentTypeEnum.VI;
             card2.number = "4242424242424242";
             card2.expDate = "1210";
-            authorization2.card = card2; 
+            authorization2.card = card2;
 
             litleBatchRequest.addAuthorization(authorization2);
 
-            authReversal reversal = new authReversal();
+            var reversal = new authReversal();
             reversal.litleTxnId = 12345678000L;
             reversal.amount = 106;
             reversal.payPalNotes = "Notes";
 
             litleBatchRequest.addAuthReversal(reversal);
 
-            authReversal reversal2 = new authReversal();
+            var reversal2 = new authReversal();
             reversal2.litleTxnId = 12345678900L;
             reversal2.amount = 106;
             reversal2.payPalNotes = "Notes";
 
             litleBatchRequest.addAuthReversal(reversal2);
 
-            capture capture = new capture();
+            var capture = new capture();
             capture.litleTxnId = 123456000;
             capture.amount = 106;
             capture.payPalNotes = "Notes";
 
             litleBatchRequest.addCapture(capture);
 
-            capture capture2 = new capture();
+            var capture2 = new capture();
             capture2.litleTxnId = 123456700;
             capture2.amount = 106;
             capture2.payPalNotes = "Notes";
 
             litleBatchRequest.addCapture(capture2);
 
-            captureGivenAuth capturegivenauth = new captureGivenAuth();
+            var capturegivenauth = new captureGivenAuth();
             capturegivenauth.amount = 106;
             capturegivenauth.orderId = "12344";
-            authInformation authInfo = new authInformation();
-            DateTime authDate = new DateTime(2002, 10, 9);
+            var authInfo = new authInformation();
+            var authDate = new DateTime(2002, 10, 9);
             authInfo.authDate = authDate;
             authInfo.authCode = "543216";
             authInfo.authAmount = 12345;
@@ -890,10 +890,10 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addCaptureGivenAuth(capturegivenauth);
 
-            captureGivenAuth capturegivenauth2 = new captureGivenAuth();
+            var capturegivenauth2 = new captureGivenAuth();
             capturegivenauth2.amount = 106;
             capturegivenauth2.orderId = "12344";
-            authInformation authInfo2 = new authInformation();
+            var authInfo2 = new authInformation();
             authDate = new DateTime(2003, 10, 9);
             authInfo2.authDate = authDate;
             authInfo2.authCode = "543216";
@@ -904,7 +904,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addCaptureGivenAuth(capturegivenauth2);
 
-            credit creditObj = new credit();
+            var creditObj = new credit();
             creditObj.amount = 106;
             creditObj.orderId = "2111";
             creditObj.orderSource = orderSourceType.ecommerce;
@@ -912,7 +912,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addCredit(creditObj);
 
-            credit creditObj2 = new credit();
+            var creditObj2 = new credit();
             creditObj2.amount = 106;
             creditObj2.orderId = "2111";
             creditObj2.orderSource = orderSourceType.ecommerce;
@@ -920,17 +920,17 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addCredit(creditObj2);
 
-            echeckCredit echeckcredit = new echeckCredit();
+            var echeckcredit = new echeckCredit();
             echeckcredit.amount = 12L;
             echeckcredit.orderId = "12345";
             echeckcredit.orderSource = orderSourceType.ecommerce;
-            echeckType echeck = new echeckType();
+            var echeck = new echeckType();
             echeck.accType = echeckAccountTypeEnum.Checking;
             echeck.accNum = "1099999903";
             echeck.routingNum = "011201995";
             echeck.checkNum = "123455";
             echeckcredit.echeck = echeck;
-            contact billToAddress = new contact();
+            var billToAddress = new contact();
             billToAddress.name = "Bob";
             billToAddress.city = "Lowell";
             billToAddress.state = "MA";
@@ -939,17 +939,17 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addEcheckCredit(echeckcredit);
 
-            echeckCredit echeckcredit2 = new echeckCredit();
+            var echeckcredit2 = new echeckCredit();
             echeckcredit2.amount = 12L;
             echeckcredit2.orderId = "12346";
             echeckcredit2.orderSource = orderSourceType.ecommerce;
-            echeckType echeck2 = new echeckType();
+            var echeck2 = new echeckType();
             echeck2.accType = echeckAccountTypeEnum.Checking;
             echeck2.accNum = "1099999903";
             echeck2.routingNum = "011201995";
             echeck2.checkNum = "123456";
             echeckcredit2.echeck = echeck2;
-            contact billToAddress2 = new contact();
+            var billToAddress2 = new contact();
             billToAddress2.name = "Mike";
             billToAddress2.city = "Lowell";
             billToAddress2.state = "MA";
@@ -958,19 +958,19 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addEcheckCredit(echeckcredit2);
 
-            echeckRedeposit echeckredeposit = new echeckRedeposit();
+            var echeckredeposit = new echeckRedeposit();
             echeckredeposit.litleTxnId = 123456;
             echeckredeposit.echeck = echeck;
 
             litleBatchRequest.addEcheckRedeposit(echeckredeposit);
 
-            echeckRedeposit echeckredeposit2 = new echeckRedeposit();
+            var echeckredeposit2 = new echeckRedeposit();
             echeckredeposit2.litleTxnId = 123457;
             echeckredeposit2.echeck = echeck2;
 
             litleBatchRequest.addEcheckRedeposit(echeckredeposit2);
 
-            echeckSale echeckSaleObj = new echeckSale();
+            var echeckSaleObj = new echeckSale();
             echeckSaleObj.amount = 123456;
             echeckSaleObj.orderId = "12345";
             echeckSaleObj.orderSource = orderSourceType.ecommerce;
@@ -979,7 +979,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addEcheckSale(echeckSaleObj);
 
-            echeckSale echeckSaleObj2 = new echeckSale();
+            var echeckSaleObj2 = new echeckSale();
             echeckSaleObj2.amount = 123456;
             echeckSaleObj2.orderId = "12346";
             echeckSaleObj2.orderSource = orderSourceType.ecommerce;
@@ -988,7 +988,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addEcheckSale(echeckSaleObj2);
 
-            echeckVerification echeckVerificationObject = new echeckVerification();
+            var echeckVerificationObject = new echeckVerification();
             echeckVerificationObject.amount = 123456;
             echeckVerificationObject.orderId = "12345";
             echeckVerificationObject.orderSource = orderSourceType.ecommerce;
@@ -997,7 +997,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addEcheckVerification(echeckVerificationObject);
 
-            echeckVerification echeckVerificationObject2 = new echeckVerification();
+            var echeckVerificationObject2 = new echeckVerification();
             echeckVerificationObject2.amount = 123456;
             echeckVerificationObject2.orderId = "12346";
             echeckVerificationObject2.orderSource = orderSourceType.ecommerce;
@@ -1006,7 +1006,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addEcheckVerification(echeckVerificationObject2);
 
-            forceCapture forcecapture = new forceCapture();
+            var forcecapture = new forceCapture();
             forcecapture.amount = 106;
             forcecapture.orderId = "12344";
             forcecapture.orderSource = orderSourceType.ecommerce;
@@ -1014,7 +1014,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addForceCapture(forcecapture);
 
-            forceCapture forcecapture2 = new forceCapture();
+            var forcecapture2 = new forceCapture();
             forcecapture2.amount = 106;
             forcecapture2.orderId = "12345";
             forcecapture2.orderSource = orderSourceType.ecommerce;
@@ -1022,7 +1022,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addForceCapture(forcecapture2);
 
-            sale saleObj = new sale();
+            var saleObj = new sale();
             saleObj.amount = 106;
             saleObj.litleTxnId = 123456;
             saleObj.orderId = "12344";
@@ -1031,7 +1031,7 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addSale(saleObj);
 
-            sale saleObj2 = new sale();
+            var saleObj2 = new sale();
             saleObj2.amount = 106;
             saleObj2.litleTxnId = 123456;
             saleObj2.orderId = "12345";
@@ -1040,14 +1040,14 @@ namespace Litle.Sdk.Test.Functional
 
             litleBatchRequest.addSale(saleObj2);
 
-            registerTokenRequestType registerTokenRequest = new registerTokenRequestType();
+            var registerTokenRequest = new registerTokenRequestType();
             registerTokenRequest.orderId = "12344";
             registerTokenRequest.accountNumber = "1233456789103801";
             registerTokenRequest.reportGroup = "Planets";
 
             litleBatchRequest.addRegisterTokenRequest(registerTokenRequest);
 
-            registerTokenRequestType registerTokenRequest2 = new registerTokenRequestType();
+            var registerTokenRequest2 = new registerTokenRequestType();
             registerTokenRequest2.orderId = "12345";
             registerTokenRequest2.accountNumber = "1233456789103801";
             registerTokenRequest2.reportGroup = "Planets";
@@ -1058,7 +1058,7 @@ namespace Litle.Sdk.Test.Functional
 
             try
             {
-                litleResponse litleResponse = litle.sendToLitleWithStream();
+                var litleResponse = litle.sendToLitleWithStream();
             }
             catch (LitleOnlineException e)
             {
@@ -1069,101 +1069,86 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void EcheckPreNoteTestAll()
         {
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
 
-            contact billToAddress = new contact();
+            var billToAddress = new contact();
             billToAddress.name = "Mike";
             billToAddress.city = "Lowell";
             billToAddress.state = "MA";
             billToAddress.email = "litle.com";
 
-            echeckType echeckSuccess = new echeckType();
+            var echeckSuccess = new echeckType();
             echeckSuccess.accType = echeckAccountTypeEnum.Corporate;
             echeckSuccess.accNum = "1092969901";
             echeckSuccess.routingNum = "011075150";
             echeckSuccess.checkNum = "123456";
 
-            echeckType echeckRoutErr = new echeckType();
+            var echeckRoutErr = new echeckType();
             echeckRoutErr.accType = echeckAccountTypeEnum.Checking;
             echeckRoutErr.accNum = "6099999992";
             echeckRoutErr.routingNum = "053133052";
             echeckRoutErr.checkNum = "123457";
 
-            echeckType echeckAccErr = new echeckType();
+            var echeckAccErr = new echeckType();
             echeckAccErr.accType = echeckAccountTypeEnum.Corporate;
             echeckAccErr.accNum = "10@2969901";
             echeckAccErr.routingNum = "011100012";
             echeckAccErr.checkNum = "123458";
 
-            echeckPreNoteSale echeckPreNoteSaleSuccess = new echeckPreNoteSale();
+            var echeckPreNoteSaleSuccess = new echeckPreNoteSale();
             echeckPreNoteSaleSuccess.orderId = "000";
             echeckPreNoteSaleSuccess.orderSource = orderSourceType.ecommerce;
             echeckPreNoteSaleSuccess.echeck = echeckSuccess;
             echeckPreNoteSaleSuccess.billToAddress = billToAddress;
             litleBatchRequest.addEcheckPreNoteSale(echeckPreNoteSaleSuccess);
 
-            var litleFile = litleBatchRequest.getLitleFile();
-            var s = "";//ReadPosition(litleBatchRequest.Serialize(), litleFile);
-
-            echeckPreNoteSale echeckPreNoteSaleRoutErr = new echeckPreNoteSale();
+            var echeckPreNoteSaleRoutErr = new echeckPreNoteSale();
             echeckPreNoteSaleRoutErr.orderId = "900";
             echeckPreNoteSaleRoutErr.orderSource = orderSourceType.ecommerce;
             echeckPreNoteSaleRoutErr.echeck = echeckRoutErr;
             echeckPreNoteSaleRoutErr.billToAddress = billToAddress;
             litleBatchRequest.addEcheckPreNoteSale(echeckPreNoteSaleRoutErr);
 
-            //s = ReadPosition(litleBatchRequest.Serialize(), litleFile);
-
-            echeckPreNoteSale echeckPreNoteSaleAccErr = new echeckPreNoteSale();
+            var echeckPreNoteSaleAccErr = new echeckPreNoteSale();
             echeckPreNoteSaleAccErr.orderId = "301";
             echeckPreNoteSaleAccErr.orderSource = orderSourceType.ecommerce;
             echeckPreNoteSaleAccErr.echeck = echeckAccErr;
             echeckPreNoteSaleAccErr.billToAddress = billToAddress;
             litleBatchRequest.addEcheckPreNoteSale(echeckPreNoteSaleAccErr);
 
-            //s = ReadPosition(litleBatchRequest.Serialize(), litleFile);
-
-            echeckPreNoteCredit echeckPreNoteCreditSuccess = new echeckPreNoteCredit();
+            var echeckPreNoteCreditSuccess = new echeckPreNoteCredit();
             echeckPreNoteCreditSuccess.orderId = "000";
             echeckPreNoteCreditSuccess.orderSource = orderSourceType.ecommerce;
             echeckPreNoteCreditSuccess.echeck = echeckSuccess;
             echeckPreNoteCreditSuccess.billToAddress = billToAddress;
             litleBatchRequest.addEcheckPreNoteCredit(echeckPreNoteCreditSuccess);
 
-            //s = ReadPosition(s, litleFile);
-
-            //s = ReadPosition(litleBatchRequest.Serialize(), litleFile);
-
-            echeckPreNoteCredit echeckPreNoteCreditRoutErr = new echeckPreNoteCredit();
+            var echeckPreNoteCreditRoutErr = new echeckPreNoteCredit();
             echeckPreNoteCreditRoutErr.orderId = "900";
             echeckPreNoteCreditRoutErr.orderSource = orderSourceType.ecommerce;
             echeckPreNoteCreditRoutErr.echeck = echeckRoutErr;
             echeckPreNoteCreditRoutErr.billToAddress = billToAddress;
             litleBatchRequest.addEcheckPreNoteCredit(echeckPreNoteCreditRoutErr);
 
-            //s = ReadPosition(litleBatchRequest.Serialize(), litleFile);
-
-            echeckPreNoteCredit echeckPreNoteCreditAccErr = new echeckPreNoteCredit();
+            var echeckPreNoteCreditAccErr = new echeckPreNoteCredit();
             echeckPreNoteCreditAccErr.orderId = "301";
             echeckPreNoteCreditAccErr.orderSource = orderSourceType.ecommerce;
             echeckPreNoteCreditAccErr.echeck = echeckAccErr;
             echeckPreNoteCreditAccErr.billToAddress = billToAddress;
             litleBatchRequest.addEcheckPreNoteCredit(echeckPreNoteCreditAccErr);
 
-            //s = ReadPosition(litleBatchRequest.Serialize(), litleFile);
-
             litle.addBatch(litleBatchRequest);
 
-            litleResponse litleResponse = litle.sendToLitleWithStream();
+            var litleResponse = litle.sendToLitleWithStream();
 
             Assert.NotNull(litleResponse);
             Assert.AreEqual("0", litleResponse.response);
             Assert.AreEqual("Valid Format", litleResponse.message);
 
-            batchResponse litleBatchResponse = litleResponse.nextBatchResponse();
+            var litleBatchResponse = litleResponse.nextBatchResponse();
             while (litleBatchResponse != null)
             {
-                echeckPreNoteSaleResponse echeckPreNoteSaleResponse = litleBatchResponse.nextEcheckPreNoteSaleResponse();
+                var echeckPreNoteSaleResponse = litleBatchResponse.nextEcheckPreNoteSaleResponse();
                 while (echeckPreNoteSaleResponse != null)
                 {
                     Assert.AreEqual(echeckPreNoteSaleResponse.orderId, echeckPreNoteSaleResponse.response);
@@ -1171,7 +1156,7 @@ namespace Litle.Sdk.Test.Functional
                     echeckPreNoteSaleResponse = litleBatchResponse.nextEcheckPreNoteSaleResponse();
                 }
 
-                echeckPreNoteCreditResponse echeckPreNoteCreditResponse = litleBatchResponse.nextEcheckPreNoteCreditResponse();
+                var echeckPreNoteCreditResponse = litleBatchResponse.nextEcheckPreNoteCreditResponse();
                 while (echeckPreNoteCreditResponse != null)
                 {
                     Assert.AreEqual(echeckPreNoteCreditResponse.orderId, echeckPreNoteCreditResponse.response);
@@ -1182,42 +1167,42 @@ namespace Litle.Sdk.Test.Functional
                 litleBatchResponse = litleResponse.nextBatchResponse();
             }
         }
-        
+
 
         [Test]
         public void PFIFInstructionTxnTest()
         {
             var memoryStream = new Dictionary<string, StringBuilder>();
-            Dictionary<string, string> configOverride = new Dictionary<string, string>();
-            configOverride["url"] = Properties.Settings.Default.url;
-            configOverride["reportGroup"] = Properties.Settings.Default.reportGroup;
+            var configOverride = new Dictionary<string, string>();
+            configOverride["url"] = Settings.Default.url;
+            configOverride["reportGroup"] = Settings.Default.reportGroup;
             configOverride["username"] = "BATCHSDKA";
-            configOverride["printxml"] = Properties.Settings.Default.printxml;
-            configOverride["timeout"] = Properties.Settings.Default.timeout;
-            configOverride["proxyHost"] = Properties.Settings.Default.proxyHost;
+            configOverride["printxml"] = Settings.Default.printxml;
+            configOverride["timeout"] = Settings.Default.timeout;
+            configOverride["proxyHost"] = Settings.Default.proxyHost;
             configOverride["merchantId"] = "0180";
             configOverride["password"] = "certpass";
-            configOverride["proxyPort"] = Properties.Settings.Default.proxyPort;
-            configOverride["sftpUrl"] = Properties.Settings.Default.sftpUrl;
-            configOverride["sftpUsername"] = Properties.Settings.Default.sftpUsername;
-            configOverride["sftpPassword"] = Properties.Settings.Default.sftpPassword;
-            configOverride["knownHostsFile"] = Properties.Settings.Default.knownHostsFile;
-            configOverride["onlineBatchUrl"] = Properties.Settings.Default.onlineBatchUrl;
-            configOverride["onlineBatchPort"] = Properties.Settings.Default.onlineBatchPort;
-            configOverride["requestDirectory"] = Properties.Settings.Default.requestDirectory;
-            configOverride["responseDirectory"] = Properties.Settings.Default.responseDirectory;
+            configOverride["proxyPort"] = Settings.Default.proxyPort;
+            configOverride["sftpUrl"] = Settings.Default.sftpUrl;
+            configOverride["sftpUsername"] = Settings.Default.sftpUsername;
+            configOverride["sftpPassword"] = Settings.Default.sftpPassword;
+            configOverride["knownHostsFile"] = Settings.Default.knownHostsFile;
+            configOverride["onlineBatchUrl"] = Settings.Default.onlineBatchUrl;
+            configOverride["onlineBatchPort"] = Settings.Default.onlineBatchPort;
+            configOverride["requestDirectory"] = Settings.Default.requestDirectory;
+            configOverride["responseDirectory"] = Settings.Default.responseDirectory;
 
-            litleRequest litleOverride = new litleRequest(memoryStream, configOverride);
+            var litleOverride = new litleRequest(memoryStream, configOverride);
 
-            batchRequest litleBatchRequest = new batchRequest(memoryStream, configOverride);
+            var litleBatchRequest = new batchRequest(memoryStream, configOverride);
 
-            echeckType echeck = new echeckType();
+            var echeck = new echeckType();
             echeck.accType = echeckAccountTypeEnum.Corporate;
             echeck.accNum = "1092969901";
             echeck.routingNum = "011075150";
             echeck.checkNum = "123455";
 
-            submerchantCredit submerchantCredit = new submerchantCredit();
+            var submerchantCredit = new submerchantCredit();
             submerchantCredit.fundingSubmerchantId = "123456";
             submerchantCredit.submerchantName = "merchant";
             submerchantCredit.fundsTransferId = "123467";
@@ -1225,19 +1210,19 @@ namespace Litle.Sdk.Test.Functional
             submerchantCredit.accountInfo = echeck;
             litleBatchRequest.addSubmerchantCredit(submerchantCredit);
 
-            payFacCredit payFacCredit = new payFacCredit();
+            var payFacCredit = new payFacCredit();
             payFacCredit.fundingSubmerchantId = "123456";
             payFacCredit.fundsTransferId = "123467";
             payFacCredit.amount = 107L;
             litleBatchRequest.addPayFacCredit(payFacCredit);
 
-            reserveCredit reserveCredit = new reserveCredit();
+            var reserveCredit = new reserveCredit();
             reserveCredit.fundingSubmerchantId = "123456";
             reserveCredit.fundsTransferId = "123467";
             reserveCredit.amount = 107L;
             litleBatchRequest.addReserveCredit(reserveCredit);
 
-            vendorCredit vendorCredit = new vendorCredit();
+            var vendorCredit = new vendorCredit();
             vendorCredit.fundingSubmerchantId = "123456";
             vendorCredit.vendorName = "merchant";
             vendorCredit.fundsTransferId = "123467";
@@ -1245,13 +1230,13 @@ namespace Litle.Sdk.Test.Functional
             vendorCredit.accountInfo = echeck;
             litleBatchRequest.addVendorCredit(vendorCredit);
 
-            physicalCheckCredit physicalCheckCredit = new physicalCheckCredit();
+            var physicalCheckCredit = new physicalCheckCredit();
             physicalCheckCredit.fundingSubmerchantId = "123456";
             physicalCheckCredit.fundsTransferId = "123467";
             physicalCheckCredit.amount = 107L;
             litleBatchRequest.addPhysicalCheckCredit(physicalCheckCredit);
 
-            submerchantDebit submerchantDebit = new submerchantDebit();
+            var submerchantDebit = new submerchantDebit();
             submerchantDebit.fundingSubmerchantId = "123456";
             submerchantDebit.submerchantName = "merchant";
             submerchantDebit.fundsTransferId = "123467";
@@ -1259,19 +1244,19 @@ namespace Litle.Sdk.Test.Functional
             submerchantDebit.accountInfo = echeck;
             litleBatchRequest.addSubmerchantDebit(submerchantDebit);
 
-            payFacDebit payFacDebit = new payFacDebit();
+            var payFacDebit = new payFacDebit();
             payFacDebit.fundingSubmerchantId = "123456";
             payFacDebit.fundsTransferId = "123467";
             payFacDebit.amount = 107L;
             litleBatchRequest.addPayFacDebit(payFacDebit);
 
-            reserveDebit reserveDebit = new reserveDebit();
+            var reserveDebit = new reserveDebit();
             reserveDebit.fundingSubmerchantId = "123456";
             reserveDebit.fundsTransferId = "123467";
             reserveDebit.amount = 107L;
             litleBatchRequest.addReserveDebit(reserveDebit);
 
-            vendorDebit vendorDebit = new vendorDebit();
+            var vendorDebit = new vendorDebit();
             vendorDebit.fundingSubmerchantId = "123456";
             vendorDebit.vendorName = "merchant";
             vendorDebit.fundsTransferId = "123467";
@@ -1279,7 +1264,7 @@ namespace Litle.Sdk.Test.Functional
             vendorDebit.accountInfo = echeck;
             litleBatchRequest.addVendorDebit(vendorDebit);
 
-            physicalCheckDebit physicalCheckDebit = new physicalCheckDebit();
+            var physicalCheckDebit = new physicalCheckDebit();
             physicalCheckDebit.fundingSubmerchantId = "123456";
             physicalCheckDebit.fundsTransferId = "123467";
             physicalCheckDebit.amount = 107L;
@@ -1287,79 +1272,79 @@ namespace Litle.Sdk.Test.Functional
 
             litleOverride.addBatch(litleBatchRequest);
 
-            litleResponse litleResponse = litleOverride.sendToLitleWithStream();
+            var litleResponse = litleOverride.sendToLitleWithStream();
 
             Assert.NotNull(litleResponse);
             Assert.AreEqual("0", litleResponse.response);
             Assert.AreEqual("Valid Format", litleResponse.message);
 
-            batchResponse litleBatchResponse = litleResponse.nextBatchResponse();
+            var litleBatchResponse = litleResponse.nextBatchResponse();
             while (litleBatchResponse != null)
             {
-                submerchantCreditResponse submerchantCreditResponse = litleBatchResponse.nextSubmerchantCreditResponse();
+                var submerchantCreditResponse = litleBatchResponse.nextSubmerchantCreditResponse();
                 while (submerchantCreditResponse != null)
                 {
                     Assert.AreEqual("000", submerchantCreditResponse.response);
                     submerchantCreditResponse = litleBatchResponse.nextSubmerchantCreditResponse();
                 }
 
-                payFacCreditResponse payFacCreditResponse = litleBatchResponse.nextPayFacCreditResponse();
+                var payFacCreditResponse = litleBatchResponse.nextPayFacCreditResponse();
                 while (payFacCreditResponse != null)
                 {
                     Assert.AreEqual("000", payFacCreditResponse.response);
                     payFacCreditResponse = litleBatchResponse.nextPayFacCreditResponse();
                 }
 
-                vendorCreditResponse vendorCreditResponse = litleBatchResponse.nextVendorCreditResponse();
+                var vendorCreditResponse = litleBatchResponse.nextVendorCreditResponse();
                 while (vendorCreditResponse != null)
                 {
                     Assert.AreEqual("000", vendorCreditResponse.response);
                     vendorCreditResponse = litleBatchResponse.nextVendorCreditResponse();
                 }
 
-                reserveCreditResponse reserveCreditResponse = litleBatchResponse.nextReserveCreditResponse();
+                var reserveCreditResponse = litleBatchResponse.nextReserveCreditResponse();
                 while (reserveCreditResponse != null)
                 {
                     Assert.AreEqual("000", reserveCreditResponse.response);
                     reserveCreditResponse = litleBatchResponse.nextReserveCreditResponse();
                 }
 
-                physicalCheckCreditResponse physicalCheckCreditResponse = litleBatchResponse.nextPhysicalCheckCreditResponse();
+                var physicalCheckCreditResponse = litleBatchResponse.nextPhysicalCheckCreditResponse();
                 while (physicalCheckCreditResponse != null)
                 {
                     Assert.AreEqual("000", physicalCheckCreditResponse.response);
                     physicalCheckCreditResponse = litleBatchResponse.nextPhysicalCheckCreditResponse();
                 }
 
-                submerchantDebitResponse submerchantDebitResponse = litleBatchResponse.nextSubmerchantDebitResponse();
+                var submerchantDebitResponse = litleBatchResponse.nextSubmerchantDebitResponse();
                 while (submerchantDebitResponse != null)
                 {
                     Assert.AreEqual("000", submerchantDebitResponse.response);
                     submerchantDebitResponse = litleBatchResponse.nextSubmerchantDebitResponse();
                 }
 
-                payFacDebitResponse payFacDebitResponse = litleBatchResponse.nextPayFacDebitResponse();
+                var payFacDebitResponse = litleBatchResponse.nextPayFacDebitResponse();
                 while (payFacDebitResponse != null)
                 {
                     Assert.AreEqual("000", payFacDebitResponse.response);
                     payFacDebitResponse = litleBatchResponse.nextPayFacDebitResponse();
                 }
 
-                vendorDebitResponse vendorDebitResponse = litleBatchResponse.nextVendorDebitResponse();
+                var vendorDebitResponse = litleBatchResponse.nextVendorDebitResponse();
                 while (vendorDebitResponse != null)
                 {
                     Assert.AreEqual("000", vendorDebitResponse.response);
                     vendorDebitResponse = litleBatchResponse.nextVendorDebitResponse();
                 }
 
-                reserveDebitResponse reserveDebitResponse = litleBatchResponse.nextReserveDebitResponse();
+                var reserveDebitResponse = litleBatchResponse.nextReserveDebitResponse();
                 while (reserveDebitResponse != null)
                 {
                     Assert.AreEqual("000", reserveDebitResponse.response);
                     reserveDebitResponse = litleBatchResponse.nextReserveDebitResponse();
                 }
 
-                physicalCheckDebitResponse physicalCheckDebitResponse = litleBatchResponse.nextPhysicalCheckDebitResponse();
+                var physicalCheckDebitResponse = litleBatchResponse.nextPhysicalCheckDebitResponse();
                 while (physicalCheckDebitResponse != null)
                 {
                     Assert.AreEqual("000", physicalCheckDebitResponse.response);

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestCapture.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestCapture.cs
@@ -1,14 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Text;
+using Litle.Sdk.Properties;
 using NUnit.Framework;
-using Litle.Sdk;
 
 namespace Litle.Sdk.Test.Functional
 {
     [TestFixture]
-    class TestCapture
+    internal class TestCapture
     {
         private LitleOnline litle;
         private IDictionary<string, StringBuilder> _memoryCache;
@@ -17,7 +15,7 @@ namespace Litle.Sdk.Test.Functional
         public void SetUpLitle()
         {
             _memoryCache = new Dictionary<string, StringBuilder>();
-            Dictionary<string, string> config = new Dictionary<string, string>();
+            var config = new Dictionary<string, string>();
             config.Add("url", "https://www.testlitle.com/sandbox/communicator/online");
             config.Add("reportGroup", "Default Report Group");
             config.Add("username", "DOTNET");
@@ -26,9 +24,9 @@ namespace Litle.Sdk.Test.Functional
             config.Add("merchantId", "101");
             config.Add("password", "TESTCASE");
             config.Add("printxml", "true");
-            config.Add("proxyHost", Properties.Settings.Default.proxyHost);
-            config.Add("proxyPort", Properties.Settings.Default.proxyPort);
-            config.Add("logFile", Properties.Settings.Default.logFile);
+            config.Add("proxyHost", Settings.Default.proxyHost);
+            config.Add("proxyPort", Settings.Default.proxyPort);
+            config.Add("logFile", Settings.Default.logFile);
             config.Add("neuterAccountNums", "true");
             litle = new LitleOnline(_memoryCache, config);
         }
@@ -36,54 +34,54 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void SimpleCapture()
         {
-            capture capture = new capture();
+            var capture = new capture();
             capture.litleTxnId = 123456000;
             capture.amount = 106;
             capture.payPalNotes = "Notes";
 
-            captureResponse response = litle.Capture(capture);
+            var response = litle.Capture(capture);
             Assert.AreEqual("Approved", response.message);
         }
 
         [Test]
         public void simpleCaptureWithPartial()
         {
-            capture capture = new capture();
+            var capture = new capture();
             capture.litleTxnId = 123456000;
             capture.amount = 106;
             capture.partial = true;
             capture.payPalNotes = "Notes";
 
-            captureResponse response = litle.Capture(capture);
+            var response = litle.Capture(capture);
             Assert.AreEqual("Approved", response.message);
         }
 
         [Test]
         public void complexCapture()
         {
-            capture capture = new capture();
+            var capture = new capture();
             capture.litleTxnId = 123456000;
             capture.amount = 106;
             capture.payPalNotes = "Notes";
-            enhancedData enhanceddata = new enhancedData();
+            var enhanceddata = new enhancedData();
             enhanceddata.customerReference = "Litle";
             enhanceddata.salesTax = 50;
             enhanceddata.deliveryType = enhancedDataDeliveryType.TBD;
             capture.enhancedData = enhanceddata;
             capture.payPalOrderComplete = true;
-            captureResponse response = litle.Capture(capture);
+            var response = litle.Capture(capture);
             Assert.AreEqual("Approved", response.message);
         }
 
         [Test]
         public void SimpleCaptureWithSpecial()
         {
-            capture capture = new capture();
+            var capture = new capture();
             capture.litleTxnId = 123456000;
             capture.amount = 106;
             capture.payPalNotes = "<'&\">";
 
-            captureResponse response = litle.Capture(capture);
+            var response = litle.Capture(capture);
             Assert.AreEqual("Approved", response.message);
         }
     }

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestCapture.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestCapture.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -10,10 +11,12 @@ namespace Litle.Sdk.Test.Functional
     class TestCapture
     {
         private LitleOnline litle;
+        private IDictionary<string, StringBuilder> _memoryCache;
 
         [TestFixtureSetUp]
         public void SetUpLitle()
         {
+            _memoryCache = new Dictionary<string, StringBuilder>();
             Dictionary<string, string> config = new Dictionary<string, string>();
             config.Add("url", "https://www.testlitle.com/sandbox/communicator/online");
             config.Add("reportGroup", "Default Report Group");
@@ -27,7 +30,7 @@ namespace Litle.Sdk.Test.Functional
             config.Add("proxyPort", Properties.Settings.Default.proxyPort);
             config.Add("logFile", Properties.Settings.Default.logFile);
             config.Add("neuterAccountNums", "true");
-            litle = new LitleOnline(config);
+            litle = new LitleOnline(_memoryCache, config);
         }
 
         [Test]

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestCaptureGivenAuth.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestCaptureGivenAuth.cs
@@ -1,16 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Text;
+using Litle.Sdk.Properties;
 using NUnit.Framework;
-using Litle.Sdk;
 
 namespace Litle.Sdk.Test.Functional
 {
     [TestFixture]
-    class TestCaptureGivenAuth
+    internal class TestCaptureGivenAuth
     {
-
         private LitleOnline litle;
         private IDictionary<string, StringBuilder> _memoryCache;
 
@@ -18,7 +16,7 @@ namespace Litle.Sdk.Test.Functional
         public void setUp()
         {
             _memoryCache = new Dictionary<string, StringBuilder>();
-            Dictionary<string, string> config = new Dictionary<string, string>();
+            var config = new Dictionary<string, string>();
             config.Add("url", "https://www.testlitle.com/sandbox/communicator/online");
             config.Add("reportGroup", "Default Report Group");
             config.Add("username", "DOTNET");
@@ -27,121 +25,126 @@ namespace Litle.Sdk.Test.Functional
             config.Add("merchantId", "101");
             config.Add("password", "TESTCASE");
             config.Add("printxml", "true");
-            config.Add("proxyHost", Properties.Settings.Default.proxyHost);
-            config.Add("proxyPort", Properties.Settings.Default.proxyPort);
-            config.Add("logFile", Properties.Settings.Default.logFile);
+            config.Add("proxyHost", Settings.Default.proxyHost);
+            config.Add("proxyPort", Settings.Default.proxyPort);
+            config.Add("logFile", Settings.Default.logFile);
             config.Add("neuterAccountNums", "true");
             litle = new LitleOnline(_memoryCache, config);
         }
 
         [Test]
-        public void simpleCaptureGivenAuthWithCard() {
-            captureGivenAuth capturegivenauth = new captureGivenAuth();
+        public void simpleCaptureGivenAuthWithCard()
+        {
+            var capturegivenauth = new captureGivenAuth();
             capturegivenauth.amount = 106;
             capturegivenauth.orderId = "12344";
-            authInformation authInfo = new authInformation();
-            DateTime authDate = new DateTime(2002, 10, 9);
+            var authInfo = new authInformation();
+            var authDate = new DateTime(2002, 10, 9);
             authInfo.authDate = authDate;
             authInfo.authCode = "543216";
             authInfo.authAmount = 12345;
             capturegivenauth.authInformation = authInfo;
             capturegivenauth.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000000";
             card.expDate = "1210";
             capturegivenauth.card = card;
-            captureGivenAuthResponse response = litle.CaptureGivenAuth(capturegivenauth);
+            var response = litle.CaptureGivenAuth(capturegivenauth);
             Assert.AreEqual("Approved", response.message);
         }
 
         [Test]
         public void simpleCaptureGivenAuthWithMpos()
         {
-            captureGivenAuth capturegivenauth = new captureGivenAuth();
+            var capturegivenauth = new captureGivenAuth();
             capturegivenauth.amount = 500;
             capturegivenauth.orderId = "12344";
-            authInformation authInfo = new authInformation();
-            DateTime authDate = new DateTime(2002, 10, 9);
+            var authInfo = new authInformation();
+            var authDate = new DateTime(2002, 10, 9);
             authInfo.authDate = authDate;
             authInfo.authCode = "543216";
             authInfo.authAmount = 12345;
             capturegivenauth.authInformation = authInfo;
             capturegivenauth.orderSource = orderSourceType.ecommerce;
-            mposType mpos = new mposType();
+            var mpos = new mposType();
             mpos.ksn = "77853211300008E00016";
-            mpos.encryptedTrack = "CASE1E185EADD6AFE78C9A214B21313DCD836FDD555FBE3A6C48D141FE80AB9172B963265AFF72111895FE415DEDA162CE8CB7AC4D91EDB611A2AB756AA9CB1A000000000000000000000000000000005A7AAF5E8885A9DB88ECD2430C497003F2646619A2382FFF205767492306AC804E8E64E8EA6981DD";
+            mpos.encryptedTrack =
+                "CASE1E185EADD6AFE78C9A214B21313DCD836FDD555FBE3A6C48D141FE80AB9172B963265AFF72111895FE415DEDA162CE8CB7AC4D91EDB611A2AB756AA9CB1A000000000000000000000000000000005A7AAF5E8885A9DB88ECD2430C497003F2646619A2382FFF205767492306AC804E8E64E8EA6981DD";
             mpos.formatId = "30";
             mpos.track1Status = 0;
             mpos.track2Status = 0;
             capturegivenauth.mpos = mpos;
-            captureGivenAuthResponse response = litle.CaptureGivenAuth(capturegivenauth);
+            var response = litle.CaptureGivenAuth(capturegivenauth);
             Assert.AreEqual("Approved", response.message);
         }
 
         [Test]
-        public void simpleCaptureGivenAuthWithToken() {
-            captureGivenAuth capturegivenauth = new captureGivenAuth();
+        public void simpleCaptureGivenAuthWithToken()
+        {
+            var capturegivenauth = new captureGivenAuth();
             capturegivenauth.amount = 106;
             capturegivenauth.orderId = "12344";
-            authInformation authInfo = new authInformation();
-            DateTime authDate = new DateTime(2002, 10, 9);
+            var authInfo = new authInformation();
+            var authDate = new DateTime(2002, 10, 9);
             authInfo.authDate = authDate;
             authInfo.authCode = "543216";
             authInfo.authAmount = 12345;
             capturegivenauth.authInformation = authInfo;
             capturegivenauth.orderSource = orderSourceType.ecommerce;
-            cardTokenType cardtoken = new cardTokenType();
+            var cardtoken = new cardTokenType();
             cardtoken.litleToken = "123456789101112";
-            cardtoken.expDate ="1210";
+            cardtoken.expDate = "1210";
             cardtoken.cardValidationNum = "555";
             cardtoken.type = methodOfPaymentTypeEnum.VI;
             capturegivenauth.token = cardtoken;
-            captureGivenAuthResponse response = litle.CaptureGivenAuth(capturegivenauth);
+            var response = litle.CaptureGivenAuth(capturegivenauth);
             Assert.AreEqual("Approved", response.message);
         }
 
         [Test]
-        public void complexCaptureGivenAuth() {
-            captureGivenAuth capturegivenauth = new captureGivenAuth();
+        public void complexCaptureGivenAuth()
+        {
+            var capturegivenauth = new captureGivenAuth();
             capturegivenauth.amount = 106;
             capturegivenauth.orderId = "12344";
-            authInformation authInfo = new authInformation();
-            DateTime authDate = new DateTime(2002, 10, 9);
+            var authInfo = new authInformation();
+            var authDate = new DateTime(2002, 10, 9);
             authInfo.authDate = authDate;
             authInfo.authCode = "543216";
             authInfo.authAmount = 12345;
             capturegivenauth.authInformation = authInfo;
-            contact contact = new contact();
+            var contact = new contact();
             contact.name = "Bob";
             contact.city = "lowell";
             contact.state = "MA";
-            contact.email ="litle.com";
+            contact.email = "litle.com";
             capturegivenauth.billToAddress = contact;
-            processingInstructions processinginstructions = new processingInstructions();
+            var processinginstructions = new processingInstructions();
             processinginstructions.bypassVelocityCheck = true;
             capturegivenauth.processingInstructions = processinginstructions;
             capturegivenauth.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000000";
             card.expDate = "1210";
             capturegivenauth.card = card;
-            captureGivenAuthResponse response = litle.CaptureGivenAuth(capturegivenauth);
+            var response = litle.CaptureGivenAuth(capturegivenauth);
             Assert.AreEqual("Approved", response.message);
         }
 
         [Test]
-        public void authInfo() {
-            captureGivenAuth capturegivenauth = new captureGivenAuth();
+        public void authInfo()
+        {
+            var capturegivenauth = new captureGivenAuth();
             capturegivenauth.amount = 106;
             capturegivenauth.orderId = "12344";
-            authInformation authInfo = new authInformation();
-            DateTime authDate = new DateTime(2002, 10, 9);
+            var authInfo = new authInformation();
+            var authDate = new DateTime(2002, 10, 9);
             authInfo.authDate = authDate;
             authInfo.authCode = "543216";
             authInfo.authAmount = 12345;
-            fraudResult fraudresult = new fraudResult();
+            var fraudresult = new fraudResult();
             fraudresult.avsResult = "12";
             fraudresult.cardValidationResult = "123";
             fraudresult.authenticationResult = "1";
@@ -149,58 +152,58 @@ namespace Litle.Sdk.Test.Functional
             authInfo.fraudResult = fraudresult;
             capturegivenauth.authInformation = authInfo;
             capturegivenauth.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000000";
             card.expDate = "1210";
-            capturegivenauth.card=card;
-            captureGivenAuthResponse response = litle.CaptureGivenAuth(capturegivenauth);
+            capturegivenauth.card = card;
+            var response = litle.CaptureGivenAuth(capturegivenauth);
             Assert.AreEqual("Approved", response.message);
         }
 
         [Test]
         public void simpleCaptureGivenAuthWithTokenAndSpecialCharacters()
         {
-            captureGivenAuth capturegivenauth = new captureGivenAuth();
+            var capturegivenauth = new captureGivenAuth();
             capturegivenauth.amount = 106;
             capturegivenauth.orderId = "<'&\">";
-            authInformation authInfo = new authInformation();
-            DateTime authDate = new DateTime(2002, 10, 9);
+            var authInfo = new authInformation();
+            var authDate = new DateTime(2002, 10, 9);
             authInfo.authDate = authDate;
             authInfo.authCode = "543216";
             authInfo.authAmount = 12345;
             capturegivenauth.authInformation = authInfo;
             capturegivenauth.orderSource = orderSourceType.ecommerce;
-            cardTokenType cardtoken = new cardTokenType();
+            var cardtoken = new cardTokenType();
             cardtoken.litleToken = "123456789101112";
             cardtoken.expDate = "1210";
             cardtoken.cardValidationNum = "555";
             cardtoken.type = methodOfPaymentTypeEnum.VI;
             capturegivenauth.token = cardtoken;
-            captureGivenAuthResponse response = litle.CaptureGivenAuth(capturegivenauth);
+            var response = litle.CaptureGivenAuth(capturegivenauth);
             Assert.AreEqual("Approved", response.message);
         }
 
         [Test]
         public void simpleCaptureGivenAuthWithSecondaryAmount()
         {
-            captureGivenAuth capturegivenauth = new captureGivenAuth();
+            var capturegivenauth = new captureGivenAuth();
             capturegivenauth.amount = 106;
             capturegivenauth.secondaryAmount = 50;
             capturegivenauth.orderId = "12344";
-            authInformation authInfo = new authInformation();
-            DateTime authDate = new DateTime(2002, 10, 9);
+            var authInfo = new authInformation();
+            var authDate = new DateTime(2002, 10, 9);
             authInfo.authDate = authDate;
             authInfo.authCode = "543216";
             authInfo.authAmount = 12345;
             capturegivenauth.authInformation = authInfo;
             capturegivenauth.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000000";
             card.expDate = "1210";
             capturegivenauth.card = card;
-            captureGivenAuthResponse response = litle.CaptureGivenAuth(capturegivenauth);
+            var response = litle.CaptureGivenAuth(capturegivenauth);
             Assert.AreEqual("Approved", response.message);
         }
     }

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestCaptureGivenAuth.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestCaptureGivenAuth.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -11,10 +12,12 @@ namespace Litle.Sdk.Test.Functional
     {
 
         private LitleOnline litle;
+        private IDictionary<string, StringBuilder> _memoryCache;
 
         [TestFixtureSetUp]
         public void setUp()
         {
+            _memoryCache = new Dictionary<string, StringBuilder>();
             Dictionary<string, string> config = new Dictionary<string, string>();
             config.Add("url", "https://www.testlitle.com/sandbox/communicator/online");
             config.Add("reportGroup", "Default Report Group");
@@ -28,7 +31,7 @@ namespace Litle.Sdk.Test.Functional
             config.Add("proxyPort", Properties.Settings.Default.proxyPort);
             config.Add("logFile", Properties.Settings.Default.logFile);
             config.Add("neuterAccountNums", "true");
-            litle = new LitleOnline(config);
+            litle = new LitleOnline(_memoryCache, config);
         }
 
         [Test]

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestCredit.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestCredit.cs
@@ -1,14 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Text;
+using Litle.Sdk.Properties;
 using NUnit.Framework;
-using Litle.Sdk;
 
 namespace Litle.Sdk.Test.Functional
 {
     [TestFixture]
-    class TestCredit
+    internal class TestCredit
     {
         private LitleOnline litle;
         private IDictionary<string, StringBuilder> _memoryCache;
@@ -17,7 +15,7 @@ namespace Litle.Sdk.Test.Functional
         public void setUp()
         {
             _memoryCache = new Dictionary<string, StringBuilder>();
-            Dictionary<string, string> config = new Dictionary<string, string>();
+            var config = new Dictionary<string, string>();
             config.Add("url", "https://www.testlitle.com/sandbox/communicator/online");
             config.Add("reportGroup", "Default Report Group");
             config.Add("username", "DOTNET");
@@ -26,9 +24,9 @@ namespace Litle.Sdk.Test.Functional
             config.Add("merchantId", "101");
             config.Add("password", "TESTCASE");
             config.Add("printxml", "true");
-            config.Add("proxyHost", Properties.Settings.Default.proxyHost);
-            config.Add("proxyPort", Properties.Settings.Default.proxyPort);
-            config.Add("logFile", Properties.Settings.Default.logFile);
+            config.Add("proxyHost", Settings.Default.proxyHost);
+            config.Add("proxyPort", Settings.Default.proxyPort);
+            config.Add("logFile", Settings.Default.logFile);
             config.Add("neuterAccountNums", "true");
             litle = new LitleOnline(_memoryCache, config);
         }
@@ -36,115 +34,116 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void SimpleCreditWithCard()
         {
-            credit creditObj = new credit();
+            var creditObj = new credit();
             creditObj.amount = 106;
             creditObj.orderId = "2111";
             creditObj.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000001";
             card.expDate = "1210";
-            
+
             creditObj.card = card;
-            
-            creditResponse response = litle.Credit(creditObj);
+
+            var response = litle.Credit(creditObj);
             Assert.AreEqual("Approved", response.message);
         }
 
         [Test]
         public void SimpleCreditWithMpos()
         {
-            credit creditObj = new credit();
+            var creditObj = new credit();
             creditObj.amount = 106;
             creditObj.orderId = "2111";
             creditObj.orderSource = orderSourceType.ecommerce;
-            mposType mpos = new mposType();
+            var mpos = new mposType();
             mpos.ksn = "77853211300008E00016";
-            mpos.encryptedTrack = "CASE1E185EADD6AFE78C9A214B21313DCD836FDD555FBE3A6C48D141FE80AB9172B963265AFF72111895FE415DEDA162CE8CB7AC4D91EDB611A2AB756AA9CB1A000000000000000000000000000000005A7AAF5E8885A9DB88ECD2430C497003F2646619A2382FFF205767492306AC804E8E64E8EA6981DD";
+            mpos.encryptedTrack =
+                "CASE1E185EADD6AFE78C9A214B21313DCD836FDD555FBE3A6C48D141FE80AB9172B963265AFF72111895FE415DEDA162CE8CB7AC4D91EDB611A2AB756AA9CB1A000000000000000000000000000000005A7AAF5E8885A9DB88ECD2430C497003F2646619A2382FFF205767492306AC804E8E64E8EA6981DD";
             mpos.formatId = "30";
             mpos.track1Status = 0;
             mpos.track2Status = 0;
             creditObj.mpos = mpos;
 
-            creditResponse response = litle.Credit(creditObj);
+            var response = litle.Credit(creditObj);
             Assert.AreEqual("Approved", response.message);
         }
 
         [Test]
         public void SimpleCreditWithPaypal()
         {
-            credit creditObj = new credit();
+            var creditObj = new credit();
             creditObj.amount = 106;
             creditObj.orderId = "123456";
             creditObj.orderSource = orderSourceType.ecommerce;
-            payPal payPalObj = new payPal();
+            var payPalObj = new payPal();
             payPalObj.payerId = "1234";
 
             creditObj.paypal = payPalObj;
 
-            creditResponse response = litle.Credit(creditObj);
+            var response = litle.Credit(creditObj);
             Assert.AreEqual("Approved", response.message);
         }
 
         [Test]
         public void PaypalNotes()
         {
-            credit creditObj = new credit();
+            var creditObj = new credit();
             creditObj.amount = 106;
             creditObj.orderId = "123456";
             creditObj.payPalNotes = "Hello";
             creditObj.orderSource = orderSourceType.ecommerce;
 
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000001";
             card.expDate = "1210";
 
             creditObj.card = card;
-            
-            creditResponse response = litle.Credit(creditObj);
+
+            var response = litle.Credit(creditObj);
             Assert.AreEqual("Approved", response.message);
         }
 
         [Test]
         public void ProcessingInstructionAndAmexData()
         {
-            credit creditObj = new credit();
+            var creditObj = new credit();
             creditObj.amount = 2000;
             creditObj.orderId = "12344";
             creditObj.orderSource = orderSourceType.ecommerce;
 
-            processingInstructions processingInstructionsObj = new processingInstructions();
+            var processingInstructionsObj = new processingInstructions();
             processingInstructionsObj.bypassVelocityCheck = true;
 
             creditObj.processingInstructions = processingInstructionsObj;
-            
-            cardType card = new cardType();
+
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000001";
             card.expDate = "1210";
 
             creditObj.card = card;
 
-            creditResponse response = litle.Credit(creditObj);
+            var response = litle.Credit(creditObj);
             Assert.AreEqual("Approved", response.message);
         }
 
         [Test]
         public void SimpleCreditWithCardAndSpecialCharacters()
         {
-            credit creditObj = new credit();
+            var creditObj = new credit();
             creditObj.amount = 106;
             creditObj.orderId = "<&'>";
             creditObj.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000<>0000001";
             card.expDate = "1210";
 
             creditObj.card = card;
 
-            creditResponse response = litle.Credit(creditObj);
+            var response = litle.Credit(creditObj);
             Assert.AreEqual("Approved", response.message);
         }
     }

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestCredit.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestCredit.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -10,10 +11,12 @@ namespace Litle.Sdk.Test.Functional
     class TestCredit
     {
         private LitleOnline litle;
+        private IDictionary<string, StringBuilder> _memoryCache;
 
         [TestFixtureSetUp]
         public void setUp()
         {
+            _memoryCache = new Dictionary<string, StringBuilder>();
             Dictionary<string, string> config = new Dictionary<string, string>();
             config.Add("url", "https://www.testlitle.com/sandbox/communicator/online");
             config.Add("reportGroup", "Default Report Group");
@@ -27,7 +30,7 @@ namespace Litle.Sdk.Test.Functional
             config.Add("proxyPort", Properties.Settings.Default.proxyPort);
             config.Add("logFile", Properties.Settings.Default.logFile);
             config.Add("neuterAccountNums", "true");
-            litle = new LitleOnline(config);
+            litle = new LitleOnline(_memoryCache, config);
         }
 
         [Test]

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestEcheckCredit.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestEcheckCredit.cs
@@ -1,14 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Text;
 using NUnit.Framework;
-using Litle.Sdk;
 
 namespace Litle.Sdk.Test.Functional
 {
     [TestFixture]
-    class TestEcheckCredit
+    internal class TestEcheckCredit
     {
         private LitleOnline litle;
         private IDictionary<string, StringBuilder> _memoryStreams;
@@ -23,10 +20,10 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void simpleEcheckCredit()
         {
-            echeckCredit echeckcredit = new echeckCredit();
+            var echeckcredit = new echeckCredit();
             echeckcredit.amount = 12L;
             echeckcredit.litleTxnId = 123456789101112L;
-            echeckCreditResponse response = litle.EcheckCredit(echeckcredit);
+            var response = litle.EcheckCredit(echeckcredit);
 
             Assert.AreEqual("Approved", response.message);
         }
@@ -34,7 +31,7 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void noLitleTxnId()
         {
-            echeckCredit echeckcredit = new echeckCredit();
+            var echeckcredit = new echeckCredit();
             try
             {
                 litle.EcheckCredit(echeckcredit);
@@ -49,57 +46,57 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void echeckCreditWithEcheck()
         {
-            echeckCredit echeckcredit = new echeckCredit();
+            var echeckcredit = new echeckCredit();
             echeckcredit.amount = 12L;
             echeckcredit.orderId = "12345";
             echeckcredit.orderSource = orderSourceType.ecommerce;
-            echeckType echeck = new echeckType();
+            var echeck = new echeckType();
             echeck.accType = echeckAccountTypeEnum.Checking;
             echeck.accNum = "12345657890";
             echeck.routingNum = "123456789";
             echeck.checkNum = "123455";
             echeckcredit.echeck = echeck;
-            contact billToAddress = new contact();
+            var billToAddress = new contact();
             billToAddress.name = "Bob";
             billToAddress.city = "Lowell";
             billToAddress.state = "MA";
             billToAddress.email = "litle.com";
             echeckcredit.billToAddress = billToAddress;
-            echeckCreditResponse response = litle.EcheckCredit(echeckcredit);
+            var response = litle.EcheckCredit(echeckcredit);
             Assert.AreEqual("Approved", response.message);
         }
 
         [Test]
         public void echeckCreditWithToken()
         {
-            echeckCredit echeckcredit = new echeckCredit();
+            var echeckcredit = new echeckCredit();
             echeckcredit.amount = 12L;
             echeckcredit.orderId = "12345";
             echeckcredit.orderSource = orderSourceType.ecommerce;
-            echeckTokenType echeckToken = new echeckTokenType();
+            var echeckToken = new echeckTokenType();
             echeckToken.accType = echeckAccountTypeEnum.Checking;
             echeckToken.litleToken = "1234565789012";
             echeckToken.routingNum = "123456789";
             echeckToken.checkNum = "123455";
             echeckcredit.echeckToken = echeckToken;
-            contact billToAddress = new contact();
+            var billToAddress = new contact();
             billToAddress.name = "Bob";
             billToAddress.city = "Lowell";
             billToAddress.state = "MA";
             billToAddress.email = "litle.com";
             echeckcredit.billToAddress = billToAddress;
-            echeckCreditResponse response = litle.EcheckCredit(echeckcredit);
+            var response = litle.EcheckCredit(echeckcredit);
             Assert.AreEqual("Approved", response.message);
         }
 
         [Test]
         public void missingBilling()
         {
-            echeckCredit echeckcredit = new echeckCredit();
+            var echeckcredit = new echeckCredit();
             echeckcredit.amount = 12L;
             echeckcredit.orderId = "12345";
             echeckcredit.orderSource = orderSourceType.ecommerce;
-            echeckType echeck = new echeckType();
+            var echeck = new echeckType();
             echeck.accType = echeckAccountTypeEnum.Checking;
             echeck.accNum = "12345657890";
             echeck.routingNum = "123456789";
@@ -119,36 +116,36 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void echeckCreditWithSecondaryAmountWithOrderIdAndCcdPaymentInfo()
         {
-            echeckCredit echeckcredit = new echeckCredit();
+            var echeckcredit = new echeckCredit();
             echeckcredit.amount = 12L;
             echeckcredit.secondaryAmount = 50;
             echeckcredit.orderId = "12345";
             echeckcredit.orderSource = orderSourceType.ecommerce;
-            echeckType echeck = new echeckType();
+            var echeck = new echeckType();
             echeck.accType = echeckAccountTypeEnum.Checking;
             echeck.accNum = "12345657890";
             echeck.routingNum = "123456789";
             echeck.checkNum = "123455";
             echeck.ccdPaymentInformation = "9876554";
             echeckcredit.echeck = echeck;
-            contact billToAddress = new contact();
+            var billToAddress = new contact();
             billToAddress.name = "Bob";
             billToAddress.city = "Lowell";
             billToAddress.state = "MA";
             billToAddress.email = "litle.com";
             echeckcredit.billToAddress = billToAddress;
-            echeckCreditResponse response = litle.EcheckCredit(echeckcredit);
+            var response = litle.EcheckCredit(echeckcredit);
             Assert.AreEqual("Approved", response.message);
         }
 
         [Test]
         public void echeckCreditWithSecondaryAmountWithLitleTxnId()
         {
-            echeckCredit echeckcredit = new echeckCredit();
+            var echeckcredit = new echeckCredit();
             echeckcredit.amount = 12L;
             echeckcredit.secondaryAmount = 50;
             echeckcredit.litleTxnId = 12345L;
-            echeckCreditResponse response = litle.EcheckCredit(echeckcredit);
+            var response = litle.EcheckCredit(echeckcredit);
             Assert.AreEqual("Approved", response.message);
         }
     }

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestEcheckCredit.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestEcheckCredit.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -10,11 +11,13 @@ namespace Litle.Sdk.Test.Functional
     class TestEcheckCredit
     {
         private LitleOnline litle;
+        private IDictionary<string, StringBuilder> _memoryStreams;
 
         [TestFixtureSetUp]
         public void beforeClass()
         {
-            litle = new LitleOnline();
+            _memoryStreams = new Dictionary<string, StringBuilder>();
+            litle = new LitleOnline(_memoryStreams);
         }
 
         [Test]

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestEcheckRedeposit.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestEcheckRedeposit.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -10,10 +11,12 @@ namespace Litle.Sdk.Test.Functional
     class TestEcheckRedeposit
     {
         private LitleOnline litle;
+        private IDictionary<string, StringBuilder> _memoryCache;
 
         [TestFixtureSetUp]
         public void setUp()
         {
+            _memoryCache = new Dictionary<string, StringBuilder>();
             Dictionary<string, string> config = new Dictionary<string, string>();
             config.Add("url", "https://www.testlitle.com/sandbox/communicator/online");
             config.Add("reportGroup", "Default Report Group");
@@ -27,7 +30,7 @@ namespace Litle.Sdk.Test.Functional
             config.Add("proxyPort", Properties.Settings.Default.proxyPort);
             config.Add("logFile", Properties.Settings.Default.logFile);
             config.Add("neuterAccountNums", "true");
-            litle = new LitleOnline(config);
+            litle = new LitleOnline(_memoryCache, config);
         }
 
 

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestEcheckRedeposit.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestEcheckRedeposit.cs
@@ -1,14 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Text;
+using Litle.Sdk.Properties;
 using NUnit.Framework;
-using Litle.Sdk;
 
 namespace Litle.Sdk.Test.Functional
 {
     [TestFixture]
-    class TestEcheckRedeposit
+    internal class TestEcheckRedeposit
     {
         private LitleOnline litle;
         private IDictionary<string, StringBuilder> _memoryCache;
@@ -17,7 +15,7 @@ namespace Litle.Sdk.Test.Functional
         public void setUp()
         {
             _memoryCache = new Dictionary<string, StringBuilder>();
-            Dictionary<string, string> config = new Dictionary<string, string>();
+            var config = new Dictionary<string, string>();
             config.Add("url", "https://www.testlitle.com/sandbox/communicator/online");
             config.Add("reportGroup", "Default Report Group");
             config.Add("username", "DOTNET");
@@ -26,51 +24,53 @@ namespace Litle.Sdk.Test.Functional
             config.Add("merchantId", "101");
             config.Add("password", "TESTCASE");
             config.Add("printxml", "true");
-            config.Add("proxyHost", Properties.Settings.Default.proxyHost);
-            config.Add("proxyPort", Properties.Settings.Default.proxyPort);
-            config.Add("logFile", Properties.Settings.Default.logFile);
+            config.Add("proxyHost", Settings.Default.proxyHost);
+            config.Add("proxyPort", Settings.Default.proxyPort);
+            config.Add("logFile", Settings.Default.logFile);
             config.Add("neuterAccountNums", "true");
             litle = new LitleOnline(_memoryCache, config);
         }
 
 
         [Test]
-        public void simpleEcheckRedeposit() {
-            echeckRedeposit echeckredeposit = new echeckRedeposit();
+        public void simpleEcheckRedeposit()
+        {
+            var echeckredeposit = new echeckRedeposit();
             echeckredeposit.litleTxnId = 123456;
-            echeckRedepositResponse response = litle.EcheckRedeposit(echeckredeposit);
+            var response = litle.EcheckRedeposit(echeckredeposit);
             Assert.AreEqual("Approved", response.message);
         }
 
         [Test]
-        public void echeckRedepositWithEcheck() {
-            echeckRedeposit echeckredeposit = new echeckRedeposit();
+        public void echeckRedepositWithEcheck()
+        {
+            var echeckredeposit = new echeckRedeposit();
             echeckredeposit.litleTxnId = 123456;
-            echeckType echeck = new echeckType();
+            var echeck = new echeckType();
             echeck.accType = echeckAccountTypeEnum.Checking;
             echeck.accNum = "12345657890";
             echeck.routingNum = "123456789";
             echeck.checkNum = "123455";
 
             echeckredeposit.echeck = echeck;
-            echeckRedepositResponse response = litle.EcheckRedeposit(echeckredeposit);
+            var response = litle.EcheckRedeposit(echeckredeposit);
             Assert.AreEqual("Approved", response.message);
         }
 
         [Test]
-        public void echeckRedepositWithEcheckToken() {
-            echeckRedeposit echeckredeposit = new echeckRedeposit();
+        public void echeckRedepositWithEcheckToken()
+        {
+            var echeckredeposit = new echeckRedeposit();
             echeckredeposit.litleTxnId = 123456;
-            echeckTokenType echeckToken = new echeckTokenType();
+            var echeckToken = new echeckTokenType();
             echeckToken.accType = echeckAccountTypeEnum.Checking;
             echeckToken.litleToken = "1234565789012";
             echeckToken.routingNum = "123456789";
             echeckToken.checkNum = "123455";
 
             echeckredeposit.token = echeckToken;
-            echeckRedepositResponse response = litle.EcheckRedeposit(echeckredeposit);
+            var response = litle.EcheckRedeposit(echeckredeposit);
             Assert.AreEqual("Approved", response.message);
         }
-            
     }
 }

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestEcheckSale.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestEcheckSale.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -10,10 +11,12 @@ namespace Litle.Sdk.Test.Functional
     class TestEcheckSale
     {
         private LitleOnline litle;
+        private IDictionary<string, StringBuilder> _memoryCache;
 
         [TestFixtureSetUp]
         public void setUp()
         {
+            _memoryCache = new Dictionary<string, StringBuilder>();
             Dictionary<string, string> config = new Dictionary<string, string>();
             config.Add("url", "https://www.testlitle.com/sandbox/communicator/online");
             config.Add("reportGroup", "Default Report Group");
@@ -27,7 +30,7 @@ namespace Litle.Sdk.Test.Functional
             config.Add("proxyPort", Properties.Settings.Default.proxyPort);
             config.Add("logFile", Properties.Settings.Default.logFile);
             config.Add("neuterAccountNums", "true");
-            litle = new LitleOnline(config);
+            litle = new LitleOnline(_memoryCache, config);
         }
 
         [Test]

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestEcheckSale.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestEcheckSale.cs
@@ -1,14 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Text;
+using Litle.Sdk.Properties;
 using NUnit.Framework;
-using Litle.Sdk;
 
 namespace Litle.Sdk.Test.Functional
 {
     [TestFixture]
-    class TestEcheckSale
+    internal class TestEcheckSale
     {
         private LitleOnline litle;
         private IDictionary<string, StringBuilder> _memoryCache;
@@ -17,7 +15,7 @@ namespace Litle.Sdk.Test.Functional
         public void setUp()
         {
             _memoryCache = new Dictionary<string, StringBuilder>();
-            Dictionary<string, string> config = new Dictionary<string, string>();
+            var config = new Dictionary<string, string>();
             config.Add("url", "https://www.testlitle.com/sandbox/communicator/online");
             config.Add("reportGroup", "Default Report Group");
             config.Add("username", "DOTNET");
@@ -26,9 +24,9 @@ namespace Litle.Sdk.Test.Functional
             config.Add("merchantId", "101");
             config.Add("password", "TESTCASE");
             config.Add("printxml", "true");
-            config.Add("proxyHost", Properties.Settings.Default.proxyHost);
-            config.Add("proxyPort", Properties.Settings.Default.proxyPort);
-            config.Add("logFile", Properties.Settings.Default.logFile);
+            config.Add("proxyHost", Settings.Default.proxyHost);
+            config.Add("proxyPort", Settings.Default.proxyPort);
+            config.Add("logFile", Settings.Default.logFile);
             config.Add("neuterAccountNums", "true");
             litle = new LitleOnline(_memoryCache, config);
         }
@@ -36,18 +34,18 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void SimpleEcheckSaleWithEcheck()
         {
-            echeckSale echeckSaleObj = new echeckSale();
+            var echeckSaleObj = new echeckSale();
             echeckSaleObj.amount = 123456;
             echeckSaleObj.orderId = "12345";
             echeckSaleObj.orderSource = orderSourceType.ecommerce;
 
-            echeckType echeckTypeObj = new echeckType();
+            var echeckTypeObj = new echeckType();
             echeckTypeObj.accType = echeckAccountTypeEnum.Checking;
             echeckTypeObj.accNum = "12345657890";
             echeckTypeObj.routingNum = "123456789";
             echeckTypeObj.checkNum = "123455";
-            
-            contact contactObj = new contact();
+
+            var contactObj = new contact();
             contactObj.name = "Bob";
             contactObj.city = "lowell";
             contactObj.state = "MA";
@@ -56,20 +54,20 @@ namespace Litle.Sdk.Test.Functional
             echeckSaleObj.echeck = echeckTypeObj;
             echeckSaleObj.billToAddress = contactObj;
 
-            echeckSalesResponse response = litle.EcheckSale(echeckSaleObj);
+            var response = litle.EcheckSale(echeckSaleObj);
             StringAssert.AreEqualIgnoringCase("Approved", response.message);
         }
 
         [Test]
         public void NoAmount()
         {
-            echeckSale echeckSaleObj = new echeckSale();
+            var echeckSaleObj = new echeckSale();
             echeckSaleObj.reportGroup = "Planets";
-            
+
             try
             {
                 //expected exception;
-                echeckSalesResponse response = litle.EcheckSale(echeckSaleObj);
+                var response = litle.EcheckSale(echeckSaleObj);
             }
             catch (LitleOnlineException e)
             {
@@ -80,20 +78,20 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void EcheckSaleWithShipTo()
         {
-            echeckSale echeckSaleObj = new echeckSale();
+            var echeckSaleObj = new echeckSale();
             echeckSaleObj.reportGroup = "Planets";
             echeckSaleObj.amount = 123456;
             echeckSaleObj.verify = true;
             echeckSaleObj.orderId = "12345";
             echeckSaleObj.orderSource = orderSourceType.ecommerce;
 
-            echeckType echeckTypeObj = new echeckType();
+            var echeckTypeObj = new echeckType();
             echeckTypeObj.accType = echeckAccountTypeEnum.Checking;
             echeckTypeObj.accNum = "12345657890";
             echeckTypeObj.routingNum = "123456789";
             echeckTypeObj.checkNum = "123455";
 
-            contact contactObj = new contact();
+            var contactObj = new contact();
             contactObj.name = "Bob";
             contactObj.city = "lowell";
             contactObj.state = "MA";
@@ -103,31 +101,31 @@ namespace Litle.Sdk.Test.Functional
             echeckSaleObj.billToAddress = contactObj;
             echeckSaleObj.shipToAddress = contactObj;
 
-            echeckSalesResponse response = litle.EcheckSale(echeckSaleObj);
+            var response = litle.EcheckSale(echeckSaleObj);
             StringAssert.AreEqualIgnoringCase("Approved", response.message);
         }
 
         [Test]
         public void EcheckSaleWithEcheckToken()
         {
-            echeckSale echeckSaleObj = new echeckSale();
+            var echeckSaleObj = new echeckSale();
             echeckSaleObj.reportGroup = "Planets";
             echeckSaleObj.amount = 123456;
             echeckSaleObj.verify = true;
             echeckSaleObj.orderId = "12345";
             echeckSaleObj.orderSource = orderSourceType.ecommerce;
 
-            echeckTokenType echeckTokenTypeObj = new echeckTokenType();
+            var echeckTokenTypeObj = new echeckTokenType();
             echeckTokenTypeObj.accType = echeckAccountTypeEnum.Checking;
             echeckTokenTypeObj.litleToken = "1234565789012";
             echeckTokenTypeObj.routingNum = "123456789";
             echeckTokenTypeObj.checkNum = "123455";
 
-            customBilling customBillingObj = new customBilling();
+            var customBillingObj = new customBilling();
             customBillingObj.phone = "123456789";
             customBillingObj.descriptor = "good";
 
-            contact contactObj = new contact();
+            var contactObj = new contact();
             contactObj.name = "Bob";
             contactObj.city = "lowell";
             contactObj.state = "MA";
@@ -137,19 +135,19 @@ namespace Litle.Sdk.Test.Functional
             echeckSaleObj.customBilling = customBillingObj;
             echeckSaleObj.billToAddress = contactObj;
 
-            echeckSalesResponse response = litle.EcheckSale(echeckSaleObj);
+            var response = litle.EcheckSale(echeckSaleObj);
             StringAssert.AreEqualIgnoringCase("Approved", response.message);
         }
 
         [Test]
         public void EcheckSaleMissingBilling()
         {
-            echeckSale echeckSaleObj = new echeckSale();
+            var echeckSaleObj = new echeckSale();
             echeckSaleObj.amount = 123456;
             echeckSaleObj.orderId = "12345";
             echeckSaleObj.orderSource = orderSourceType.ecommerce;
 
-            echeckType echeckTypeObj = new echeckType();
+            var echeckTypeObj = new echeckType();
             echeckTypeObj.accType = echeckAccountTypeEnum.Checking;
             echeckTypeObj.accNum = "12345657890";
             echeckTypeObj.routingNum = "123456789";
@@ -160,7 +158,7 @@ namespace Litle.Sdk.Test.Functional
             try
             {
                 //expected exception;
-                echeckSalesResponse response = litle.EcheckSale(echeckSaleObj);
+                var response = litle.EcheckSale(echeckSaleObj);
             }
             catch (LitleOnlineException e)
             {
@@ -171,31 +169,31 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void SimpleEcheckSale()
         {
-            echeckSale echeckSaleObj = new echeckSale();
+            var echeckSaleObj = new echeckSale();
             echeckSaleObj.reportGroup = "Planets";
             echeckSaleObj.litleTxnId = 123456789101112;
             echeckSaleObj.amount = 12;
 
-            echeckSalesResponse response = litle.EcheckSale(echeckSaleObj);
+            var response = litle.EcheckSale(echeckSaleObj);
             StringAssert.AreEqualIgnoringCase("Approved", response.message);
         }
 
         [Test]
         public void SimpleEcheckSaleWithSecondaryAmountWithOrderId()
         {
-            echeckSale echeckSaleObj = new echeckSale();
+            var echeckSaleObj = new echeckSale();
             echeckSaleObj.amount = 123456;
             echeckSaleObj.secondaryAmount = 50;
             echeckSaleObj.orderId = "12345";
             echeckSaleObj.orderSource = orderSourceType.ecommerce;
 
-            echeckType echeckTypeObj = new echeckType();
+            var echeckTypeObj = new echeckType();
             echeckTypeObj.accType = echeckAccountTypeEnum.CorpSavings;
             echeckTypeObj.accNum = "12345657890";
             echeckTypeObj.routingNum = "123456789";
             echeckTypeObj.checkNum = "123455";
 
-            contact contactObj = new contact();
+            var contactObj = new contact();
             contactObj.name = "Bob";
             contactObj.city = "lowell";
             contactObj.state = "MA";
@@ -204,21 +202,21 @@ namespace Litle.Sdk.Test.Functional
             echeckSaleObj.echeck = echeckTypeObj;
             echeckSaleObj.billToAddress = contactObj;
 
-            echeckSalesResponse response = litle.EcheckSale(echeckSaleObj);
+            var response = litle.EcheckSale(echeckSaleObj);
             StringAssert.AreEqualIgnoringCase("Approved", response.message);
         }
 
         [Test]
         public void SimpleEcheckSaleWithSecondaryAmount()
         {
-            echeckSale echeckSaleObj = new echeckSale();
+            var echeckSaleObj = new echeckSale();
             echeckSaleObj.amount = 123456;
             echeckSaleObj.secondaryAmount = 50;
             echeckSaleObj.litleTxnId = 1234565L;
             try
             {
                 ////expected exception;
-                echeckSalesResponse response = litle.EcheckSale(echeckSaleObj);
+                var response = litle.EcheckSale(echeckSaleObj);
             }
             catch (LitleOnlineException e)
             {

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestEcheckVerification.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestEcheckVerification.cs
@@ -1,14 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Text;
+using Litle.Sdk.Properties;
 using NUnit.Framework;
-using Litle.Sdk;
 
 namespace Litle.Sdk.Test.Functional
 {
     [TestFixture]
-    class TestEcheckVerification
+    internal class TestEcheckVerification
     {
         private LitleOnline litle;
         private IDictionary<string, StringBuilder> _memoryCache;
@@ -17,7 +15,7 @@ namespace Litle.Sdk.Test.Functional
         public void setUp()
         {
             _memoryCache = new Dictionary<string, StringBuilder>();
-            Dictionary<string, string> config = new Dictionary<string, string>();
+            var config = new Dictionary<string, string>();
             config.Add("url", "https://www.testlitle.com/sandbox/communicator/online");
             config.Add("reportGroup", "Default Report Group");
             config.Add("username", "DOTNET");
@@ -26,9 +24,9 @@ namespace Litle.Sdk.Test.Functional
             config.Add("merchantId", "101");
             config.Add("password", "TESTCASE");
             config.Add("printxml", "true");
-            config.Add("proxyHost", Properties.Settings.Default.proxyHost);
-            config.Add("proxyPort", Properties.Settings.Default.proxyPort);
-            config.Add("logFile", Properties.Settings.Default.logFile);
+            config.Add("proxyHost", Settings.Default.proxyHost);
+            config.Add("proxyPort", Settings.Default.proxyPort);
+            config.Add("logFile", Settings.Default.logFile);
             config.Add("neuterAccountNums", "true");
             litle = new LitleOnline(_memoryCache, config);
         }
@@ -36,18 +34,18 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void SimpleEcheckVerification()
         {
-            echeckVerification echeckVerificationObject = new echeckVerification();
+            var echeckVerificationObject = new echeckVerification();
             echeckVerificationObject.amount = 123456;
             echeckVerificationObject.orderId = "12345";
             echeckVerificationObject.orderSource = orderSourceType.ecommerce;
-            
-            echeckType echeckTypeObj = new echeckType();
+
+            var echeckTypeObj = new echeckType();
             echeckTypeObj.accType = echeckAccountTypeEnum.Checking;
             echeckTypeObj.accNum = "12345657890";
             echeckTypeObj.routingNum = "123456789";
             echeckTypeObj.checkNum = "123455";
-            
-            contact contactObj = new contact();
+
+            var contactObj = new contact();
             contactObj.name = "Bob";
             contactObj.city = "lowell";
             contactObj.state = "MA";
@@ -56,25 +54,25 @@ namespace Litle.Sdk.Test.Functional
             echeckVerificationObject.echeck = echeckTypeObj;
             echeckVerificationObject.billToAddress = contactObj;
 
-            echeckVerificationResponse response = litle.EcheckVerification(echeckVerificationObject);
+            var response = litle.EcheckVerification(echeckVerificationObject);
             StringAssert.AreEqualIgnoringCase("Approved", response.message);
         }
 
         [Test]
         public void EcheckVerificationWithEcheckToken()
         {
-            echeckVerification echeckVerificationObject = new echeckVerification();
+            var echeckVerificationObject = new echeckVerification();
             echeckVerificationObject.amount = 123456;
             echeckVerificationObject.orderId = "12345";
             echeckVerificationObject.orderSource = orderSourceType.ecommerce;
 
-            echeckTokenType echeckTokenObj = new echeckTokenType();
+            var echeckTokenObj = new echeckTokenType();
             echeckTokenObj.accType = echeckAccountTypeEnum.Checking;
             echeckTokenObj.litleToken = "1234565789012";
             echeckTokenObj.routingNum = "123456789";
             echeckTokenObj.checkNum = "123455";
 
-            contact contactObj = new contact();
+            var contactObj = new contact();
             contactObj.name = "Bob";
             contactObj.city = "lowell";
             contactObj.state = "MA";
@@ -83,20 +81,20 @@ namespace Litle.Sdk.Test.Functional
             echeckVerificationObject.token = echeckTokenObj;
             echeckVerificationObject.billToAddress = contactObj;
 
-            echeckVerificationResponse response = litle.EcheckVerification(echeckVerificationObject);
+            var response = litle.EcheckVerification(echeckVerificationObject);
             StringAssert.AreEqualIgnoringCase("Approved", response.message);
         }
 
         [Test]
         public void TestMissingBillingField()
         {
-            echeckVerification echeckVerificationObject = new echeckVerification();
+            var echeckVerificationObject = new echeckVerification();
             echeckVerificationObject.reportGroup = "Planets";
             echeckVerificationObject.amount = 123;
             echeckVerificationObject.orderId = "12345";
             echeckVerificationObject.orderSource = orderSourceType.ecommerce;
 
-            echeckType echeckTypeObj = new echeckType();
+            var echeckTypeObj = new echeckType();
             echeckTypeObj.accType = echeckAccountTypeEnum.Checking;
             echeckTypeObj.accNum = "12345657890";
             echeckTypeObj.routingNum = "123456789";
@@ -105,7 +103,7 @@ namespace Litle.Sdk.Test.Functional
             try
             {
                 //expected exception;
-                echeckVerificationResponse response = litle.EcheckVerification(echeckVerificationObject);
+                var response = litle.EcheckVerification(echeckVerificationObject);
             }
             catch (LitleOnlineException e)
             {

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestEcheckVerification.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestEcheckVerification.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -10,10 +11,12 @@ namespace Litle.Sdk.Test.Functional
     class TestEcheckVerification
     {
         private LitleOnline litle;
+        private IDictionary<string, StringBuilder> _memoryCache;
 
         [TestFixtureSetUp]
         public void setUp()
         {
+            _memoryCache = new Dictionary<string, StringBuilder>();
             Dictionary<string, string> config = new Dictionary<string, string>();
             config.Add("url", "https://www.testlitle.com/sandbox/communicator/online");
             config.Add("reportGroup", "Default Report Group");
@@ -27,7 +30,7 @@ namespace Litle.Sdk.Test.Functional
             config.Add("proxyPort", Properties.Settings.Default.proxyPort);
             config.Add("logFile", Properties.Settings.Default.logFile);
             config.Add("neuterAccountNums", "true");
-            litle = new LitleOnline(config);
+            litle = new LitleOnline(_memoryCache, config);
         }
 
         [Test]

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestForceCapture.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestForceCapture.cs
@@ -1,14 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Text;
+using Litle.Sdk.Properties;
 using NUnit.Framework;
-using Litle.Sdk;
 
 namespace Litle.Sdk.Test.Functional
 {
     [TestFixture]
-    class TestForceCapture
+    internal class TestForceCapture
     {
         private LitleOnline litle;
         private IDictionary<string, StringBuilder> _memoryCache;
@@ -17,7 +15,7 @@ namespace Litle.Sdk.Test.Functional
         public void setUp()
         {
             _memoryCache = new Dictionary<string, StringBuilder>();
-            Dictionary<string, string> config = new Dictionary<string, string>();
+            var config = new Dictionary<string, string>();
             config.Add("url", "https://www.testlitle.com/sandbox/communicator/online");
             config.Add("reportGroup", "Default Report Group");
             config.Add("username", "DOTNET");
@@ -26,61 +24,64 @@ namespace Litle.Sdk.Test.Functional
             config.Add("merchantId", "101");
             config.Add("password", "TESTCASE");
             config.Add("printxml", "true");
-            config.Add("proxyHost", Properties.Settings.Default.proxyHost);
-            config.Add("proxyPort", Properties.Settings.Default.proxyPort);
-            config.Add("logFile", Properties.Settings.Default.logFile);
+            config.Add("proxyHost", Settings.Default.proxyHost);
+            config.Add("proxyPort", Settings.Default.proxyPort);
+            config.Add("logFile", Settings.Default.logFile);
             config.Add("neuterAccountNums", "true");
             litle = new LitleOnline(_memoryCache, config);
         }
 
         [Test]
-        public void simpleForceCaptureWithCard() {
-            forceCapture forcecapture = new forceCapture();
+        public void simpleForceCaptureWithCard()
+        {
+            var forcecapture = new forceCapture();
             forcecapture.amount = 106;
             forcecapture.orderId = "12344";
             forcecapture.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000001";
             card.expDate = "1210";
             forcecapture.card = card;
-            forceCaptureResponse response = litle.ForceCapture(forcecapture);
+            var response = litle.ForceCapture(forcecapture);
             Assert.AreEqual("Approved", response.message);
         }
 
         [Test]
         public void simpleForceCaptureWithMpos()
         {
-            mposType mpos = new mposType();
+            var mpos = new mposType();
             mpos.ksn = "77853211300008E00016";
-            mpos.encryptedTrack = "CASE1E185EADD6AFE78C9A214B21313DCD836FDD555FBE3A6C48D141FE80AB9172B963265AFF72111895FE415DEDA162CE8CB7AC4D91EDB611A2AB756AA9CB1A000000000000000000000000000000005A7AAF5E8885A9DB88ECD2430C497003F2646619A2382FFF205767492306AC804E8E64E8EA6981DD";
+            mpos.encryptedTrack =
+                "CASE1E185EADD6AFE78C9A214B21313DCD836FDD555FBE3A6C48D141FE80AB9172B963265AFF72111895FE415DEDA162CE8CB7AC4D91EDB611A2AB756AA9CB1A000000000000000000000000000000005A7AAF5E8885A9DB88ECD2430C497003F2646619A2382FFF205767492306AC804E8E64E8EA6981DD";
             mpos.formatId = "30";
             mpos.track1Status = 0;
             mpos.track2Status = 0;
-            forceCapture forcecapture = new forceCapture();
+            var forcecapture = new forceCapture();
             forcecapture.amount = 322;
             forcecapture.orderId = "12344";
             forcecapture.orderSource = orderSourceType.ecommerce;
             forcecapture.mpos = mpos;
-            forceCaptureResponse response = litle.ForceCapture(forcecapture);
+            var response = litle.ForceCapture(forcecapture);
             Assert.AreEqual("Approved", response.message);
         }
 
         [Test]
-        public void simpleForceCaptureWithToken() {
-            forceCapture forcecapture = new forceCapture();
+        public void simpleForceCaptureWithToken()
+        {
+            var forcecapture = new forceCapture();
             forcecapture.amount = 106;
             forcecapture.orderId = "12344";
             forcecapture.orderSource = orderSourceType.ecommerce;
-            cardTokenType token = new cardTokenType();
+            var token = new cardTokenType();
             token.litleToken = "123456789101112";
             token.expDate = "1210";
             token.cardValidationNum = "555";
             token.type = methodOfPaymentTypeEnum.VI;
             forcecapture.token = token;
-            forceCaptureResponse response = litle.ForceCapture(forcecapture);
-            Assert.AreEqual("Approved", response.message); ;
+            var response = litle.ForceCapture(forcecapture);
+            Assert.AreEqual("Approved", response.message);
+            ;
         }
-            
     }
 }

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestForceCapture.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestForceCapture.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -10,10 +11,12 @@ namespace Litle.Sdk.Test.Functional
     class TestForceCapture
     {
         private LitleOnline litle;
+        private IDictionary<string, StringBuilder> _memoryCache;
 
         [TestFixtureSetUp]
         public void setUp()
         {
+            _memoryCache = new Dictionary<string, StringBuilder>();
             Dictionary<string, string> config = new Dictionary<string, string>();
             config.Add("url", "https://www.testlitle.com/sandbox/communicator/online");
             config.Add("reportGroup", "Default Report Group");
@@ -27,7 +30,7 @@ namespace Litle.Sdk.Test.Functional
             config.Add("proxyPort", Properties.Settings.Default.proxyPort);
             config.Add("logFile", Properties.Settings.Default.logFile);
             config.Add("neuterAccountNums", "true");
-            litle = new LitleOnline(config);
+            litle = new LitleOnline(_memoryCache, config);
         }
 
         [Test]

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestSale.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestSale.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -10,10 +11,12 @@ namespace Litle.Sdk.Test.Functional
     class TestSale
     {
         private LitleOnline litle;
+        private IDictionary<string, StringBuilder> _memoryCache;
 
         [TestFixtureSetUp]
         public void setUp()
         {
+            _memoryCache = new Dictionary<string, StringBuilder>();
             Dictionary<string, string> config = new Dictionary<string, string>();
             config.Add("url", "https://www.testlitle.com/sandbox/communicator/online");
             config.Add("reportGroup", "Default Report Group");
@@ -27,7 +30,7 @@ namespace Litle.Sdk.Test.Functional
             config.Add("proxyPort", Properties.Settings.Default.proxyPort);
             config.Add("logFile", Properties.Settings.Default.logFile);
             config.Add("neuterAccountNums", "true");
-            litle = new LitleOnline(config);
+            litle = new LitleOnline(_memoryCache, config);
         }
 
         [Test]

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestSale.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestSale.cs
@@ -1,14 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Text;
+using Litle.Sdk.Properties;
 using NUnit.Framework;
-using Litle.Sdk;
 
 namespace Litle.Sdk.Test.Functional
 {
     [TestFixture]
-    class TestSale
+    internal class TestSale
     {
         private LitleOnline litle;
         private IDictionary<string, StringBuilder> _memoryCache;
@@ -17,7 +15,7 @@ namespace Litle.Sdk.Test.Functional
         public void setUp()
         {
             _memoryCache = new Dictionary<string, StringBuilder>();
-            Dictionary<string, string> config = new Dictionary<string, string>();
+            var config = new Dictionary<string, string>();
             config.Add("url", "https://www.testlitle.com/sandbox/communicator/online");
             config.Add("reportGroup", "Default Report Group");
             config.Add("username", "DOTNET");
@@ -26,9 +24,9 @@ namespace Litle.Sdk.Test.Functional
             config.Add("merchantId", "101");
             config.Add("password", "TESTCASE");
             config.Add("printxml", "true");
-            config.Add("proxyHost", Properties.Settings.Default.proxyHost);
-            config.Add("proxyPort", Properties.Settings.Default.proxyPort);
-            config.Add("logFile", Properties.Settings.Default.logFile);
+            config.Add("proxyHost", Settings.Default.proxyHost);
+            config.Add("proxyPort", Settings.Default.proxyPort);
+            config.Add("logFile", Settings.Default.logFile);
             config.Add("neuterAccountNums", "true");
             litle = new LitleOnline(_memoryCache, config);
         }
@@ -36,69 +34,71 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void SimpleSaleWithCard()
         {
-            sale saleObj = new sale();
+            var saleObj = new sale();
             saleObj.amount = 106;
             saleObj.litleTxnId = 123456;
             saleObj.orderId = "12344";
             saleObj.orderSource = orderSourceType.ecommerce;
-            cardType cardObj = new cardType();
+            var cardObj = new cardType();
             cardObj.type = methodOfPaymentTypeEnum.VI;
             cardObj.number = "4100000000000000";
             cardObj.expDate = "1210";
             saleObj.card = cardObj;
 
-            saleResponse responseObj = litle.Sale(saleObj);
+            var responseObj = litle.Sale(saleObj);
             StringAssert.AreEqualIgnoringCase("Approved", responseObj.message);
         }
 
         [Test]
         public void SimpleSaleWithMpos()
         {
-            sale saleObj = new sale();
+            var saleObj = new sale();
             saleObj.amount = 106;
             saleObj.litleTxnId = 123456;
             saleObj.orderId = "12344";
             saleObj.orderSource = orderSourceType.ecommerce;
-            mposType mpos = new mposType();
+            var mpos = new mposType();
             mpos.ksn = "77853211300008E00016";
-            mpos.encryptedTrack = "CASE1E185EADD6AFE78C9A214B21313DCD836FDD555FBE3A6C48D141FE80AB9172B963265AFF72111895FE415DEDA162CE8CB7AC4D91EDB611A2AB756AA9CB1A000000000000000000000000000000005A7AAF5E8885A9DB88ECD2430C497003F2646619A2382FFF205767492306AC804E8E64E8EA6981DD";
+            mpos.encryptedTrack =
+                "CASE1E185EADD6AFE78C9A214B21313DCD836FDD555FBE3A6C48D141FE80AB9172B963265AFF72111895FE415DEDA162CE8CB7AC4D91EDB611A2AB756AA9CB1A000000000000000000000000000000005A7AAF5E8885A9DB88ECD2430C497003F2646619A2382FFF205767492306AC804E8E64E8EA6981DD";
             mpos.formatId = "30";
             mpos.track1Status = 0;
-            mpos.track2Status = 0; ;
+            mpos.track2Status = 0;
+            ;
             saleObj.mpos = mpos;
 
-            saleResponse responseObj = litle.Sale(saleObj);
+            var responseObj = litle.Sale(saleObj);
             StringAssert.AreEqualIgnoringCase("Approved", responseObj.message);
         }
 
         [Test]
         public void SimpleSaleWithPayPal()
         {
-            sale saleObj = new sale();
+            var saleObj = new sale();
             saleObj.amount = 106;
             saleObj.litleTxnId = 123456;
             saleObj.orderId = "12344";
             saleObj.orderSource = orderSourceType.ecommerce;
-            payPal payPalObj = new payPal();
+            var payPalObj = new payPal();
             payPalObj.payerId = "1234";
             payPalObj.token = "1234";
             payPalObj.transactionId = "123456";
             saleObj.paypal = payPalObj;
-            saleResponse responseObj = litle.Sale(saleObj);
+            var responseObj = litle.Sale(saleObj);
             StringAssert.AreEqualIgnoringCase("Approved", responseObj.message);
         }
 
         [Test]
         public void SimpleSaleWithApplepayAndSecondaryAmountAndWallet()
         {
-            sale saleObj = new sale();
+            var saleObj = new sale();
             saleObj.amount = 110;
             saleObj.secondaryAmount = 50;
             saleObj.litleTxnId = 123456;
             saleObj.orderId = "12344";
             saleObj.orderSource = orderSourceType.ecommerce;
-            applepayType applepay = new applepayType();
-            applepayHeaderType applepayHeaderType = new applepayHeaderType();
+            var applepay = new applepayType();
+            var applepayHeaderType = new applepayHeaderType();
             applepayHeaderType.applicationData = "454657413164";
             applepayHeaderType.ephemeralPublicKey = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
             applepayHeaderType.publicKeyHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
@@ -108,12 +108,12 @@ namespace Litle.Sdk.Test.Functional
             applepay.signature = "sign";
             applepay.version = "1";
             saleObj.applepay = applepay;
-            wallet wallet = new Sdk.wallet();
+            var wallet = new wallet();
             wallet.walletSourceTypeId = "123";
             wallet.walletSourceType = walletWalletSourceType.MasterPass;
             saleObj.wallet = wallet;
 
-            saleResponse responseObj = litle.Sale(saleObj);
+            var responseObj = litle.Sale(saleObj);
             Assert.AreEqual("Insufficient Funds", responseObj.message);
             Assert.AreEqual("110", responseObj.applepayResponse.transactionAmount);
         }
@@ -121,23 +121,24 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void SimpleSaleWithInvalidFraudCheck()
         {
-            sale saleObj = new sale();
+            var saleObj = new sale();
             saleObj.amount = 106;
             saleObj.litleTxnId = 123456;
             saleObj.orderId = "12344";
             saleObj.orderSource = orderSourceType.ecommerce;
-            cardType cardObj = new cardType();
+            var cardObj = new cardType();
             cardObj.type = methodOfPaymentTypeEnum.VI;
             cardObj.number = "4100000000000000";
             cardObj.expDate = "1210";
             saleObj.card = cardObj;
-            fraudCheckType cardholderAuthentication = new fraudCheckType();
-            cardholderAuthentication.authenticationValue = "123456789012345678901234567890123456789012345678901234567890";
+            var cardholderAuthentication = new fraudCheckType();
+            cardholderAuthentication.authenticationValue =
+                "123456789012345678901234567890123456789012345678901234567890";
             saleObj.cardholderAuthentication = cardholderAuthentication;
 
             try
             {
-                saleResponse responseObj = litle.Sale(saleObj);
+                var responseObj = litle.Sale(saleObj);
             }
             catch (LitleOnlineException e)
             {

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestToken.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestToken.cs
@@ -1,14 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Text;
+using Litle.Sdk.Properties;
 using NUnit.Framework;
-using Litle.Sdk;
 
 namespace Litle.Sdk.Test.Functional
 {
     [TestFixture]
-    class TestToken
+    internal class TestToken
     {
         private LitleOnline litle;
         private IDictionary<string, StringBuilder> _memoryCache;
@@ -17,7 +15,7 @@ namespace Litle.Sdk.Test.Functional
         public void setUp()
         {
             _memoryCache = new Dictionary<string, StringBuilder>();
-            Dictionary<string, string> config = new Dictionary<string, string>();
+            var config = new Dictionary<string, string>();
             config.Add("url", "https://www.testlitle.com/sandbox/communicator/online");
             config.Add("reportGroup", "Default Report Group");
             config.Add("username", "DOTNET");
@@ -26,9 +24,9 @@ namespace Litle.Sdk.Test.Functional
             config.Add("merchantId", "101");
             config.Add("password", "TESTCASE");
             config.Add("printxml", "true");
-            config.Add("proxyHost", Properties.Settings.Default.proxyHost);
-            config.Add("proxyPort", Properties.Settings.Default.proxyPort);
-            config.Add("logFile", Properties.Settings.Default.logFile);
+            config.Add("proxyHost", Settings.Default.proxyHost);
+            config.Add("proxyPort", Settings.Default.proxyPort);
+            config.Add("logFile", Settings.Default.logFile);
             config.Add("neuterAccountNums", "true");
             litle = new LitleOnline(_memoryCache, config);
         }
@@ -36,11 +34,11 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void SimpleToken()
         {
-            registerTokenRequestType registerTokenRequest = new registerTokenRequestType();
+            var registerTokenRequest = new registerTokenRequestType();
             registerTokenRequest.orderId = "12344";
             registerTokenRequest.accountNumber = "1233456789103801";
             registerTokenRequest.reportGroup = "Planets";
-            registerTokenResponse rtokenResponse = litle.RegisterToken(registerTokenRequest);
+            var rtokenResponse = litle.RegisterToken(registerTokenRequest);
             StringAssert.AreEqualIgnoringCase("Account number was successfully registered", rtokenResponse.message);
         }
 
@@ -48,36 +46,36 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void SimpleTokenWithPayPage()
         {
-            registerTokenRequestType registerTokenRequest = new registerTokenRequestType();
+            var registerTokenRequest = new registerTokenRequestType();
             registerTokenRequest.orderId = "12344";
             registerTokenRequest.paypageRegistrationId = "1233456789101112";
             registerTokenRequest.reportGroup = "Planets";
-            registerTokenResponse rtokenResponse = litle.RegisterToken(registerTokenRequest);
+            var rtokenResponse = litle.RegisterToken(registerTokenRequest);
             StringAssert.AreEqualIgnoringCase("Account number was successfully registered", rtokenResponse.message);
         }
 
         [Test]
         public void SimpleTokenWithEcheck()
         {
-            registerTokenRequestType registerTokenRequest = new registerTokenRequestType();
+            var registerTokenRequest = new registerTokenRequestType();
             registerTokenRequest.orderId = "12344";
-            echeckForTokenType echeckObj = new echeckForTokenType();
+            var echeckObj = new echeckForTokenType();
             echeckObj.accNum = "12344565";
             echeckObj.routingNum = "123476545";
             registerTokenRequest.echeckForToken = echeckObj;
             registerTokenRequest.reportGroup = "Planets";
-            registerTokenResponse rtokenResponse = litle.RegisterToken(registerTokenRequest);
+            var rtokenResponse = litle.RegisterToken(registerTokenRequest);
             StringAssert.AreEqualIgnoringCase("Account number was successfully registered", rtokenResponse.message);
         }
 
         [Test]
         public void SimpleTokenWithApplepay()
         {
-            registerTokenRequestType registerTokenRequest = new registerTokenRequestType();
+            var registerTokenRequest = new registerTokenRequestType();
             registerTokenRequest.orderId = "12344";
             registerTokenRequest.reportGroup = "Planets";
-            applepayType applepay = new applepayType();
-            applepayHeaderType applepayHeaderType = new applepayHeaderType();
+            var applepay = new applepayType();
+            var applepayHeaderType = new applepayHeaderType();
             applepayHeaderType.applicationData = "454657413164";
             applepayHeaderType.ephemeralPublicKey = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
             applepayHeaderType.publicKeyHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
@@ -87,7 +85,7 @@ namespace Litle.Sdk.Test.Functional
             applepay.signature = "sign";
             applepay.version = "1";
             registerTokenRequest.applepay = applepay;
-            registerTokenResponse rtokenResponse = litle.RegisterToken(registerTokenRequest);
+            var rtokenResponse = litle.RegisterToken(registerTokenRequest);
             StringAssert.AreEqualIgnoringCase("Account number was successfully registered", rtokenResponse.message);
             Assert.AreEqual("0", rtokenResponse.applepayResponse.transactionAmount);
         }
@@ -95,16 +93,16 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void TokenEcheckMissingRequiredField()
         {
-            registerTokenRequestType registerTokenRequest = new registerTokenRequestType();
+            var registerTokenRequest = new registerTokenRequestType();
             registerTokenRequest.orderId = "12344";
-            echeckForTokenType echeckObj = new echeckForTokenType();
+            var echeckObj = new echeckForTokenType();
             echeckObj.routingNum = "123476545";
             registerTokenRequest.echeckForToken = echeckObj;
             registerTokenRequest.reportGroup = "Planets";
             try
             {
                 //expected exception;
-                registerTokenResponse rtokenResponse = litle.RegisterToken(registerTokenRequest);
+                var rtokenResponse = litle.RegisterToken(registerTokenRequest);
             }
             catch (LitleOnlineException e)
             {
@@ -115,11 +113,11 @@ namespace Litle.Sdk.Test.Functional
         [Test]
         public void TestSimpleTokenWithNullableTypeField()
         {
-            registerTokenRequestType registerTokenRequest = new registerTokenRequestType();
+            var registerTokenRequest = new registerTokenRequestType();
             registerTokenRequest.orderId = "12344";
             registerTokenRequest.accountNumber = "1233456789103801";
             registerTokenRequest.reportGroup = "Planets";
-            registerTokenResponse rtokenResponse = litle.RegisterToken(registerTokenRequest);
+            var rtokenResponse = litle.RegisterToken(registerTokenRequest);
             StringAssert.AreEqualIgnoringCase("Account number was successfully registered", rtokenResponse.message);
             Assert.IsNull(rtokenResponse.type);
         }

--- a/LitleSdkForNet/LitleSdkForNetTest/Functional/TestToken.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Functional/TestToken.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -10,10 +11,12 @@ namespace Litle.Sdk.Test.Functional
     class TestToken
     {
         private LitleOnline litle;
+        private IDictionary<string, StringBuilder> _memoryCache;
 
         [TestFixtureSetUp]
         public void setUp()
         {
+            _memoryCache = new Dictionary<string, StringBuilder>();
             Dictionary<string, string> config = new Dictionary<string, string>();
             config.Add("url", "https://www.testlitle.com/sandbox/communicator/online");
             config.Add("reportGroup", "Default Report Group");
@@ -27,7 +30,7 @@ namespace Litle.Sdk.Test.Functional
             config.Add("proxyPort", Properties.Settings.Default.proxyPort);
             config.Add("logFile", Properties.Settings.Default.logFile);
             config.Add("neuterAccountNums", "true");
-            litle = new LitleOnline(config);
+            litle = new LitleOnline(_memoryCache, config);
         }
 
         [Test]

--- a/LitleSdkForNet/LitleSdkForNetTest/Program.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Program.cs
@@ -1,16 +1,12 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Litle.Sdk.Test
 {
-    class Program
+    internal class Program
     {
         [STAThread]
-        static void Main(string[] args)
+        private static void Main()
         {
-
         }
     }
 }

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestActivateReversal.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestActivateReversal.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -13,11 +14,13 @@ namespace Litle.Sdk.Test.Unit
     class TestActivateReversal
     {        
         private LitleOnline litle;
+        private IDictionary<string, StringBuilder> _memoryStreams;
 
         [TestFixtureSetUp]
         public void SetUpLitle()
         {
-            litle = new LitleOnline();
+            _memoryStreams = new Dictionary<string, StringBuilder>();
+            litle = new LitleOnline(_memoryStreams);
         }
 
         [Test]
@@ -28,7 +31,7 @@ namespace Litle.Sdk.Test.Unit
             activateReversal.reportGroup = "b";
             activateReversal.litleTxnId = "123";
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(new Dictionary<string, StringBuilder>());
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<litleTxnId>123</litleTxnId>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><activateReversalResponse><litleTxnId>123</litleTxnId></activateReversalResponse></litleOnlineResponse>");

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestActivateReversal.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestActivateReversal.cs
@@ -1,18 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Text;
-using NUnit.Framework;
-using Litle.Sdk;
-using Moq;
 using System.Text.RegularExpressions;
-
+using Moq;
+using NUnit.Framework;
 
 namespace Litle.Sdk.Test.Unit
 {
     [TestFixture]
-    class TestActivateReversal
-    {        
+    internal class TestActivateReversal
+    {
         private LitleOnline litle;
         private IDictionary<string, StringBuilder> _memoryStreams;
 
@@ -26,22 +22,24 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestSimple()
         {
-            activateReversal activateReversal = new activateReversal();
+            var activateReversal = new activateReversal();
             activateReversal.id = "a";
             activateReversal.reportGroup = "b";
             activateReversal.litleTxnId = "123";
 
             var mock = new Mock<Communications>(new Dictionary<string, StringBuilder>());
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<litleTxnId>123</litleTxnId>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><activateReversalResponse><litleTxnId>123</litleTxnId></activateReversalResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(It.IsRegex(".*<litleTxnId>123</litleTxnId>.*", RegexOptions.Singleline),
+                        It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><activateReversalResponse><litleTxnId>123</litleTxnId></activateReversalResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            activateReversalResponse response = litle.ActivateReversal(activateReversal);
+            var response = litle.ActivateReversal(activateReversal);
             Assert.AreEqual("123", response.litleTxnId);
         }
-
-
     }
 }

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestAuthReversal.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestAuthReversal.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -14,11 +15,13 @@ namespace Litle.Sdk.Test.Unit
     {
         
         private LitleOnline litle;
+        private IDictionary<string, StringBuilder> _memoryStreams;
 
         [TestFixtureSetUp]
         public void SetUpLitle()
         {
-            litle = new LitleOnline();
+            _memoryStreams = new Dictionary<string, StringBuilder>();
+            litle = new LitleOnline(_memoryStreams);
         }
 
         [Test]
@@ -31,7 +34,7 @@ namespace Litle.Sdk.Test.Unit
             reversal.payPalNotes = "note";
             reversal.reportGroup = "Planets";
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(new Dictionary<string, StringBuilder>());
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<surchargeAmount>1</surchargeAmount>\r\n<payPalNotes>note</payPalNotes>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authReversalResponse><litleTxnId>123</litleTxnId></authReversalResponse></litleOnlineResponse>");
@@ -50,7 +53,7 @@ namespace Litle.Sdk.Test.Unit
             reversal.payPalNotes = "note";
             reversal.reportGroup = "Planets";
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(new Dictionary<string, StringBuilder>());
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<payPalNotes>note</payPalNotes>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authReversalResponse><litleTxnId>123</litleTxnId></authReversalResponse></litleOnlineResponse>");

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestAuthReversal.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestAuthReversal.cs
@@ -1,19 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Text;
-using NUnit.Framework;
-using Litle.Sdk;
-using Moq;
 using System.Text.RegularExpressions;
-
+using Moq;
+using NUnit.Framework;
 
 namespace Litle.Sdk.Test.Unit
 {
     [TestFixture]
-    class TestAuthReversal
+    internal class TestAuthReversal
     {
-        
         private LitleOnline litle;
         private IDictionary<string, StringBuilder> _memoryStreams;
 
@@ -27,7 +22,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestSurchargeAmount()
         {
-            authReversal reversal = new authReversal();
+            var reversal = new authReversal();
             reversal.litleTxnId = 3;
             reversal.amount = 2;
             reversal.surchargeAmount = 1;
@@ -36,10 +31,16 @@ namespace Litle.Sdk.Test.Unit
 
             var mock = new Mock<Communications>(new Dictionary<string, StringBuilder>());
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<surchargeAmount>1</surchargeAmount>\r\n<payPalNotes>note</payPalNotes>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authReversalResponse><litleTxnId>123</litleTxnId></authReversalResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*<amount>2</amount>\r\n<surchargeAmount>1</surchargeAmount>\r\n<payPalNotes>note</payPalNotes>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authReversalResponse><litleTxnId>123</litleTxnId></authReversalResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.AuthReversal(reversal);
         }
@@ -47,7 +48,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestSurchargeAmount_Optional()
         {
-            authReversal reversal = new authReversal();
+            var reversal = new authReversal();
             reversal.litleTxnId = 3;
             reversal.amount = 2;
             reversal.payPalNotes = "note";
@@ -55,13 +56,17 @@ namespace Litle.Sdk.Test.Unit
 
             var mock = new Mock<Communications>(new Dictionary<string, StringBuilder>());
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<payPalNotes>note</payPalNotes>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authReversalResponse><litleTxnId>123</litleTxnId></authReversalResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(".*<amount>2</amount>\r\n<payPalNotes>note</payPalNotes>.*", RegexOptions.Singleline),
+                        It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authReversalResponse><litleTxnId>123</litleTxnId></authReversalResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.AuthReversal(reversal);
         }
-
     }
 }

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestAuthorization.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestAuthorization.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -14,11 +15,13 @@ namespace Litle.Sdk.Test.Unit
     {
 
         private LitleOnline litle;
+        private IDictionary<string, StringBuilder> _memoryStreams;
 
         [TestFixtureSetUp]
         public void SetUpLitle()
         {
-            litle = new LitleOnline();
+            _memoryStreams = new Dictionary<string, StringBuilder>();
+            litle = new LitleOnline(_memoryStreams);
         }
 
         [Test]
@@ -31,7 +34,7 @@ namespace Litle.Sdk.Test.Unit
             auth.reportGroup = "Planets";
             auth.fraudFilterOverride = true;
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<fraudFilterOverride>true</fraudFilterOverride>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
@@ -57,7 +60,7 @@ namespace Litle.Sdk.Test.Unit
             billToAddress.zip = "12345";
             auth.billToAddress = billToAddress;
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<zip>12345</zip>.*<email>gdake@litle.com</email>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
@@ -83,7 +86,7 @@ namespace Litle.Sdk.Test.Unit
             billToAddress.zip = "12345";
             auth.billToAddress = billToAddress;
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>.*<orderSource>3dsAttempted</orderSource>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
@@ -109,7 +112,7 @@ namespace Litle.Sdk.Test.Unit
             billToAddress.zip = "12345";
             auth.billToAddress = billToAddress;
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>.*<orderSource>3dsAuthenticated</orderSource>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
@@ -132,7 +135,7 @@ namespace Litle.Sdk.Test.Unit
             auth.orderSource = orderSourceType.ecommerce;
             auth.reportGroup = "Planets";
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<secondaryAmount>1</secondaryAmount>\r\n<orderSource>ecommerce</orderSource>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
@@ -155,7 +158,7 @@ namespace Litle.Sdk.Test.Unit
             auth.orderSource = orderSourceType.ecommerce;
             auth.reportGroup = "Planets";
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<surchargeAmount>1</surchargeAmount>\r\n<orderSource>ecommerce</orderSource>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
@@ -177,7 +180,7 @@ namespace Litle.Sdk.Test.Unit
             auth.orderSource = orderSourceType.ecommerce;
             auth.reportGroup = "Planets";
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<orderSource>ecommerce</orderSource>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
@@ -204,7 +207,7 @@ namespace Litle.Sdk.Test.Unit
             card.expDate = "1210";
             auth.card = card;
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<card>\r\n<type>GC</type>\r\n<number>414100000000000000</number>\r\n<expDate>1210</expDate>\r\n</card>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
@@ -241,7 +244,7 @@ namespace Litle.Sdk.Test.Unit
             wallet.walletSourceTypeId = "123";
             auth.wallet = wallet;
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<authorization.*?<orderSource>applepay</orderSource>.*?<applepay>.*?<data>user</data>.*?</applepay>.*?<wallet>.*?<walletSourceTypeId>123</walletSourceTypeId>.*?</wallet>.*?</authorization>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
@@ -271,7 +274,7 @@ namespace Litle.Sdk.Test.Unit
             auth.recurringRequest.subscription.planCode = "abc123";
             auth.recurringRequest.subscription.numberOfPayments = 12;
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<fraudFilterOverride>true</fraudFilterOverride>\r\n<recurringRequest>\r\n<subscription>\r\n<planCode>abc123</planCode>\r\n<numberOfPayments>12</numberOfPayments>\r\n</subscription>\r\n</recurringRequest>\r\n</authorization>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.18' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
@@ -298,7 +301,7 @@ namespace Litle.Sdk.Test.Unit
             auth.fraudFilterOverride = true;
             auth.debtRepayment = true;
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<fraudFilterOverride>true</fraudFilterOverride>\r\n<debtRepayment>true</debtRepayment>\r\n</authorization>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
@@ -370,7 +373,7 @@ namespace Litle.Sdk.Test.Unit
 
             Assert.AreEqual(expectedResult, auth.Serialize());
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<authorization id=\".*>.*<customerIpAddress>192.168.1.1</customerIpAddress>.*</authorization>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
 
@@ -417,7 +420,7 @@ namespace Litle.Sdk.Test.Unit
 
             Assert.AreEqual(expectedResult, auth.Serialize());
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<authorization id=\".*>.*<billMeLaterRequest>\r\n<virtualAuthenticationKeyPresenceIndicator>Presence</virtualAuthenticationKeyPresenceIndicator>\r\n<virtualAuthenticationKeyData>Data</virtualAuthenticationKeyData>\r\n</billMeLaterRequest>.*</authorization>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
 
@@ -462,7 +465,7 @@ namespace Litle.Sdk.Test.Unit
             string test = auth.Serialize();
             Assert.AreEqual(expectedResult, auth.Serialize());
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
             mock.Setup(Communications => Communications.HttpPost(It.IsAny<String>(), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.23' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><orderId>123</orderId><fraudResult><advancedFraudResults><deviceReviewStatus>\"ReviewStatus\"</deviceReviewStatus><deviceReputationScore>800</deviceReputationScore></advancedFraudResults></fraudResult></authorizationResponse></litleOnlineResponse>");
 
@@ -524,7 +527,7 @@ namespace Litle.Sdk.Test.Unit
 
             Assert.AreEqual(expectedResult, auth.Serialize());
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
             mock.Setup(Communications => Communications.HttpPost(It.IsAny<String>(), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.23' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
 

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestAuthorization.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestAuthorization.cs
@@ -1,19 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Text;
-using NUnit.Framework;
-using Litle.Sdk;
-using Moq;
 using System.Text.RegularExpressions;
-
+using Moq;
+using NUnit.Framework;
 
 namespace Litle.Sdk.Test.Unit
 {
     [TestFixture]
-    class TestAuthorization
+    internal class TestAuthorization
     {
-
         private LitleOnline litle;
         private IDictionary<string, StringBuilder> _memoryStreams;
 
@@ -27,7 +22,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestFraudFilterOverride()
         {
-            authorization auth = new authorization();
+            var auth = new authorization();
             auth.orderId = "12344";
             auth.amount = 2;
             auth.orderSource = orderSourceType.ecommerce;
@@ -36,12 +31,17 @@ namespace Litle.Sdk.Test.Unit
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<fraudFilterOverride>true</fraudFilterOverride>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(".*<fraudFilterOverride>true</fraudFilterOverride>.*", RegexOptions.Singleline),
+                        It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            authorizationResponse authorizationResponse = litle.Authorize(auth);
+            var authorizationResponse = litle.Authorize(auth);
 
             Assert.NotNull(authorizationResponse);
             Assert.AreEqual(123, authorizationResponse.litleTxnId);
@@ -50,24 +50,29 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestContactShouldSendEmailForEmail_NotZip()
         {
-            authorization auth = new authorization();
+            var auth = new authorization();
             auth.orderId = "12344";
             auth.amount = 2;
             auth.orderSource = orderSourceType.ecommerce;
             auth.reportGroup = "Planets";
-            contact billToAddress = new contact();
+            var billToAddress = new contact();
             billToAddress.email = "gdake@litle.com";
             billToAddress.zip = "12345";
             auth.billToAddress = billToAddress;
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<zip>12345</zip>.*<email>gdake@litle.com</email>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(".*<zip>12345</zip>.*<email>gdake@litle.com</email>.*", RegexOptions.Singleline),
+                        It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            authorizationResponse authorizationResponse = litle.Authorize(auth);
+            var authorizationResponse = litle.Authorize(auth);
 
             Assert.NotNull(authorizationResponse);
             Assert.AreEqual(123, authorizationResponse.litleTxnId);
@@ -76,24 +81,29 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void Test3dsAttemptedShouldNotSayItem()
         {
-            authorization auth = new authorization();
+            var auth = new authorization();
             auth.orderId = "12344";
             auth.amount = 2;
             auth.orderSource = orderSourceType.item3dsAttempted;
             auth.reportGroup = "Planets";
-            contact billToAddress = new contact();
+            var billToAddress = new contact();
             billToAddress.email = "gdake@litle.com";
             billToAddress.zip = "12345";
             auth.billToAddress = billToAddress;
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>.*<orderSource>3dsAttempted</orderSource>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(".*<amount>2</amount>.*<orderSource>3dsAttempted</orderSource>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            authorizationResponse authorizationResponse = litle.Authorize(auth);
+            var authorizationResponse = litle.Authorize(auth);
 
             Assert.NotNull(authorizationResponse);
             Assert.AreEqual(123, authorizationResponse.litleTxnId);
@@ -102,24 +112,29 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void Test3dsAuthenticatedShouldNotSayItem()
         {
-            authorization auth = new authorization();
+            var auth = new authorization();
             auth.orderId = "12344";
             auth.amount = 2;
             auth.orderSource = orderSourceType.item3dsAuthenticated;
             auth.reportGroup = "Planets";
-            contact billToAddress = new contact();
+            var billToAddress = new contact();
             billToAddress.email = "gdake@litle.com";
             billToAddress.zip = "12345";
             auth.billToAddress = billToAddress;
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>.*<orderSource>3dsAuthenticated</orderSource>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(".*<amount>2</amount>.*<orderSource>3dsAuthenticated</orderSource>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            authorizationResponse authorizationResponse = litle.Authorize(auth);
+            var authorizationResponse = litle.Authorize(auth);
 
             Assert.NotNull(authorizationResponse);
             Assert.AreEqual(123, authorizationResponse.litleTxnId);
@@ -128,7 +143,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestSecondaryAmount()
         {
-            authorization auth = new authorization();
+            var auth = new authorization();
             auth.orderId = "12344";
             auth.amount = 2;
             auth.secondaryAmount = 1;
@@ -137,12 +152,18 @@ namespace Litle.Sdk.Test.Unit
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<secondaryAmount>1</secondaryAmount>\r\n<orderSource>ecommerce</orderSource>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*<amount>2</amount>\r\n<secondaryAmount>1</secondaryAmount>\r\n<orderSource>ecommerce</orderSource>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            authorizationResponse authorizationResponse = litle.Authorize(auth);
+            var authorizationResponse = litle.Authorize(auth);
 
             Assert.NotNull(authorizationResponse);
             Assert.AreEqual(123, authorizationResponse.litleTxnId);
@@ -151,7 +172,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestSurchargeAmount()
         {
-            authorization auth = new authorization();
+            var auth = new authorization();
             auth.orderId = "12344";
             auth.amount = 2;
             auth.surchargeAmount = 1;
@@ -160,12 +181,18 @@ namespace Litle.Sdk.Test.Unit
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<surchargeAmount>1</surchargeAmount>\r\n<orderSource>ecommerce</orderSource>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*<amount>2</amount>\r\n<surchargeAmount>1</surchargeAmount>\r\n<orderSource>ecommerce</orderSource>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            authorizationResponse authorizationResponse = litle.Authorize(auth);
+            var authorizationResponse = litle.Authorize(auth);
 
             Assert.NotNull(authorizationResponse);
             Assert.AreEqual(123, authorizationResponse.litleTxnId);
@@ -174,7 +201,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestSurchargeAmount_Optional()
         {
-            authorization auth = new authorization();
+            var auth = new authorization();
             auth.orderId = "12344";
             auth.amount = 2;
             auth.orderSource = orderSourceType.ecommerce;
@@ -182,12 +209,17 @@ namespace Litle.Sdk.Test.Unit
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<orderSource>ecommerce</orderSource>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(".*<amount>2</amount>\r\n<orderSource>ecommerce</orderSource>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            authorizationResponse authorizationResponse = litle.Authorize(auth);
+            var authorizationResponse = litle.Authorize(auth);
 
             Assert.NotNull(authorizationResponse);
             Assert.AreEqual(123, authorizationResponse.litleTxnId);
@@ -196,12 +228,12 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestMethodOfPaymentAllowsGiftCard()
         {
-            authorization auth = new authorization();
+            var auth = new authorization();
             auth.orderId = "12344";
             auth.amount = 2;
             auth.orderSource = orderSourceType.ecommerce;
             auth.reportGroup = "Planets";
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.GC;
             card.number = "414100000000000000";
             card.expDate = "1210";
@@ -209,12 +241,18 @@ namespace Litle.Sdk.Test.Unit
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<card>\r\n<type>GC</type>\r\n<number>414100000000000000</number>\r\n<expDate>1210</expDate>\r\n</card>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*<card>\r\n<type>GC</type>\r\n<number>414100000000000000</number>\r\n<expDate>1210</expDate>\r\n</card>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            authorizationResponse authorizationResponse = litle.Authorize(auth);
+            var authorizationResponse = litle.Authorize(auth);
 
             Assert.NotNull(authorizationResponse);
             Assert.AreEqual(123, authorizationResponse.litleTxnId);
@@ -223,13 +261,13 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestMethodOfPaymentApplepayAndWallet()
         {
-            authorization auth = new authorization();
+            var auth = new authorization();
             auth.orderId = "12344";
             auth.amount = 2;
             auth.orderSource = orderSourceType.applepay;
             auth.reportGroup = "Planets";
-            applepayType applepay = new applepayType();
-            applepayHeaderType applepayHeaderType = new applepayHeaderType();
+            var applepay = new applepayType();
+            var applepayHeaderType = new applepayHeaderType();
             applepayHeaderType.applicationData = "454657413164";
             applepayHeaderType.ephemeralPublicKey = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
             applepayHeaderType.publicKeyHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
@@ -240,18 +278,24 @@ namespace Litle.Sdk.Test.Unit
             applepay.version = "1";
             auth.applepay = applepay;
 
-            wallet wallet = new wallet();
+            var wallet = new wallet();
             wallet.walletSourceTypeId = "123";
             auth.wallet = wallet;
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<authorization.*?<orderSource>applepay</orderSource>.*?<applepay>.*?<data>user</data>.*?</applepay>.*?<wallet>.*?<walletSourceTypeId>123</walletSourceTypeId>.*?</wallet>.*?</authorization>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*?<litleOnlineRequest.*?<authorization.*?<orderSource>applepay</orderSource>.*?<applepay>.*?<data>user</data>.*?</applepay>.*?<wallet>.*?<walletSourceTypeId>123</walletSourceTypeId>.*?</wallet>.*?</authorization>.*?",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            authorizationResponse authorizationResponse = litle.Authorize(auth);
+            var authorizationResponse = litle.Authorize(auth);
 
             Assert.NotNull(authorizationResponse);
             Assert.AreEqual(123, authorizationResponse.litleTxnId);
@@ -260,7 +304,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestRecurringRequest()
         {
-            authorization auth = new authorization();
+            var auth = new authorization();
             auth.card = new cardType();
             auth.card.type = methodOfPaymentTypeEnum.VI;
             auth.card.number = "4100000000000001";
@@ -276,12 +320,18 @@ namespace Litle.Sdk.Test.Unit
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<fraudFilterOverride>true</fraudFilterOverride>\r\n<recurringRequest>\r\n<subscription>\r\n<planCode>abc123</planCode>\r\n<numberOfPayments>12</numberOfPayments>\r\n</subscription>\r\n</recurringRequest>\r\n</authorization>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.18' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*<fraudFilterOverride>true</fraudFilterOverride>\r\n<recurringRequest>\r\n<subscription>\r\n<planCode>abc123</planCode>\r\n<numberOfPayments>12</numberOfPayments>\r\n</subscription>\r\n</recurringRequest>\r\n</authorization>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.18' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            authorizationResponse authorizationResponse = litle.Authorize(auth);
+            var authorizationResponse = litle.Authorize(auth);
 
             Assert.NotNull(authorizationResponse);
             Assert.AreEqual(123, authorizationResponse.litleTxnId);
@@ -290,7 +340,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestDebtRepayment()
         {
-            authorization auth = new authorization();
+            var auth = new authorization();
             auth.card = new cardType();
             auth.card.type = methodOfPaymentTypeEnum.VI;
             auth.card.number = "4100000000000001";
@@ -303,12 +353,18 @@ namespace Litle.Sdk.Test.Unit
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<fraudFilterOverride>true</fraudFilterOverride>\r\n<debtRepayment>true</debtRepayment>\r\n</authorization>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*<fraudFilterOverride>true</fraudFilterOverride>\r\n<debtRepayment>true</debtRepayment>\r\n</authorization>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            authorizationResponse authorizationResponse = litle.Authorize(auth);
+            var authorizationResponse = litle.Authorize(auth);
 
             Assert.NotNull(authorizationResponse);
             Assert.AreEqual(123, authorizationResponse.litleTxnId);
@@ -317,9 +373,10 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestRecurringResponse_Full()
         {
-            String xmlResponse = "<litleOnlineResponse version='8.18' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId><recurringResponse><subscriptionId>12</subscriptionId><responseCode>345</responseCode><responseMessage>Foo</responseMessage><recurringTxnId>678</recurringTxnId></recurringResponse></authorizationResponse></litleOnlineResponse>";
-            litleOnlineResponse litleOnlineResponse = LitleOnline.DeserializeObject(xmlResponse);
-            authorizationResponse authorizationResponse = (authorizationResponse)litleOnlineResponse.authorizationResponse;
+            var xmlResponse =
+                "<litleOnlineResponse version='8.18' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId><recurringResponse><subscriptionId>12</subscriptionId><responseCode>345</responseCode><responseMessage>Foo</responseMessage><recurringTxnId>678</recurringTxnId></recurringResponse></authorizationResponse></litleOnlineResponse>";
+            var litleOnlineResponse = LitleOnline.DeserializeObject(xmlResponse);
+            var authorizationResponse = litleOnlineResponse.authorizationResponse;
 
             Assert.AreEqual(123, authorizationResponse.litleTxnId);
             Assert.AreEqual(12, authorizationResponse.recurringResponse.subscriptionId);
@@ -331,9 +388,10 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestRecurringResponse_NoRecurringTxnId()
         {
-            String xmlResponse = "<litleOnlineResponse version='8.18' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId><recurringResponse><subscriptionId>12</subscriptionId><responseCode>345</responseCode><responseMessage>Foo</responseMessage></recurringResponse></authorizationResponse></litleOnlineResponse>";
-            litleOnlineResponse litleOnlineResponse = LitleOnline.DeserializeObject(xmlResponse);
-            authorizationResponse authorizationResponse = (authorizationResponse)litleOnlineResponse.authorizationResponse;
+            var xmlResponse =
+                "<litleOnlineResponse version='8.18' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId><recurringResponse><subscriptionId>12</subscriptionId><responseCode>345</responseCode><responseMessage>Foo</responseMessage></recurringResponse></authorizationResponse></litleOnlineResponse>";
+            var litleOnlineResponse = LitleOnline.DeserializeObject(xmlResponse);
+            var authorizationResponse = litleOnlineResponse.authorizationResponse;
 
             Assert.AreEqual(123, authorizationResponse.litleTxnId);
             Assert.AreEqual(12, authorizationResponse.recurringResponse.subscriptionId);
@@ -345,7 +403,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestSimpleAuthWithFraudCheck()
         {
-            authorization auth = new authorization();
+            var auth = new authorization();
             auth.card = new cardType();
             auth.card.type = methodOfPaymentTypeEnum.VI;
             auth.card.number = "4100000000000001";
@@ -356,7 +414,7 @@ namespace Litle.Sdk.Test.Unit
             auth.cardholderAuthentication = new fraudCheckType();
             auth.cardholderAuthentication.customerIpAddress = "192.168.1.1";
 
-            String expectedResult = @"
+            var expectedResult = @"
 <authorization id="""" reportGroup="""">
 <orderId>12344</orderId>
 <amount>2</amount>
@@ -374,14 +432,20 @@ namespace Litle.Sdk.Test.Unit
             Assert.AreEqual(expectedResult, auth.Serialize());
 
             var mock = new Mock<Communications>(_memoryStreams);
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<authorization id=\".*>.*<customerIpAddress>192.168.1.1</customerIpAddress>.*</authorization>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*<authorization id=\".*>.*<customerIpAddress>192.168.1.1</customerIpAddress>.*</authorization>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.Authorize(auth);
 
-            authorizationResponse authorizationResponse = litle.Authorize(auth);
+            var authorizationResponse = litle.Authorize(auth);
 
             Assert.NotNull(authorizationResponse);
             Assert.AreEqual(123, authorizationResponse.litleTxnId);
@@ -390,7 +454,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestSimpleAuthWithBillMeLaterRequest()
         {
-            authorization auth = new authorization();
+            var auth = new authorization();
             auth.card = new cardType();
             auth.card.type = methodOfPaymentTypeEnum.VI;
             auth.card.number = "4100000000000001";
@@ -402,7 +466,7 @@ namespace Litle.Sdk.Test.Unit
             auth.billMeLaterRequest.virtualAuthenticationKeyData = "Data";
             auth.billMeLaterRequest.virtualAuthenticationKeyPresenceIndicator = "Presence";
 
-            String expectedResult = @"
+            var expectedResult = @"
 <authorization id="""" reportGroup="""">
 <orderId>12344</orderId>
 <amount>2</amount>
@@ -421,14 +485,20 @@ namespace Litle.Sdk.Test.Unit
             Assert.AreEqual(expectedResult, auth.Serialize());
 
             var mock = new Mock<Communications>(_memoryStreams);
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<authorization id=\".*>.*<billMeLaterRequest>\r\n<virtualAuthenticationKeyPresenceIndicator>Presence</virtualAuthenticationKeyPresenceIndicator>\r\n<virtualAuthenticationKeyData>Data</virtualAuthenticationKeyData>\r\n</billMeLaterRequest>.*</authorization>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*<authorization id=\".*>.*<billMeLaterRequest>\r\n<virtualAuthenticationKeyPresenceIndicator>Presence</virtualAuthenticationKeyPresenceIndicator>\r\n<virtualAuthenticationKeyData>Data</virtualAuthenticationKeyData>\r\n</billMeLaterRequest>.*</authorization>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.Authorize(auth);
 
-            authorizationResponse authorizationResponse = litle.Authorize(auth);
+            var authorizationResponse = litle.Authorize(auth);
 
             Assert.NotNull(authorizationResponse);
             Assert.AreEqual(123, authorizationResponse.litleTxnId);
@@ -437,7 +507,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestAuthWithAdvancedFraud()
         {
-            authorization auth = new authorization();
+            var auth = new authorization();
             auth.orderId = "123";
             auth.amount = 10;
             auth.advancedFraudChecks = new advancedFraudChecksType();
@@ -449,7 +519,7 @@ namespace Litle.Sdk.Test.Unit
             auth.advancedFraudChecks.customAttribute5 = "testAttribute5";
 
 
-            String expectedResult = @"
+            var expectedResult = @"
 <authorization id="""" reportGroup="""">
 <orderId>123</orderId>
 <amount>10</amount>
@@ -462,16 +532,18 @@ namespace Litle.Sdk.Test.Unit
 <customAttribute5>testAttribute5</customAttribute5>
 </advancedFraudChecks>
 </authorization>";
-            string test = auth.Serialize();
+            var test = auth.Serialize();
             Assert.AreEqual(expectedResult, auth.Serialize());
 
             var mock = new Mock<Communications>(_memoryStreams);
-            mock.Setup(Communications => Communications.HttpPost(It.IsAny<String>(), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.23' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><orderId>123</orderId><fraudResult><advancedFraudResults><deviceReviewStatus>\"ReviewStatus\"</deviceReviewStatus><deviceReputationScore>800</deviceReputationScore></advancedFraudResults></fraudResult></authorizationResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications => Communications.HttpPost(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.23' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><orderId>123</orderId><fraudResult><advancedFraudResults><deviceReviewStatus>\"ReviewStatus\"</deviceReviewStatus><deviceReputationScore>800</deviceReputationScore></advancedFraudResults></fraudResult></authorizationResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            authorizationResponse authorizationResponse = litle.Authorize(auth);
+            var authorizationResponse = litle.Authorize(auth);
 
             Assert.NotNull(authorizationResponse);
             Assert.AreEqual("123", authorizationResponse.orderId);
@@ -480,7 +552,8 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestAdvancedFraudResponse()
         {
-            String xmlResponse = @"<litleOnlineResponse version='8.23' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+            var xmlResponse =
+                @"<litleOnlineResponse version='8.23' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
 <authorizationResponse>
 <litleTxnId>123</litleTxnId>
 <fraudResult>
@@ -493,8 +566,8 @@ namespace Litle.Sdk.Test.Unit
 </authorizationResponse>
 </litleOnlineResponse>";
 
-            litleOnlineResponse litleOnlineResponse = LitleOnline.DeserializeObject(xmlResponse);
-            authorizationResponse authorizationResponse = (authorizationResponse)litleOnlineResponse.authorizationResponse;
+            var litleOnlineResponse = LitleOnline.DeserializeObject(xmlResponse);
+            var authorizationResponse = litleOnlineResponse.authorizationResponse;
 
 
             Assert.AreEqual(123, authorizationResponse.litleTxnId);
@@ -510,13 +583,13 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestAuthWithPosCatLevelEnum()
         {
-            authorization auth = new authorization();
+            var auth = new authorization();
             auth.pos = new pos();
             auth.orderId = "ABC123";
             auth.amount = 98700;
             auth.pos.catLevel = posCatLevelEnum.selfservice;
 
-            String expectedResult = @"
+            var expectedResult = @"
 <authorization id="""" reportGroup="""">
 <orderId>ABC123</orderId>
 <amount>98700</amount>
@@ -528,12 +601,14 @@ namespace Litle.Sdk.Test.Unit
             Assert.AreEqual(expectedResult, auth.Serialize());
 
             var mock = new Mock<Communications>(_memoryStreams);
-            mock.Setup(Communications => Communications.HttpPost(It.IsAny<String>(), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.23' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications => Communications.HttpPost(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.23' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            authorizationResponse authorizationResponse = litle.Authorize(auth);
+            var authorizationResponse = litle.Authorize(auth);
 
             Assert.NotNull(authorizationResponse);
             Assert.AreEqual(123, authorizationResponse.litleTxnId);
@@ -542,7 +617,8 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestRecycleEngineActive()
         {
-            String xmlResponse = @"<litleOnlineResponse version='8.23' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+            var xmlResponse =
+                @"<litleOnlineResponse version='8.23' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
 <authorizationResponse>
 <litleTxnId>123</litleTxnId>
 <fraudResult>
@@ -558,8 +634,8 @@ namespace Litle.Sdk.Test.Unit
 </authorizationResponse>
 </litleOnlineResponse>";
 
-            litleOnlineResponse litleOnlineResponse = LitleOnline.DeserializeObject(xmlResponse);
-            authorizationResponse authorizationResponse = (authorizationResponse)litleOnlineResponse.authorizationResponse;
+            var litleOnlineResponse = LitleOnline.DeserializeObject(xmlResponse);
+            var authorizationResponse = litleOnlineResponse.authorizationResponse;
 
 
             Assert.AreEqual(123, authorizationResponse.litleTxnId);
@@ -572,6 +648,5 @@ namespace Litle.Sdk.Test.Unit
             Assert.AreEqual("rule triggered", authorizationResponse.fraudResult.advancedFraudResults.triggeredRule);
             Assert.AreEqual(true, authorizationResponse.recycling.recycleEngineActive);
         }
-
     }
 }

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestBatch.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestBatch.cs
@@ -1,19 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Text;
-using NUnit.Framework;
-using Litle.Sdk;
-using Moq;
 using System.Text.RegularExpressions;
-using Moq.Language.Flow;
 using System.Xml;
-
+using Moq;
+using NUnit.Framework;
 
 namespace Litle.Sdk.Test.Unit
 {
     [TestFixture]
-    class TestBatch
+    internal class TestBatch
     {
         private litleRequest litle;
         private const string timeFormat = "MM-dd-yyyy_HH-mm-ss-ffff_";
@@ -33,12 +29,19 @@ namespace Litle.Sdk.Test.Unit
         {
             memoryStreams = new Dictionary<string, StringBuilder>();
             mockLitleTime = new Mock<litleTime>();
-            mockLitleTime.Setup(litleTime => litleTime.getCurrentTime(It.Is<String>(resultFormat => resultFormat == timeFormat))).Returns("01-01-1960_01-22-30-1234_");
+            mockLitleTime.Setup(
+                litleTime => litleTime.getCurrentTime(It.Is<string>(resultFormat => resultFormat == timeFormat)))
+                .Returns("01-01-1960_01-22-30-1234_");
 
             mockLitleFile = new Mock<litleFile>(memoryStreams);
-            mockLitleFile.Setup(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object)).Returns(mockFilePath);
-            mockLitleFile.Setup(litleFile => litleFile.AppendFileToFile(mockFilePath, It.IsAny<String>())).Returns(mockFilePath);
-            mockLitleFile.Setup(litleFile => litleFile.AppendLineToFile(mockFilePath, It.IsAny<String>())).Returns(mockFilePath);
+            mockLitleFile.Setup(
+                litleFile =>
+                    litleFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        mockLitleTime.Object)).Returns(mockFilePath);
+            mockLitleFile.Setup(litleFile => litleFile.AppendFileToFile(mockFilePath, It.IsAny<string>()))
+                .Returns(mockFilePath);
+            mockLitleFile.Setup(litleFile => litleFile.AppendLineToFile(mockFilePath, It.IsAny<string>()))
+                .Returns(mockFilePath);
 
             mockCommunications = new Mock<Communications>(memoryStreams);
         }
@@ -49,14 +52,20 @@ namespace Litle.Sdk.Test.Unit
             litle = new litleRequest(memoryStreams);
 
             mockXmlReader = new Mock<XmlReader>();
-            mockXmlReader.SetupSequence(XmlReader => XmlReader.ReadToFollowing(It.IsAny<String>())).Returns(true).Returns(true).Returns(false);
-            mockXmlReader.SetupSequence(XmlReader => XmlReader.ReadState).Returns(ReadState.Initial).Returns(ReadState.Interactive).Returns(ReadState.Closed);
+            mockXmlReader.SetupSequence(XmlReader => XmlReader.ReadToFollowing(It.IsAny<string>()))
+                .Returns(true)
+                .Returns(true)
+                .Returns(false);
+            mockXmlReader.SetupSequence(XmlReader => XmlReader.ReadState)
+                .Returns(ReadState.Initial)
+                .Returns(ReadState.Interactive)
+                .Returns(ReadState.Closed);
         }
 
         [Test]
         public void testInitialization()
         {
-            Dictionary<String, String> mockConfig = new Dictionary<string, string>();
+            var mockConfig = new Dictionary<string, string>();
 
             mockConfig["url"] = "https://www.mockurl.com";
             mockConfig["reportGroup"] = "Mock Report Group";
@@ -90,10 +99,10 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void testAccountUpdate()
         {
-            accountUpdate accountUpdate = new accountUpdate();
+            var accountUpdate = new accountUpdate();
             accountUpdate.reportGroup = "Planets";
             accountUpdate.orderId = "12344";
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000002";
             card.expDate = "1210";
@@ -103,42 +112,47 @@ namespace Litle.Sdk.Test.Unit
             var mockLitleXmlSerializer = new Mock<litleXmlSerializer>();
 
             mockXmlReader.SetupSequence(XmlReader => XmlReader.ReadOuterXml())
-                .Returns("<accountUpdateResponse reportGroup=\"Merch01ReportGrp\" xmlns=\"http://www.litle.com/schema\"><litleTxnId>123</litleTxnId><orderId>MERCH01-0002</orderId><response>000</response><responseTime>2010-04-11T15:44:26</responseTime><message>Approved</message></accountUpdateResponse>")
-                .Returns("<accountUpdateResponse reportGroup=\"Merch01ReportGrp\" xmlns=\"http://www.litle.com/schema\"><litleTxnId>124</litleTxnId><orderId>MERCH01-0002</orderId><response>000</response><responseTime>2010-04-11T15:44:26</responseTime><message>Approved</message></accountUpdateResponse>");
+                .Returns(
+                    "<accountUpdateResponse reportGroup=\"Merch01ReportGrp\" xmlns=\"http://www.litle.com/schema\"><litleTxnId>123</litleTxnId><orderId>MERCH01-0002</orderId><response>000</response><responseTime>2010-04-11T15:44:26</responseTime><message>Approved</message></accountUpdateResponse>")
+                .Returns(
+                    "<accountUpdateResponse reportGroup=\"Merch01ReportGrp\" xmlns=\"http://www.litle.com/schema\"><litleTxnId>124</litleTxnId><orderId>MERCH01-0002</orderId><response>000</response><responseTime>2010-04-11T15:44:26</responseTime><message>Approved</message></accountUpdateResponse>");
 
-            batchResponse mockLitleBatchResponse = new batchResponse();
+            var mockLitleBatchResponse = new batchResponse();
             mockLitleBatchResponse.setAccountUpdateResponseReader(mockXmlReader.Object);
 
             mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse()).Returns(mockLitleBatchResponse);
-            litleResponse mockedLitleResponse = mockLitleResponse.Object;
+            var mockedLitleResponse = mockLitleResponse.Object;
 
-            Communications mockedCommunication = mockCommunications.Object;
+            var mockedCommunication = mockCommunications.Object;
             litle.setCommunication(mockedCommunication);
 
-            mockLitleXmlSerializer.Setup(litleXmlSerializer => litleXmlSerializer.DeserializeObjectFromFile(mockedCommunication, It.IsAny<String>())).Returns(mockedLitleResponse);
+            mockLitleXmlSerializer.Setup(
+                litleXmlSerializer =>
+                    litleXmlSerializer.DeserializeObjectFromFile(mockedCommunication, It.IsAny<string>()))
+                .Returns(mockedLitleResponse);
 
 
-            litleXmlSerializer mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
+            var mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
             litle.setLitleXmlSerializer(mockedLitleXmlSerializer);
 
-            litleFile mockedLitleFile = mockLitleFile.Object;
+            var mockedLitleFile = mockLitleFile.Object;
             litle.setLitleFile(mockedLitleFile);
 
             litle.setLitleTime(mockLitleTime.Object);
 
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
             litleBatchRequest.setLitleFile(mockedLitleFile);
             litleBatchRequest.setLitleTime(mockLitleTime.Object);
             litleBatchRequest.addAccountUpdate(accountUpdate);
             litleBatchRequest.addAccountUpdate(accountUpdate);
             litle.addBatch(litleBatchRequest);
 
-            string batchFileName = litle.sendToLitle();
-            litleResponse actualLitleResponse = litle.receiveFromLitle(batchFileName);
-            batchResponse actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
-            accountUpdateResponse actualAccountUpdateResponse1 = actualLitleBatchResponse.nextAccountUpdateResponse();
-            accountUpdateResponse actualAccountUpdateResponse2 = actualLitleBatchResponse.nextAccountUpdateResponse();
-            accountUpdateResponse nullAccountUpdateResponse = actualLitleBatchResponse.nextAccountUpdateResponse();
+            var batchFileName = litle.sendToLitle();
+            var actualLitleResponse = litle.receiveFromLitle(batchFileName);
+            var actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
+            var actualAccountUpdateResponse1 = actualLitleBatchResponse.nextAccountUpdateResponse();
+            var actualAccountUpdateResponse2 = actualLitleBatchResponse.nextAccountUpdateResponse();
+            var nullAccountUpdateResponse = actualLitleBatchResponse.nextAccountUpdateResponse();
 
             Assert.AreEqual(123, actualAccountUpdateResponse1.litleTxnId);
             Assert.AreEqual("000", actualAccountUpdateResponse1.response);
@@ -146,20 +160,24 @@ namespace Litle.Sdk.Test.Unit
             Assert.AreEqual("000", actualAccountUpdateResponse2.response);
             Assert.IsNull(nullAccountUpdateResponse);
 
-            mockCommunications.Verify(Communications => Communications.FtpDropOff(It.IsAny<String>(), mockFileName, It.IsAny<Dictionary<String, String>>()));
-            mockCommunications.Verify(Communications => Communications.FtpPickUp(It.IsAny<String>(), It.IsAny<Dictionary<String, String>>(), mockFileName));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpDropOff(It.IsAny<string>(), mockFileName, It.IsAny<Dictionary<string, string>>()));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpPickUp(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), mockFileName));
         }
 
 
         [Test]
         public void testAuth()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.reportGroup = "Planets";
             authorization.orderId = "12344";
             authorization.amount = 106;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000002";
             card.expDate = "1210";
@@ -169,52 +187,61 @@ namespace Litle.Sdk.Test.Unit
             var mockLitleXmlSerializer = new Mock<litleXmlSerializer>();
 
             mockXmlReader.SetupSequence(XmlReader => XmlReader.ReadOuterXml())
-                .Returns("<authorizationResponse id=\"\" reportGroup=\"Planets\" xmlns=\"http://www.litle.com/schema\"><litleTxnId>123</litleTxnId><orderId>123</orderId><response>000</response><responseTime>2013-06-19T19:54:42</responseTime><message>Approved</message><authCode>123457</authCode><fraudResult><avsResult>00</avsResult></fraudResult><tokenResponse><litleToken>1711000103054242</litleToken><tokenResponseCode>802</tokenResponseCode><tokenMessage>Account number was previously registered</tokenMessage><type>VI</type><bin>424242</bin></tokenResponse></authorizationResponse>")
-                .Returns("<authorizationResponse id=\"\" reportGroup=\"Planets\" xmlns=\"http://www.litle.com/schema\"><litleTxnId>124</litleTxnId><orderId>124</orderId><response>000</response><responseTime>2013-06-19T19:54:42</responseTime><message>Approved</message><authCode>123457</authCode><fraudResult><avsResult>00</avsResult></fraudResult><tokenResponse><litleToken>1711000103054242</litleToken><tokenResponseCode>802</tokenResponseCode><tokenMessage>Account number was previously registered</tokenMessage><type>VI</type><bin>424242</bin></tokenResponse></authorizationResponse>");
+                .Returns(
+                    "<authorizationResponse id=\"\" reportGroup=\"Planets\" xmlns=\"http://www.litle.com/schema\"><litleTxnId>123</litleTxnId><orderId>123</orderId><response>000</response><responseTime>2013-06-19T19:54:42</responseTime><message>Approved</message><authCode>123457</authCode><fraudResult><avsResult>00</avsResult></fraudResult><tokenResponse><litleToken>1711000103054242</litleToken><tokenResponseCode>802</tokenResponseCode><tokenMessage>Account number was previously registered</tokenMessage><type>VI</type><bin>424242</bin></tokenResponse></authorizationResponse>")
+                .Returns(
+                    "<authorizationResponse id=\"\" reportGroup=\"Planets\" xmlns=\"http://www.litle.com/schema\"><litleTxnId>124</litleTxnId><orderId>124</orderId><response>000</response><responseTime>2013-06-19T19:54:42</responseTime><message>Approved</message><authCode>123457</authCode><fraudResult><avsResult>00</avsResult></fraudResult><tokenResponse><litleToken>1711000103054242</litleToken><tokenResponseCode>802</tokenResponseCode><tokenMessage>Account number was previously registered</tokenMessage><type>VI</type><bin>424242</bin></tokenResponse></authorizationResponse>");
 
-            batchResponse mockLitleBatchResponse = new batchResponse();
+            var mockLitleBatchResponse = new batchResponse();
             mockLitleBatchResponse.setAuthorizationResponseReader(mockXmlReader.Object);
 
             mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse()).Returns(mockLitleBatchResponse);
-            litleResponse mockedLitleResponse = mockLitleResponse.Object;
+            var mockedLitleResponse = mockLitleResponse.Object;
 
-            mockLitleXmlSerializer.Setup(litleXmlSerializer => litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<String>())).Returns(mockedLitleResponse);
+            mockLitleXmlSerializer.Setup(
+                litleXmlSerializer =>
+                    litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<string>()))
+                .Returns(mockedLitleResponse);
 
-            Communications mockedCommunication = mockCommunications.Object;
+            var mockedCommunication = mockCommunications.Object;
             litle.setCommunication(mockedCommunication);
 
-            litleXmlSerializer mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
+            var mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
             litle.setLitleXmlSerializer(mockedLitleXmlSerializer);
 
-            litleFile mockedLitleFile = mockLitleFile.Object;
+            var mockedLitleFile = mockLitleFile.Object;
             litle.setLitleFile(mockedLitleFile);
 
             litle.setLitleTime(mockLitleTime.Object);
 
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
             litleBatchRequest.setLitleFile(mockedLitleFile);
             litleBatchRequest.setLitleTime(mockLitleTime.Object);
             litleBatchRequest.addAuthorization(authorization);
             litleBatchRequest.addAuthorization(authorization);
             litle.addBatch(litleBatchRequest);
 
-            string batchFileName = litle.sendToLitle();
-            litleResponse actualLitleResponse = litle.receiveFromLitle(batchFileName);
-            batchResponse actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
+            var batchFileName = litle.sendToLitle();
+            var actualLitleResponse = litle.receiveFromLitle(batchFileName);
+            var actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
 
             Assert.AreSame(mockLitleBatchResponse, actualLitleBatchResponse);
             Assert.AreEqual(123, actualLitleBatchResponse.nextAuthorizationResponse().litleTxnId);
             Assert.AreEqual(124, actualLitleBatchResponse.nextAuthorizationResponse().litleTxnId);
             Assert.IsNull(actualLitleBatchResponse.nextAuthorizationResponse());
 
-            mockCommunications.Verify(Communications => Communications.FtpDropOff(It.IsAny<String>(), mockFileName, It.IsAny<Dictionary<String, String>>()));
-            mockCommunications.Verify(Communications => Communications.FtpPickUp(It.IsAny<String>(), It.IsAny<Dictionary<String, String>>(), mockFileName));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpDropOff(It.IsAny<string>(), mockFileName, It.IsAny<Dictionary<string, string>>()));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpPickUp(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), mockFileName));
         }
 
         [Test]
         public void testAuthReversal()
         {
-            authReversal authreversal = new authReversal();
+            var authreversal = new authReversal();
             authreversal.litleTxnId = 12345678000;
             authreversal.amount = 106;
             authreversal.payPalNotes = "Notes";
@@ -223,55 +250,64 @@ namespace Litle.Sdk.Test.Unit
             var mockLitleXmlSerializer = new Mock<litleXmlSerializer>();
 
             mockXmlReader.SetupSequence(XmlReader => XmlReader.ReadOuterXml())
-                .Returns("<authReversalResponse id=\"123\" customerId=\"Customer Id\" reportGroup=\"Auth Reversals\" xmlns=\"http://www.litle.com/schema\"><litleTxnId>123</litleTxnId><orderId>abc123</orderId><response>000</response><responseTime>2011-08-30T13:15:43</responseTime><message>Approved</message></authReversalResponse>")
-                .Returns("<authReversalResponse id=\"123\" customerId=\"Customer Id\" reportGroup=\"Auth Reversals\" xmlns=\"http://www.litle.com/schema\"><litleTxnId>124</litleTxnId><orderId>abc123</orderId><response>000</response><responseTime>2011-08-30T13:15:43</responseTime><message>Approved</message></authReversalResponse>");
+                .Returns(
+                    "<authReversalResponse id=\"123\" customerId=\"Customer Id\" reportGroup=\"Auth Reversals\" xmlns=\"http://www.litle.com/schema\"><litleTxnId>123</litleTxnId><orderId>abc123</orderId><response>000</response><responseTime>2011-08-30T13:15:43</responseTime><message>Approved</message></authReversalResponse>")
+                .Returns(
+                    "<authReversalResponse id=\"123\" customerId=\"Customer Id\" reportGroup=\"Auth Reversals\" xmlns=\"http://www.litle.com/schema\"><litleTxnId>124</litleTxnId><orderId>abc123</orderId><response>000</response><responseTime>2011-08-30T13:15:43</responseTime><message>Approved</message></authReversalResponse>");
 
-            batchResponse mockLitleBatchResponse = new batchResponse();
+            var mockLitleBatchResponse = new batchResponse();
             mockLitleBatchResponse.setAuthReversalResponseReader(mockXmlReader.Object);
 
             mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse()).Returns(mockLitleBatchResponse);
-            litleResponse mockedLitleResponse = mockLitleResponse.Object;
+            var mockedLitleResponse = mockLitleResponse.Object;
 
-            mockLitleXmlSerializer.Setup(litleXmlSerializer => litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<String>())).Returns(mockedLitleResponse);
+            mockLitleXmlSerializer.Setup(
+                litleXmlSerializer =>
+                    litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<string>()))
+                .Returns(mockedLitleResponse);
 
-            Communications mockedCommunications = mockCommunications.Object;
+            var mockedCommunications = mockCommunications.Object;
             litle.setCommunication(mockedCommunications);
 
-            litleXmlSerializer mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
+            var mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
             litle.setLitleXmlSerializer(mockedLitleXmlSerializer);
 
-            litleFile mockedLitleFile = mockLitleFile.Object;
+            var mockedLitleFile = mockLitleFile.Object;
             litle.setLitleFile(mockedLitleFile);
 
             litle.setLitleTime(mockLitleTime.Object);
 
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
             litleBatchRequest.setLitleFile(mockedLitleFile);
             litleBatchRequest.setLitleTime(mockLitleTime.Object);
             litleBatchRequest.addAuthReversal(authreversal);
             litleBatchRequest.addAuthReversal(authreversal);
             litle.addBatch(litleBatchRequest);
 
-            string batchFileName = litle.sendToLitle();
+            var batchFileName = litle.sendToLitle();
 
-            litleResponse actualLitleResponse = litle.receiveFromLitle(batchFileName);
-            batchResponse actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
-            authReversalResponse actualAuthReversalResponse1 = actualLitleBatchResponse.nextAuthReversalResponse();
-            authReversalResponse actualAuthReversalResponse2 = actualLitleBatchResponse.nextAuthReversalResponse();
-            authReversalResponse nullAuthReversalResponse = actualLitleBatchResponse.nextAuthReversalResponse();
+            var actualLitleResponse = litle.receiveFromLitle(batchFileName);
+            var actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
+            var actualAuthReversalResponse1 = actualLitleBatchResponse.nextAuthReversalResponse();
+            var actualAuthReversalResponse2 = actualLitleBatchResponse.nextAuthReversalResponse();
+            var nullAuthReversalResponse = actualLitleBatchResponse.nextAuthReversalResponse();
 
             Assert.AreEqual(123, actualAuthReversalResponse1.litleTxnId);
             Assert.AreEqual(124, actualAuthReversalResponse2.litleTxnId);
             Assert.IsNull(nullAuthReversalResponse);
 
-            mockCommunications.Verify(Communications => Communications.FtpDropOff(It.IsAny<String>(), mockFileName, It.IsAny<Dictionary<String, String>>()));
-            mockCommunications.Verify(Communications => Communications.FtpPickUp(It.IsAny<String>(), It.IsAny<Dictionary<String, String>>(), mockFileName));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpDropOff(It.IsAny<string>(), mockFileName, It.IsAny<Dictionary<string, string>>()));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpPickUp(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), mockFileName));
         }
 
         [Test]
         public void testCapture()
         {
-            capture capture = new capture();
+            var capture = new capture();
             capture.litleTxnId = 12345678000;
             capture.amount = 106;
 
@@ -279,63 +315,73 @@ namespace Litle.Sdk.Test.Unit
             var mockLitleXmlSerializer = new Mock<litleXmlSerializer>();
 
             mockXmlReader.SetupSequence(XmlReader => XmlReader.ReadOuterXml())
-              .Returns("<captureResponse id=\"123\" reportGroup=\"RG27\" xmlns=\"http://www.litle.com/schema\"> <litleTxnId>123</litleTxnId> <orderId>12z58743y1</orderId> <response>000</response> <responseTime>2011-09-01T10:24:31</responseTime> <message>message</message> </captureResponse>")
-              .Returns("<captureResponse id=\"124\" reportGroup=\"RG27\" xmlns=\"http://www.litle.com/schema\"> <litleTxnId>124</litleTxnId> <orderId>12z58743y1</orderId> <response>000</response> <responseTime>2011-09-01T10:24:31</responseTime> <message>message</message> </captureResponse>");
+                .Returns(
+                    "<captureResponse id=\"123\" reportGroup=\"RG27\" xmlns=\"http://www.litle.com/schema\"> <litleTxnId>123</litleTxnId> <orderId>12z58743y1</orderId> <response>000</response> <responseTime>2011-09-01T10:24:31</responseTime> <message>message</message> </captureResponse>")
+                .Returns(
+                    "<captureResponse id=\"124\" reportGroup=\"RG27\" xmlns=\"http://www.litle.com/schema\"> <litleTxnId>124</litleTxnId> <orderId>12z58743y1</orderId> <response>000</response> <responseTime>2011-09-01T10:24:31</responseTime> <message>message</message> </captureResponse>");
 
-            batchResponse mockedLitleBatchResponse = new batchResponse();
+            var mockedLitleBatchResponse = new batchResponse();
             mockedLitleBatchResponse.setCaptureResponseReader(mockXmlReader.Object);
 
-            mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse()).Returns(mockedLitleBatchResponse);
-            litleResponse mockedLitleResponse = mockLitleResponse.Object;
+            mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse())
+                .Returns(mockedLitleBatchResponse);
+            var mockedLitleResponse = mockLitleResponse.Object;
 
-            Communications mockedCommunications = mockCommunications.Object;
+            var mockedCommunications = mockCommunications.Object;
 
-            mockLitleXmlSerializer.Setup(litleXmlSerializer => litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<String>())).Returns(mockedLitleResponse);
-            litleXmlSerializer mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
+            mockLitleXmlSerializer.Setup(
+                litleXmlSerializer =>
+                    litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<string>()))
+                .Returns(mockedLitleResponse);
+            var mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
 
-            litleFile mockedLitleFile = mockLitleFile.Object;
+            var mockedLitleFile = mockLitleFile.Object;
 
             litle.setCommunication(mockedCommunications);
             litle.setLitleXmlSerializer(mockedLitleXmlSerializer);
             litle.setLitleFile(mockedLitleFile);
             litle.setLitleTime(mockLitleTime.Object);
 
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
             litleBatchRequest.setLitleFile(mockedLitleFile);
             litleBatchRequest.setLitleTime(mockLitleTime.Object);
             litleBatchRequest.addCapture(capture);
             litleBatchRequest.addCapture(capture);
             litle.addBatch(litleBatchRequest);
 
-            string batchFileName = litle.sendToLitle();
+            var batchFileName = litle.sendToLitle();
 
-            litleResponse actualLitleResponse = litle.receiveFromLitle(batchFileName);
-            batchResponse actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
-            captureResponse actualCaptureResponse1 = actualLitleBatchResponse.nextCaptureResponse();
-            captureResponse actualCaptureResponse2 = actualLitleBatchResponse.nextCaptureResponse();
-            captureResponse nullCaptureResponse = actualLitleBatchResponse.nextCaptureResponse();
+            var actualLitleResponse = litle.receiveFromLitle(batchFileName);
+            var actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
+            var actualCaptureResponse1 = actualLitleBatchResponse.nextCaptureResponse();
+            var actualCaptureResponse2 = actualLitleBatchResponse.nextCaptureResponse();
+            var nullCaptureResponse = actualLitleBatchResponse.nextCaptureResponse();
 
             Assert.AreEqual(123, actualCaptureResponse1.litleTxnId);
             Assert.AreEqual(124, actualCaptureResponse2.litleTxnId);
             Assert.IsNull(nullCaptureResponse);
 
-            mockCommunications.Verify(Communications => Communications.FtpDropOff(It.IsAny<String>(), mockFileName, It.IsAny<Dictionary<String, String>>()));
-            mockCommunications.Verify(Communications => Communications.FtpPickUp(It.IsAny<String>(), It.IsAny<Dictionary<String, String>>(), mockFileName));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpDropOff(It.IsAny<string>(), mockFileName, It.IsAny<Dictionary<string, string>>()));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpPickUp(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), mockFileName));
         }
 
         [Test]
         public void testCaptureGivenAuth()
         {
-            captureGivenAuth capturegivenauth = new captureGivenAuth();
+            var capturegivenauth = new captureGivenAuth();
             capturegivenauth.orderId = "12344";
             capturegivenauth.amount = 106;
-            authInformation authinfo = new authInformation();
+            var authinfo = new authInformation();
             authinfo.authDate = new DateTime(2002, 10, 9);
             authinfo.authCode = "543216";
             authinfo.authAmount = 12345;
             capturegivenauth.authInformation = authinfo;
             capturegivenauth.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000001";
             card.expDate = "1210";
@@ -345,58 +391,68 @@ namespace Litle.Sdk.Test.Unit
             var mockLitleXmlSerializer = new Mock<litleXmlSerializer>();
 
             mockXmlReader.SetupSequence(XmlReader => XmlReader.ReadOuterXml())
-                .Returns("<captureGivenAuthResponse xmlns='http://www.litle.com/schema'><litleTxnId>123</litleTxnId></captureGivenAuthResponse>")
-                .Returns("<captureGivenAuthResponse xmlns='http://www.litle.com/schema'><litleTxnId>124</litleTxnId></captureGivenAuthResponse>");
+                .Returns(
+                    "<captureGivenAuthResponse xmlns='http://www.litle.com/schema'><litleTxnId>123</litleTxnId></captureGivenAuthResponse>")
+                .Returns(
+                    "<captureGivenAuthResponse xmlns='http://www.litle.com/schema'><litleTxnId>124</litleTxnId></captureGivenAuthResponse>");
 
-            batchResponse mockedLitleBatchResponse = new batchResponse();
+            var mockedLitleBatchResponse = new batchResponse();
             mockedLitleBatchResponse.setCaptureGivenAuthResponseReader(mockXmlReader.Object);
 
-            mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse()).Returns(mockedLitleBatchResponse);
-            litleResponse mockedLitleResponse = mockLitleResponse.Object;
+            mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse())
+                .Returns(mockedLitleBatchResponse);
+            var mockedLitleResponse = mockLitleResponse.Object;
 
-            Communications mockedCommunications = mockCommunications.Object;
+            var mockedCommunications = mockCommunications.Object;
 
-            mockLitleXmlSerializer.Setup(litleXmlSerializer => litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<String>())).Returns(mockedLitleResponse);
-            litleXmlSerializer mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
+            mockLitleXmlSerializer.Setup(
+                litleXmlSerializer =>
+                    litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<string>()))
+                .Returns(mockedLitleResponse);
+            var mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
 
-            litleFile mockedLitleFile = mockLitleFile.Object;
+            var mockedLitleFile = mockLitleFile.Object;
 
             litle.setCommunication(mockedCommunications);
             litle.setLitleXmlSerializer(mockedLitleXmlSerializer);
             litle.setLitleFile(mockedLitleFile);
             litle.setLitleTime(mockLitleTime.Object);
 
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
             litleBatchRequest.setLitleFile(mockedLitleFile);
             litleBatchRequest.setLitleTime(mockLitleTime.Object);
             litleBatchRequest.addCaptureGivenAuth(capturegivenauth);
             litleBatchRequest.addCaptureGivenAuth(capturegivenauth);
             litle.addBatch(litleBatchRequest);
 
-            string batchFileName = litle.sendToLitle();
+            var batchFileName = litle.sendToLitle();
 
-            litleResponse actualLitleResponse = litle.receiveFromLitle(batchFileName);
-            batchResponse actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
-            captureGivenAuthResponse actualCaptureGivenAuthReponse1 = actualLitleBatchResponse.nextCaptureGivenAuthResponse();
-            captureGivenAuthResponse actualCaptureGivenAuthReponse2 = actualLitleBatchResponse.nextCaptureGivenAuthResponse();
-            captureGivenAuthResponse nullCaptureGivenAuthReponse = actualLitleBatchResponse.nextCaptureGivenAuthResponse();
+            var actualLitleResponse = litle.receiveFromLitle(batchFileName);
+            var actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
+            var actualCaptureGivenAuthReponse1 = actualLitleBatchResponse.nextCaptureGivenAuthResponse();
+            var actualCaptureGivenAuthReponse2 = actualLitleBatchResponse.nextCaptureGivenAuthResponse();
+            var nullCaptureGivenAuthReponse = actualLitleBatchResponse.nextCaptureGivenAuthResponse();
 
             Assert.AreEqual(123, actualCaptureGivenAuthReponse1.litleTxnId);
             Assert.AreEqual(124, actualCaptureGivenAuthReponse2.litleTxnId);
             Assert.IsNull(nullCaptureGivenAuthReponse);
 
-            mockCommunications.Verify(Communications => Communications.FtpDropOff(It.IsAny<String>(), mockFileName, It.IsAny<Dictionary<String, String>>()));
-            mockCommunications.Verify(Communications => Communications.FtpPickUp(It.IsAny<String>(), It.IsAny<Dictionary<String, String>>(), mockFileName));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpDropOff(It.IsAny<string>(), mockFileName, It.IsAny<Dictionary<string, string>>()));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpPickUp(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), mockFileName));
         }
 
         [Test]
         public void testCredit()
         {
-            credit credit = new credit();
+            var credit = new credit();
             credit.orderId = "12344";
             credit.amount = 106;
             credit.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000001";
             card.expDate = "1210";
@@ -406,54 +462,64 @@ namespace Litle.Sdk.Test.Unit
             var mockLitleXmlSerializer = new Mock<litleXmlSerializer>();
 
             mockXmlReader.SetupSequence(XmlReader => XmlReader.ReadOuterXml())
-                .Returns("<creditResponse xmlns='http://www.litle.com/schema'><litleTxnId>123</litleTxnId></creditResponse>")
-                .Returns("<creditResponse xmlns='http://www.litle.com/schema'><litleTxnId>124</litleTxnId></creditResponse>");
+                .Returns(
+                    "<creditResponse xmlns='http://www.litle.com/schema'><litleTxnId>123</litleTxnId></creditResponse>")
+                .Returns(
+                    "<creditResponse xmlns='http://www.litle.com/schema'><litleTxnId>124</litleTxnId></creditResponse>");
 
-            batchResponse mockedLitleBatchResponse = new batchResponse();
+            var mockedLitleBatchResponse = new batchResponse();
             mockedLitleBatchResponse.setCreditResponseReader(mockXmlReader.Object);
 
-            mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse()).Returns(mockedLitleBatchResponse);
-            litleResponse mockedLitleResponse = mockLitleResponse.Object;
+            mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse())
+                .Returns(mockedLitleBatchResponse);
+            var mockedLitleResponse = mockLitleResponse.Object;
 
-            Communications mockedCommunications = mockCommunications.Object;
+            var mockedCommunications = mockCommunications.Object;
 
-            mockLitleXmlSerializer.Setup(litleXmlSerializer => litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<String>())).Returns(mockedLitleResponse);
-            litleXmlSerializer mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
+            mockLitleXmlSerializer.Setup(
+                litleXmlSerializer =>
+                    litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<string>()))
+                .Returns(mockedLitleResponse);
+            var mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
 
-            litleFile mockedLitleFile = mockLitleFile.Object;
+            var mockedLitleFile = mockLitleFile.Object;
 
             litle.setCommunication(mockedCommunications);
             litle.setLitleXmlSerializer(mockedLitleXmlSerializer);
             litle.setLitleFile(mockedLitleFile);
             litle.setLitleTime(mockLitleTime.Object);
 
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
             litleBatchRequest.setLitleFile(mockedLitleFile);
             litleBatchRequest.setLitleTime(mockLitleTime.Object);
             litleBatchRequest.addCredit(credit);
             litleBatchRequest.addCredit(credit);
             litle.addBatch(litleBatchRequest);
 
-            string batchFileName = litle.sendToLitle();
+            var batchFileName = litle.sendToLitle();
 
-            litleResponse actualLitleResponse = litle.receiveFromLitle(batchFileName);
-            batchResponse actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
-            creditResponse actualCreditReponse1 = actualLitleBatchResponse.nextCreditResponse();
-            creditResponse actualCreditReponse2 = actualLitleBatchResponse.nextCreditResponse();
-            creditResponse nullCreditReponse1 = actualLitleBatchResponse.nextCreditResponse();
+            var actualLitleResponse = litle.receiveFromLitle(batchFileName);
+            var actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
+            var actualCreditReponse1 = actualLitleBatchResponse.nextCreditResponse();
+            var actualCreditReponse2 = actualLitleBatchResponse.nextCreditResponse();
+            var nullCreditReponse1 = actualLitleBatchResponse.nextCreditResponse();
 
             Assert.AreEqual(123, actualCreditReponse1.litleTxnId);
             Assert.AreEqual(124, actualCreditReponse2.litleTxnId);
             Assert.IsNull(nullCreditReponse1);
 
-            mockCommunications.Verify(Communications => Communications.FtpDropOff(It.IsAny<String>(), mockFileName, It.IsAny<Dictionary<String, String>>()));
-            mockCommunications.Verify(Communications => Communications.FtpPickUp(It.IsAny<String>(), It.IsAny<Dictionary<String, String>>(), mockFileName));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpDropOff(It.IsAny<string>(), mockFileName, It.IsAny<Dictionary<string, string>>()));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpPickUp(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), mockFileName));
         }
 
         [Test]
         public void testEcheckCredit()
         {
-            echeckCredit echeckcredit = new echeckCredit();
+            var echeckcredit = new echeckCredit();
             echeckcredit.amount = 12;
             echeckcredit.litleTxnId = 123456789101112;
 
@@ -461,118 +527,138 @@ namespace Litle.Sdk.Test.Unit
             var mockLitleXmlSerializer = new Mock<litleXmlSerializer>();
 
             mockXmlReader.SetupSequence(XmlReader => XmlReader.ReadOuterXml())
-                .Returns("<echeckCreditResponse xmlns='http://www.litle.com/schema'><litleTxnId>123</litleTxnId></echeckCreditResponse>")
-                .Returns("<echeckCreditResponse xmlns='http://www.litle.com/schema'><litleTxnId>124</litleTxnId></echeckCreditResponse>");
+                .Returns(
+                    "<echeckCreditResponse xmlns='http://www.litle.com/schema'><litleTxnId>123</litleTxnId></echeckCreditResponse>")
+                .Returns(
+                    "<echeckCreditResponse xmlns='http://www.litle.com/schema'><litleTxnId>124</litleTxnId></echeckCreditResponse>");
 
-            batchResponse mockedLitleBatchResponse = new batchResponse();
+            var mockedLitleBatchResponse = new batchResponse();
             mockedLitleBatchResponse.setEcheckCreditResponseReader(mockXmlReader.Object);
 
-            mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse()).Returns(mockedLitleBatchResponse);
-            litleResponse mockedLitleResponse = mockLitleResponse.Object;
+            mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse())
+                .Returns(mockedLitleBatchResponse);
+            var mockedLitleResponse = mockLitleResponse.Object;
 
-            Communications mockedCommunications = mockCommunications.Object;
+            var mockedCommunications = mockCommunications.Object;
 
-            mockLitleXmlSerializer.Setup(litleXmlSerializer => litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<String>())).Returns(mockedLitleResponse);
-            litleXmlSerializer mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
+            mockLitleXmlSerializer.Setup(
+                litleXmlSerializer =>
+                    litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<string>()))
+                .Returns(mockedLitleResponse);
+            var mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
 
-            litleFile mockedLitleFile = mockLitleFile.Object;
+            var mockedLitleFile = mockLitleFile.Object;
 
             litle.setCommunication(mockedCommunications);
             litle.setLitleXmlSerializer(mockedLitleXmlSerializer);
             litle.setLitleFile(mockedLitleFile);
             litle.setLitleTime(mockLitleTime.Object);
 
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
             litleBatchRequest.setLitleFile(mockedLitleFile);
             litleBatchRequest.setLitleTime(mockLitleTime.Object);
             litleBatchRequest.addEcheckCredit(echeckcredit);
             litleBatchRequest.addEcheckCredit(echeckcredit);
             litle.addBatch(litleBatchRequest);
 
-            string batchFileName = litle.sendToLitle();
+            var batchFileName = litle.sendToLitle();
 
-            litleResponse actualLitleResponse = litle.receiveFromLitle(batchFileName);
-            batchResponse actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
-            echeckCreditResponse actualEcheckCreditResponse1 = actualLitleBatchResponse.nextEcheckCreditResponse();
-            echeckCreditResponse actualEcheckCreditResponse2 = actualLitleBatchResponse.nextEcheckCreditResponse();
-            echeckCreditResponse nullEcheckCreditResponse = actualLitleBatchResponse.nextEcheckCreditResponse();
+            var actualLitleResponse = litle.receiveFromLitle(batchFileName);
+            var actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
+            var actualEcheckCreditResponse1 = actualLitleBatchResponse.nextEcheckCreditResponse();
+            var actualEcheckCreditResponse2 = actualLitleBatchResponse.nextEcheckCreditResponse();
+            var nullEcheckCreditResponse = actualLitleBatchResponse.nextEcheckCreditResponse();
 
             Assert.AreEqual(123, actualEcheckCreditResponse1.litleTxnId);
             Assert.AreEqual(124, actualEcheckCreditResponse2.litleTxnId);
             Assert.IsNull(nullEcheckCreditResponse);
 
-            mockCommunications.Verify(Communications => Communications.FtpDropOff(It.IsAny<String>(), mockFileName, It.IsAny<Dictionary<String, String>>()));
-            mockCommunications.Verify(Communications => Communications.FtpPickUp(It.IsAny<String>(), It.IsAny<Dictionary<String, String>>(), mockFileName));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpDropOff(It.IsAny<string>(), mockFileName, It.IsAny<Dictionary<string, string>>()));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpPickUp(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), mockFileName));
         }
 
         [Test]
         public void testEcheckRedeposit()
         {
-            echeckRedeposit echeckredeposit = new echeckRedeposit();
+            var echeckredeposit = new echeckRedeposit();
             echeckredeposit.litleTxnId = 123456;
 
             var mockLitleResponse = new Mock<litleResponse>();
             var mockLitleXmlSerializer = new Mock<litleXmlSerializer>();
 
             mockXmlReader.SetupSequence(XmlReader => XmlReader.ReadOuterXml())
-                .Returns("<echeckRedepositResponse xmlns='http://www.litle.com/schema'><litleTxnId>123</litleTxnId></echeckRedepositResponse>")
-                .Returns("<echeckRedepositResponse xmlns='http://www.litle.com/schema'><litleTxnId>124</litleTxnId></echeckRedepositResponse>");
+                .Returns(
+                    "<echeckRedepositResponse xmlns='http://www.litle.com/schema'><litleTxnId>123</litleTxnId></echeckRedepositResponse>")
+                .Returns(
+                    "<echeckRedepositResponse xmlns='http://www.litle.com/schema'><litleTxnId>124</litleTxnId></echeckRedepositResponse>");
 
-            batchResponse mockedLitleBatchResponse = new batchResponse();
+            var mockedLitleBatchResponse = new batchResponse();
             mockedLitleBatchResponse.setEcheckRedepositResponseReader(mockXmlReader.Object);
 
-            mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse()).Returns(mockedLitleBatchResponse);
-            litleResponse mockedLitleResponse = mockLitleResponse.Object;
+            mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse())
+                .Returns(mockedLitleBatchResponse);
+            var mockedLitleResponse = mockLitleResponse.Object;
 
-            Communications mockedCommunications = mockCommunications.Object;
+            var mockedCommunications = mockCommunications.Object;
 
-            mockLitleXmlSerializer.Setup(litleXmlSerializer => litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<String>())).Returns(mockedLitleResponse);
-            litleXmlSerializer mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
+            mockLitleXmlSerializer.Setup(
+                litleXmlSerializer =>
+                    litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<string>()))
+                .Returns(mockedLitleResponse);
+            var mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
 
-            litleFile mockedLitleFile = mockLitleFile.Object;
+            var mockedLitleFile = mockLitleFile.Object;
 
             litle.setCommunication(mockedCommunications);
             litle.setLitleXmlSerializer(mockedLitleXmlSerializer);
             litle.setLitleFile(mockedLitleFile);
             litle.setLitleTime(mockLitleTime.Object);
 
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
             litleBatchRequest.setLitleFile(mockedLitleFile);
             litleBatchRequest.setLitleTime(mockLitleTime.Object);
             litleBatchRequest.addEcheckRedeposit(echeckredeposit);
             litleBatchRequest.addEcheckRedeposit(echeckredeposit);
             litle.addBatch(litleBatchRequest);
 
-            string batchFileName = litle.sendToLitle();
+            var batchFileName = litle.sendToLitle();
 
-            litleResponse actualLitleResponse = litle.receiveFromLitle(batchFileName);
-            batchResponse actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
-            echeckRedepositResponse actualEcheckRedepositResponse1 = actualLitleBatchResponse.nextEcheckRedepositResponse();
-            echeckRedepositResponse actualEcheckRedepositResponse2 = actualLitleBatchResponse.nextEcheckRedepositResponse();
-            echeckRedepositResponse nullEcheckRedepositResponse = actualLitleBatchResponse.nextEcheckRedepositResponse();
+            var actualLitleResponse = litle.receiveFromLitle(batchFileName);
+            var actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
+            var actualEcheckRedepositResponse1 = actualLitleBatchResponse.nextEcheckRedepositResponse();
+            var actualEcheckRedepositResponse2 = actualLitleBatchResponse.nextEcheckRedepositResponse();
+            var nullEcheckRedepositResponse = actualLitleBatchResponse.nextEcheckRedepositResponse();
 
             Assert.AreEqual(123, actualEcheckRedepositResponse1.litleTxnId);
             Assert.AreEqual(124, actualEcheckRedepositResponse2.litleTxnId);
             Assert.IsNull(nullEcheckRedepositResponse);
 
-            mockCommunications.Verify(Communications => Communications.FtpDropOff(It.IsAny<String>(), mockFileName, It.IsAny<Dictionary<String, String>>()));
-            mockCommunications.Verify(Communications => Communications.FtpPickUp(It.IsAny<String>(), It.IsAny<Dictionary<String, String>>(), mockFileName));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpDropOff(It.IsAny<string>(), mockFileName, It.IsAny<Dictionary<string, string>>()));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpPickUp(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), mockFileName));
         }
 
         [Test]
         public void testEcheckSale()
         {
-            echeckSale echecksale = new echeckSale();
+            var echecksale = new echeckSale();
             echecksale.orderId = "12345";
             echecksale.amount = 123456;
             echecksale.orderSource = orderSourceType.ecommerce;
-            echeckType echeck = new echeckType();
+            var echeck = new echeckType();
             echeck.accType = echeckAccountTypeEnum.Checking;
             echeck.accNum = "12345657890";
             echeck.routingNum = "123456789";
             echeck.checkNum = "123455";
             echecksale.echeck = echeck;
-            contact contact = new contact();
+            var contact = new contact();
             contact.name = "Bob";
             contact.city = "lowell";
             contact.state = "MA";
@@ -583,64 +669,74 @@ namespace Litle.Sdk.Test.Unit
             var mockLitleXmlSerializer = new Mock<litleXmlSerializer>();
 
             mockXmlReader.SetupSequence(XmlReader => XmlReader.ReadOuterXml())
-                .Returns("<echeckSalesResponse xmlns='http://www.litle.com/schema'><litleTxnId>123</litleTxnId></echeckSalesResponse>")
-                .Returns("<echeckSalesResponse xmlns='http://www.litle.com/schema'><litleTxnId>124</litleTxnId></echeckSalesResponse>");
+                .Returns(
+                    "<echeckSalesResponse xmlns='http://www.litle.com/schema'><litleTxnId>123</litleTxnId></echeckSalesResponse>")
+                .Returns(
+                    "<echeckSalesResponse xmlns='http://www.litle.com/schema'><litleTxnId>124</litleTxnId></echeckSalesResponse>");
 
-            batchResponse mockedLitleBatchResponse = new batchResponse();
+            var mockedLitleBatchResponse = new batchResponse();
             mockedLitleBatchResponse.setEcheckSalesResponseReader(mockXmlReader.Object);
 
-            mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse()).Returns(mockedLitleBatchResponse);
-            litleResponse mockedLitleResponse = mockLitleResponse.Object;
+            mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse())
+                .Returns(mockedLitleBatchResponse);
+            var mockedLitleResponse = mockLitleResponse.Object;
 
-            Communications mockedCommunications = mockCommunications.Object;
+            var mockedCommunications = mockCommunications.Object;
 
-            mockLitleXmlSerializer.Setup(litleXmlSerializer => litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<String>())).Returns(mockedLitleResponse);
-            litleXmlSerializer mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
+            mockLitleXmlSerializer.Setup(
+                litleXmlSerializer =>
+                    litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<string>()))
+                .Returns(mockedLitleResponse);
+            var mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
 
-            litleFile mockedLitleFile = mockLitleFile.Object;
+            var mockedLitleFile = mockLitleFile.Object;
 
             litle.setCommunication(mockedCommunications);
             litle.setLitleXmlSerializer(mockedLitleXmlSerializer);
             litle.setLitleFile(mockedLitleFile);
             litle.setLitleTime(mockLitleTime.Object);
 
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
             litleBatchRequest.setLitleFile(mockedLitleFile);
             litleBatchRequest.setLitleTime(mockLitleTime.Object);
             litleBatchRequest.addEcheckSale(echecksale);
             litleBatchRequest.addEcheckSale(echecksale);
             litle.addBatch(litleBatchRequest);
 
-            string batchFileName = litle.sendToLitle();
+            var batchFileName = litle.sendToLitle();
 
-            litleResponse actualLitleResponse = litle.receiveFromLitle(batchFileName);
-            batchResponse actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
-            echeckSalesResponse actualEcheckSalesResponse1 = actualLitleBatchResponse.nextEcheckSalesResponse();
-            echeckSalesResponse actualEcheckSalesResponse2 = actualLitleBatchResponse.nextEcheckSalesResponse();
-            echeckSalesResponse nullEcheckSalesResponse = actualLitleBatchResponse.nextEcheckSalesResponse();
+            var actualLitleResponse = litle.receiveFromLitle(batchFileName);
+            var actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
+            var actualEcheckSalesResponse1 = actualLitleBatchResponse.nextEcheckSalesResponse();
+            var actualEcheckSalesResponse2 = actualLitleBatchResponse.nextEcheckSalesResponse();
+            var nullEcheckSalesResponse = actualLitleBatchResponse.nextEcheckSalesResponse();
 
             Assert.AreEqual(123, actualEcheckSalesResponse1.litleTxnId);
             Assert.AreEqual(124, actualEcheckSalesResponse2.litleTxnId);
             Assert.IsNull(nullEcheckSalesResponse);
 
-            mockCommunications.Verify(Communications => Communications.FtpDropOff(It.IsAny<String>(), mockFileName, It.IsAny<Dictionary<String, String>>()));
-            mockCommunications.Verify(Communications => Communications.FtpPickUp(It.IsAny<String>(), It.IsAny<Dictionary<String, String>>(), mockFileName));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpDropOff(It.IsAny<string>(), mockFileName, It.IsAny<Dictionary<string, string>>()));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpPickUp(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), mockFileName));
         }
 
         [Test]
         public void testEcheckVerification()
         {
-            echeckVerification echeckverification = new echeckVerification();
+            var echeckverification = new echeckVerification();
             echeckverification.orderId = "12345";
             echeckverification.amount = 123456;
             echeckverification.orderSource = orderSourceType.ecommerce;
-            echeckType echeck = new echeckType();
+            var echeck = new echeckType();
             echeck.accType = echeckAccountTypeEnum.Checking;
             echeck.accNum = "12345657890";
             echeck.routingNum = "123456789";
             echeck.checkNum = "123455";
             echeckverification.echeck = echeck;
-            contact contact = new contact();
+            var contact = new contact();
             contact.name = "Bob";
             contact.city = "lowell";
             contact.state = "MA";
@@ -651,58 +747,68 @@ namespace Litle.Sdk.Test.Unit
             var mockLitleXmlSerializer = new Mock<litleXmlSerializer>();
 
             mockXmlReader.SetupSequence(XmlReader => XmlReader.ReadOuterXml())
-                .Returns("<echeckVerificationResponse xmlns='http://www.litle.com/schema'><litleTxnId>123</litleTxnId></echeckVerificationResponse>")
-                .Returns("<echeckVerificationResponse xmlns='http://www.litle.com/schema'><litleTxnId>124</litleTxnId></echeckVerificationResponse>");
+                .Returns(
+                    "<echeckVerificationResponse xmlns='http://www.litle.com/schema'><litleTxnId>123</litleTxnId></echeckVerificationResponse>")
+                .Returns(
+                    "<echeckVerificationResponse xmlns='http://www.litle.com/schema'><litleTxnId>124</litleTxnId></echeckVerificationResponse>");
 
-            batchResponse mockedLitleBatchResponse = new batchResponse();
+            var mockedLitleBatchResponse = new batchResponse();
             mockedLitleBatchResponse.setEcheckVerificationResponseReader(mockXmlReader.Object);
 
-            mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse()).Returns(mockedLitleBatchResponse);
-            litleResponse mockedLitleResponse = mockLitleResponse.Object;
+            mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse())
+                .Returns(mockedLitleBatchResponse);
+            var mockedLitleResponse = mockLitleResponse.Object;
 
-            Communications mockedCommunications = mockCommunications.Object;
+            var mockedCommunications = mockCommunications.Object;
 
-            mockLitleXmlSerializer.Setup(litleXmlSerializer => litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<String>())).Returns(mockedLitleResponse);
-            litleXmlSerializer mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
+            mockLitleXmlSerializer.Setup(
+                litleXmlSerializer =>
+                    litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<string>()))
+                .Returns(mockedLitleResponse);
+            var mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
 
-            litleFile mockedLitleFile = mockLitleFile.Object;
+            var mockedLitleFile = mockLitleFile.Object;
 
             litle.setCommunication(mockedCommunications);
             litle.setLitleXmlSerializer(mockedLitleXmlSerializer);
             litle.setLitleFile(mockedLitleFile);
             litle.setLitleTime(mockLitleTime.Object);
 
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
             litleBatchRequest.setLitleFile(mockedLitleFile);
             litleBatchRequest.setLitleTime(mockLitleTime.Object);
             litleBatchRequest.addEcheckVerification(echeckverification);
             litleBatchRequest.addEcheckVerification(echeckverification);
             litle.addBatch(litleBatchRequest);
 
-            string batchFileName = litle.sendToLitle();
+            var batchFileName = litle.sendToLitle();
 
-            litleResponse actualLitleResponse = litle.receiveFromLitle(batchFileName);
-            batchResponse actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
-            echeckVerificationResponse actualEcheckVerificationResponse1 = actualLitleBatchResponse.nextEcheckVerificationResponse();
-            echeckVerificationResponse actualEcheckVerificationResponse2 = actualLitleBatchResponse.nextEcheckVerificationResponse();
-            echeckVerificationResponse nullEcheckVerificationResponse = actualLitleBatchResponse.nextEcheckVerificationResponse();
+            var actualLitleResponse = litle.receiveFromLitle(batchFileName);
+            var actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
+            var actualEcheckVerificationResponse1 = actualLitleBatchResponse.nextEcheckVerificationResponse();
+            var actualEcheckVerificationResponse2 = actualLitleBatchResponse.nextEcheckVerificationResponse();
+            var nullEcheckVerificationResponse = actualLitleBatchResponse.nextEcheckVerificationResponse();
 
             Assert.AreEqual(123, actualEcheckVerificationResponse1.litleTxnId);
             Assert.AreEqual(124, actualEcheckVerificationResponse2.litleTxnId);
             Assert.IsNull(nullEcheckVerificationResponse);
 
-            mockCommunications.Verify(Communications => Communications.FtpDropOff(It.IsAny<String>(), mockFileName, It.IsAny<Dictionary<String, String>>()));
-            mockCommunications.Verify(Communications => Communications.FtpPickUp(It.IsAny<String>(), It.IsAny<Dictionary<String, String>>(), mockFileName));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpDropOff(It.IsAny<string>(), mockFileName, It.IsAny<Dictionary<string, string>>()));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpPickUp(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), mockFileName));
         }
 
         [Test]
         public void testForceCapture()
         {
-            forceCapture forcecapture = new forceCapture();
+            var forcecapture = new forceCapture();
             forcecapture.orderId = "12344";
             forcecapture.amount = 106;
             forcecapture.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000001";
             card.expDate = "1210";
@@ -712,58 +818,68 @@ namespace Litle.Sdk.Test.Unit
             var mockLitleXmlSerializer = new Mock<litleXmlSerializer>();
 
             mockXmlReader.SetupSequence(XmlReader => XmlReader.ReadOuterXml())
-                .Returns("<forceCaptureResponse xmlns='http://www.litle.com/schema'><litleTxnId>123</litleTxnId></forceCaptureResponse>")
-                .Returns("<forceCaptureResponse xmlns='http://www.litle.com/schema'><litleTxnId>124</litleTxnId></forceCaptureResponse>");
+                .Returns(
+                    "<forceCaptureResponse xmlns='http://www.litle.com/schema'><litleTxnId>123</litleTxnId></forceCaptureResponse>")
+                .Returns(
+                    "<forceCaptureResponse xmlns='http://www.litle.com/schema'><litleTxnId>124</litleTxnId></forceCaptureResponse>");
 
-            batchResponse mockedLitleBatchResponse = new batchResponse();
+            var mockedLitleBatchResponse = new batchResponse();
             mockedLitleBatchResponse.setForceCaptureResponseReader(mockXmlReader.Object);
 
-            mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse()).Returns(mockedLitleBatchResponse);
-            litleResponse mockedLitleResponse = mockLitleResponse.Object;
+            mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse())
+                .Returns(mockedLitleBatchResponse);
+            var mockedLitleResponse = mockLitleResponse.Object;
 
-            Communications mockedCommunications = mockCommunications.Object;
+            var mockedCommunications = mockCommunications.Object;
 
-            mockLitleXmlSerializer.Setup(litleXmlSerializer => litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<String>())).Returns(mockedLitleResponse);
-            litleXmlSerializer mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
+            mockLitleXmlSerializer.Setup(
+                litleXmlSerializer =>
+                    litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<string>()))
+                .Returns(mockedLitleResponse);
+            var mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
 
-            litleFile mockedLitleFile = mockLitleFile.Object;
+            var mockedLitleFile = mockLitleFile.Object;
 
             litle.setCommunication(mockedCommunications);
             litle.setLitleXmlSerializer(mockedLitleXmlSerializer);
             litle.setLitleFile(mockedLitleFile);
             litle.setLitleTime(mockLitleTime.Object);
 
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
             litleBatchRequest.setLitleFile(mockedLitleFile);
             litleBatchRequest.setLitleTime(mockLitleTime.Object);
             litleBatchRequest.addForceCapture(forcecapture);
             litleBatchRequest.addForceCapture(forcecapture);
             litle.addBatch(litleBatchRequest);
 
-            string batchFileName = litle.sendToLitle();
+            var batchFileName = litle.sendToLitle();
 
-            litleResponse actualLitleResponse = litle.receiveFromLitle(batchFileName);
-            batchResponse actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
-            forceCaptureResponse actualForceCaptureResponse1 = actualLitleBatchResponse.nextForceCaptureResponse();
-            forceCaptureResponse actualForceCaptureResponse2 = actualLitleBatchResponse.nextForceCaptureResponse();
-            forceCaptureResponse nullForceCaptureResponse = actualLitleBatchResponse.nextForceCaptureResponse();
+            var actualLitleResponse = litle.receiveFromLitle(batchFileName);
+            var actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
+            var actualForceCaptureResponse1 = actualLitleBatchResponse.nextForceCaptureResponse();
+            var actualForceCaptureResponse2 = actualLitleBatchResponse.nextForceCaptureResponse();
+            var nullForceCaptureResponse = actualLitleBatchResponse.nextForceCaptureResponse();
 
             Assert.AreEqual(123, actualForceCaptureResponse1.litleTxnId);
             Assert.AreEqual(124, actualForceCaptureResponse2.litleTxnId);
             Assert.IsNull(nullForceCaptureResponse);
 
-            mockCommunications.Verify(Communications => Communications.FtpDropOff(It.IsAny<String>(), mockFileName, It.IsAny<Dictionary<String, String>>()));
-            mockCommunications.Verify(Communications => Communications.FtpPickUp(It.IsAny<String>(), It.IsAny<Dictionary<String, String>>(), mockFileName));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpDropOff(It.IsAny<string>(), mockFileName, It.IsAny<Dictionary<string, string>>()));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpPickUp(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), mockFileName));
         }
 
         [Test]
         public void testSale()
         {
-            sale sale = new sale();
+            var sale = new sale();
             sale.orderId = "12344";
             sale.amount = 106;
             sale.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000002";
             card.expDate = "1210";
@@ -776,51 +892,59 @@ namespace Litle.Sdk.Test.Unit
                 .Returns("<saleResponse xmlns='http://www.litle.com/schema'><litleTxnId>123</litleTxnId></saleResponse>")
                 .Returns("<saleResponse xmlns='http://www.litle.com/schema'><litleTxnId>124</litleTxnId></saleResponse>");
 
-            batchResponse mockedLitleBatchResponse = new batchResponse();
+            var mockedLitleBatchResponse = new batchResponse();
             mockedLitleBatchResponse.setSaleResponseReader(mockXmlReader.Object);
 
-            mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse()).Returns(mockedLitleBatchResponse);
-            litleResponse mockedLitleResponse = mockLitleResponse.Object;
+            mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse())
+                .Returns(mockedLitleBatchResponse);
+            var mockedLitleResponse = mockLitleResponse.Object;
 
-            Communications mockedCommunications = mockCommunications.Object;
+            var mockedCommunications = mockCommunications.Object;
 
-            mockLitleXmlSerializer.Setup(litleXmlSerializer => litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<String>())).Returns(mockedLitleResponse);
-            litleXmlSerializer mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
+            mockLitleXmlSerializer.Setup(
+                litleXmlSerializer =>
+                    litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<string>()))
+                .Returns(mockedLitleResponse);
+            var mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
 
-            litleFile mockedLitleFile = mockLitleFile.Object;
+            var mockedLitleFile = mockLitleFile.Object;
 
             litle.setCommunication(mockedCommunications);
             litle.setLitleXmlSerializer(mockedLitleXmlSerializer);
             litle.setLitleFile(mockedLitleFile);
             litle.setLitleTime(mockLitleTime.Object);
 
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
             litleBatchRequest.setLitleFile(mockedLitleFile);
             litleBatchRequest.setLitleTime(mockLitleTime.Object);
             litleBatchRequest.addSale(sale);
             litleBatchRequest.addSale(sale);
             litle.addBatch(litleBatchRequest);
 
-            string batchFileName = litle.sendToLitle();
+            var batchFileName = litle.sendToLitle();
 
-            litleResponse actualLitleResponse = litle.receiveFromLitle(batchFileName);
-            batchResponse actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
-            saleResponse actualSaleResponse1 = actualLitleBatchResponse.nextSaleResponse();
-            saleResponse actualSaleResponse2 = actualLitleBatchResponse.nextSaleResponse();
-            saleResponse nullSaleResponse = actualLitleBatchResponse.nextSaleResponse();
+            var actualLitleResponse = litle.receiveFromLitle(batchFileName);
+            var actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
+            var actualSaleResponse1 = actualLitleBatchResponse.nextSaleResponse();
+            var actualSaleResponse2 = actualLitleBatchResponse.nextSaleResponse();
+            var nullSaleResponse = actualLitleBatchResponse.nextSaleResponse();
 
             Assert.AreEqual(123, actualSaleResponse1.litleTxnId);
             Assert.AreEqual(124, actualSaleResponse2.litleTxnId);
             Assert.IsNull(nullSaleResponse);
 
-            mockCommunications.Verify(Communications => Communications.FtpDropOff(It.IsAny<String>(), mockFileName, It.IsAny<Dictionary<String, String>>()));
-            mockCommunications.Verify(Communications => Communications.FtpPickUp(It.IsAny<String>(), It.IsAny<Dictionary<String, String>>(), mockFileName));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpDropOff(It.IsAny<string>(), mockFileName, It.IsAny<Dictionary<string, string>>()));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpPickUp(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), mockFileName));
         }
 
         [Test]
         public void testToken()
         {
-            registerTokenRequestType token = new registerTokenRequestType();
+            var token = new registerTokenRequestType();
             token.orderId = "12344";
             token.accountNumber = "1233456789103801";
 
@@ -828,54 +952,64 @@ namespace Litle.Sdk.Test.Unit
             var mockLitleXmlSerializer = new Mock<litleXmlSerializer>();
 
             mockXmlReader.SetupSequence(XmlReader => XmlReader.ReadOuterXml())
-                .Returns("<registerTokenResponse xmlns='http://www.litle.com/schema'><litleTxnId>123</litleTxnId></registerTokenResponse>")
-                .Returns("<registerTokenResponse xmlns='http://www.litle.com/schema'><litleTxnId>124</litleTxnId></registerTokenResponse>");
+                .Returns(
+                    "<registerTokenResponse xmlns='http://www.litle.com/schema'><litleTxnId>123</litleTxnId></registerTokenResponse>")
+                .Returns(
+                    "<registerTokenResponse xmlns='http://www.litle.com/schema'><litleTxnId>124</litleTxnId></registerTokenResponse>");
 
-            batchResponse mockedLitleBatchResponse = new batchResponse();
+            var mockedLitleBatchResponse = new batchResponse();
             mockedLitleBatchResponse.setRegisterTokenResponseReader(mockXmlReader.Object);
 
-            mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse()).Returns(mockedLitleBatchResponse);
-            litleResponse mockedLitleResponse = mockLitleResponse.Object;
+            mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse())
+                .Returns(mockedLitleBatchResponse);
+            var mockedLitleResponse = mockLitleResponse.Object;
 
-            Communications mockedCommunications = mockCommunications.Object;
+            var mockedCommunications = mockCommunications.Object;
 
-            mockLitleXmlSerializer.Setup(litleXmlSerializer => litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<String>())).Returns(mockedLitleResponse);
-            litleXmlSerializer mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
+            mockLitleXmlSerializer.Setup(
+                litleXmlSerializer =>
+                    litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<string>()))
+                .Returns(mockedLitleResponse);
+            var mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
 
-            litleFile mockedLitleFile = mockLitleFile.Object;
+            var mockedLitleFile = mockLitleFile.Object;
 
             litle.setCommunication(mockedCommunications);
             litle.setLitleXmlSerializer(mockedLitleXmlSerializer);
             litle.setLitleFile(mockedLitleFile);
             litle.setLitleTime(mockLitleTime.Object);
 
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
             litleBatchRequest.setLitleFile(mockedLitleFile);
             litleBatchRequest.setLitleTime(mockLitleTime.Object);
             litleBatchRequest.addRegisterTokenRequest(token);
             litleBatchRequest.addRegisterTokenRequest(token);
             litle.addBatch(litleBatchRequest);
 
-            string batchFileName = litle.sendToLitle();
+            var batchFileName = litle.sendToLitle();
 
-            litleResponse actualLitleResponse = litle.receiveFromLitle(batchFileName);
-            batchResponse actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
-            registerTokenResponse actualRegisterTokenResponse1 = actualLitleBatchResponse.nextRegisterTokenResponse();
-            registerTokenResponse actualRegisterTokenResponse2 = actualLitleBatchResponse.nextRegisterTokenResponse();
-            registerTokenResponse nullRegisterTokenResponse = actualLitleBatchResponse.nextRegisterTokenResponse();
+            var actualLitleResponse = litle.receiveFromLitle(batchFileName);
+            var actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
+            var actualRegisterTokenResponse1 = actualLitleBatchResponse.nextRegisterTokenResponse();
+            var actualRegisterTokenResponse2 = actualLitleBatchResponse.nextRegisterTokenResponse();
+            var nullRegisterTokenResponse = actualLitleBatchResponse.nextRegisterTokenResponse();
 
             Assert.AreEqual(123, actualRegisterTokenResponse1.litleTxnId);
             Assert.AreEqual(124, actualRegisterTokenResponse2.litleTxnId);
             Assert.IsNull(nullRegisterTokenResponse);
 
-            mockCommunications.Verify(Communications => Communications.FtpDropOff(It.IsAny<String>(), mockFileName, It.IsAny<Dictionary<String, String>>()));
-            mockCommunications.Verify(Communications => Communications.FtpPickUp(It.IsAny<String>(), It.IsAny<Dictionary<String, String>>(), mockFileName));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpDropOff(It.IsAny<string>(), mockFileName, It.IsAny<Dictionary<string, string>>()));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpPickUp(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), mockFileName));
         }
 
         [Test]
         public void testUpdateCardValidationNumOnToken()
         {
-            updateCardValidationNumOnToken updateCardValidationNumOnToken = new updateCardValidationNumOnToken();
+            var updateCardValidationNumOnToken = new updateCardValidationNumOnToken();
             updateCardValidationNumOnToken.orderId = "12344";
             updateCardValidationNumOnToken.litleToken = "123";
 
@@ -883,59 +1017,72 @@ namespace Litle.Sdk.Test.Unit
             var mockLitleXmlSerializer = new Mock<litleXmlSerializer>();
 
             mockXmlReader.SetupSequence(XmlReader => XmlReader.ReadOuterXml())
-                .Returns("<updateCardValidationNumOnTokenResponse xmlns='http://www.litle.com/schema'><litleTxnId>123</litleTxnId></updateCardValidationNumOnTokenResponse>")
-                .Returns("<updateCardValidationNumOnTokenResponse xmlns='http://www.litle.com/schema'><litleTxnId>124</litleTxnId></updateCardValidationNumOnTokenResponse>");
+                .Returns(
+                    "<updateCardValidationNumOnTokenResponse xmlns='http://www.litle.com/schema'><litleTxnId>123</litleTxnId></updateCardValidationNumOnTokenResponse>")
+                .Returns(
+                    "<updateCardValidationNumOnTokenResponse xmlns='http://www.litle.com/schema'><litleTxnId>124</litleTxnId></updateCardValidationNumOnTokenResponse>");
 
-            batchResponse mockedLitleBatchResponse = new batchResponse();
+            var mockedLitleBatchResponse = new batchResponse();
             mockedLitleBatchResponse.setUpdateCardValidationNumOnTokenResponseReader(mockXmlReader.Object);
 
-            mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse()).Returns(mockedLitleBatchResponse);
-            litleResponse mockedLitleResponse = mockLitleResponse.Object;
+            mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse())
+                .Returns(mockedLitleBatchResponse);
+            var mockedLitleResponse = mockLitleResponse.Object;
 
-            Communications mockedCommunications = mockCommunications.Object;
+            var mockedCommunications = mockCommunications.Object;
 
-            mockLitleXmlSerializer.Setup(litleXmlSerializer => litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<String>())).Returns(mockedLitleResponse);
-            litleXmlSerializer mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
+            mockLitleXmlSerializer.Setup(
+                litleXmlSerializer =>
+                    litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<string>()))
+                .Returns(mockedLitleResponse);
+            var mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
 
-            litleFile mockedLitleFile = mockLitleFile.Object;
+            var mockedLitleFile = mockLitleFile.Object;
 
             litle.setCommunication(mockedCommunications);
             litle.setLitleXmlSerializer(mockedLitleXmlSerializer);
             litle.setLitleFile(mockedLitleFile);
             litle.setLitleTime(mockLitleTime.Object);
 
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
             litleBatchRequest.setLitleFile(mockedLitleFile);
             litleBatchRequest.setLitleTime(mockLitleTime.Object);
             litleBatchRequest.addUpdateCardValidationNumOnToken(updateCardValidationNumOnToken);
             litleBatchRequest.addUpdateCardValidationNumOnToken(updateCardValidationNumOnToken);
             litle.addBatch(litleBatchRequest);
 
-            string batchFileName = litle.sendToLitle();
+            var batchFileName = litle.sendToLitle();
 
-            litleResponse actualLitleResponse = litle.receiveFromLitle(batchFileName);
-            batchResponse actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
-            updateCardValidationNumOnTokenResponse actualUpdateCardValidationNumOnTokenResponse1 = actualLitleBatchResponse.nextUpdateCardValidationNumOnTokenResponse();
-            updateCardValidationNumOnTokenResponse actualUpdateCardValidationNumOnTokenResponse2 = actualLitleBatchResponse.nextUpdateCardValidationNumOnTokenResponse();
-            updateCardValidationNumOnTokenResponse nullUpdateCardValidationNumOnTokenResponse = actualLitleBatchResponse.nextUpdateCardValidationNumOnTokenResponse();
+            var actualLitleResponse = litle.receiveFromLitle(batchFileName);
+            var actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
+            var actualUpdateCardValidationNumOnTokenResponse1 =
+                actualLitleBatchResponse.nextUpdateCardValidationNumOnTokenResponse();
+            var actualUpdateCardValidationNumOnTokenResponse2 =
+                actualLitleBatchResponse.nextUpdateCardValidationNumOnTokenResponse();
+            var nullUpdateCardValidationNumOnTokenResponse =
+                actualLitleBatchResponse.nextUpdateCardValidationNumOnTokenResponse();
 
             Assert.AreEqual(123, actualUpdateCardValidationNumOnTokenResponse1.litleTxnId);
             Assert.AreEqual(124, actualUpdateCardValidationNumOnTokenResponse2.litleTxnId);
             Assert.IsNull(nullUpdateCardValidationNumOnTokenResponse);
 
-            mockCommunications.Verify(Communications => Communications.FtpDropOff(It.IsAny<String>(), mockFileName, It.IsAny<Dictionary<String, String>>()));
-            mockCommunications.Verify(Communications => Communications.FtpPickUp(It.IsAny<String>(), It.IsAny<Dictionary<String, String>>(), mockFileName));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpDropOff(It.IsAny<string>(), mockFileName, It.IsAny<Dictionary<string, string>>()));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpPickUp(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), mockFileName));
         }
 
         [Test]
         public void testLitleOnlineException()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.reportGroup = "Planets";
             authorization.orderId = "12344";
             authorization.amount = 106;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000002";
             card.expDate = "1210";
@@ -945,26 +1092,29 @@ namespace Litle.Sdk.Test.Unit
             var mockLitleBatchResponse = new Mock<batchResponse>();
             var mockLitleXmlSerializer = new Mock<litleXmlSerializer>();
 
-            authorizationResponse mockAuthorizationResponse1 = new authorizationResponse();
+            var mockAuthorizationResponse1 = new authorizationResponse();
             mockAuthorizationResponse1.litleTxnId = 123;
-            authorizationResponse mockAuthorizationResponse2 = new authorizationResponse();
+            var mockAuthorizationResponse2 = new authorizationResponse();
             mockAuthorizationResponse2.litleTxnId = 124;
 
             mockLitleBatchResponse.SetupSequence(litleBatchResponse => litleBatchResponse.nextAuthorizationResponse())
                 .Returns(mockAuthorizationResponse1)
                 .Returns(mockAuthorizationResponse2)
-                .Returns((authorizationResponse)null);
+                .Returns(null);
 
-            litleResponse mockedLitleResponse = mockLitleResponse.Object;
+            var mockedLitleResponse = mockLitleResponse.Object;
             mockedLitleResponse.message = "Error validating xml data against the schema";
             mockedLitleResponse.response = "1";
 
-            Communications mockedCommunications = mockCommunications.Object;
+            var mockedCommunications = mockCommunications.Object;
 
-            mockLitleXmlSerializer.Setup(litleXmlSerializer => litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<String>())).Returns(mockedLitleResponse);
-            litleXmlSerializer mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
+            mockLitleXmlSerializer.Setup(
+                litleXmlSerializer =>
+                    litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<string>()))
+                .Returns(mockedLitleResponse);
+            var mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
 
-            litleFile mockedLitleFile = mockLitleFile.Object;
+            var mockedLitleFile = mockLitleFile.Object;
 
             try
             {
@@ -972,7 +1122,7 @@ namespace Litle.Sdk.Test.Unit
                 litle.setLitleXmlSerializer(mockedLitleXmlSerializer);
                 litle.setLitleFile(mockedLitleFile);
                 litle.setLitleTime(mockLitleTime.Object);
-                batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+                var litleBatchRequest = new batchRequest(memoryStreams);
                 litleBatchRequest.setLitleFile(mockedLitleFile);
                 litleBatchRequest.setLitleTime(mockLitleTime.Object);
 
@@ -980,8 +1130,8 @@ namespace Litle.Sdk.Test.Unit
                 litleBatchRequest.addAuthorization(authorization);
                 litle.addBatch(litleBatchRequest);
 
-                string batchFileName = litle.sendToLitle();
-                litleResponse litleResponse = litle.receiveFromLitle(batchFileName);
+                var batchFileName = litle.sendToLitle();
+                var litleResponse = litle.receiveFromLitle(batchFileName);
             }
             catch (LitleOnlineException e)
             {
@@ -992,12 +1142,12 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void testInvalidOperationException()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.reportGroup = "Planets";
             authorization.orderId = "12344";
             authorization.amount = 106;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000002";
             card.expDate = "1210";
@@ -1007,12 +1157,15 @@ namespace Litle.Sdk.Test.Unit
 
             var mockXml = new Mock<litleXmlSerializer>();
 
-            Communications mockedCommunications = mockCommunications.Object;
+            var mockedCommunications = mockCommunications.Object;
 
-            mockXml.Setup(litleXmlSerializer => litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<String>())).Returns(mockLitleResponse);
-            litleXmlSerializer mockedLitleXmlSerializer = mockXml.Object;
+            mockXml.Setup(
+                litleXmlSerializer =>
+                    litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<string>()))
+                .Returns(mockLitleResponse);
+            var mockedLitleXmlSerializer = mockXml.Object;
 
-            litleFile mockedLitleFile = mockLitleFile.Object;
+            var mockedLitleFile = mockLitleFile.Object;
 
             try
             {
@@ -1020,7 +1173,7 @@ namespace Litle.Sdk.Test.Unit
                 litle.setLitleXmlSerializer(mockedLitleXmlSerializer);
                 litle.setLitleFile(mockedLitleFile);
                 litle.setLitleTime(mockLitleTime.Object);
-                batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+                var litleBatchRequest = new batchRequest(memoryStreams);
                 litleBatchRequest.setLitleFile(mockedLitleFile);
                 litleBatchRequest.setLitleTime(mockLitleTime.Object);
 
@@ -1028,8 +1181,8 @@ namespace Litle.Sdk.Test.Unit
                 litleBatchRequest.addAuthorization(authorization);
                 litle.addBatch(litleBatchRequest);
 
-                string batchFileName = litle.sendToLitle();
-                litleResponse litleResponse = litle.receiveFromLitle(batchFileName);
+                var batchFileName = litle.sendToLitle();
+                var litleResponse = litle.receiveFromLitle(batchFileName);
             }
             catch (LitleOnlineException e)
             {
@@ -1040,11 +1193,11 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void testDefaultReportGroup()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "12344";
             authorization.amount = 106;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000002";
             card.expDate = "1210";
@@ -1054,40 +1207,46 @@ namespace Litle.Sdk.Test.Unit
             var mockLitleXmlSerializer = new Mock<litleXmlSerializer>();
 
             mockXmlReader.SetupSequence(XmlReader => XmlReader.ReadOuterXml())
-                .Returns("<authorizationResponse reportGroup=\"Default Report Group\" xmlns='http://www.litle.com/schema'><litleTxnId>123</litleTxnId></authorizationResponse>")
-                .Returns("<authorizationResponse reportGroup=\"Default Report Group\" xmlns='http://www.litle.com/schema'><litleTxnId>124</litleTxnId></authorizationResponse>");
+                .Returns(
+                    "<authorizationResponse reportGroup=\"Default Report Group\" xmlns='http://www.litle.com/schema'><litleTxnId>123</litleTxnId></authorizationResponse>")
+                .Returns(
+                    "<authorizationResponse reportGroup=\"Default Report Group\" xmlns='http://www.litle.com/schema'><litleTxnId>124</litleTxnId></authorizationResponse>");
 
-            batchResponse mockedLitleBatchResponse = new batchResponse();
+            var mockedLitleBatchResponse = new batchResponse();
             mockedLitleBatchResponse.setAuthorizationResponseReader(mockXmlReader.Object);
 
-            mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse()).Returns(mockedLitleBatchResponse);
-            litleResponse mockedLitleResponse = mockLitleResponse.Object;
+            mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse())
+                .Returns(mockedLitleBatchResponse);
+            var mockedLitleResponse = mockLitleResponse.Object;
 
-            Communications mockedCommunications = mockCommunications.Object;
+            var mockedCommunications = mockCommunications.Object;
 
-            mockLitleXmlSerializer.Setup(litleXmlSerializer => litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<String>())).Returns(mockedLitleResponse);
-            litleXmlSerializer mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
+            mockLitleXmlSerializer.Setup(
+                litleXmlSerializer =>
+                    litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<string>()))
+                .Returns(mockedLitleResponse);
+            var mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
 
-            litleFile mockedLitleFile = mockLitleFile.Object;
+            var mockedLitleFile = mockLitleFile.Object;
 
             litle.setCommunication(mockedCommunications);
             litle.setLitleXmlSerializer(mockedLitleXmlSerializer);
             litle.setLitleFile(mockedLitleFile);
             litle.setLitleTime(mockLitleTime.Object);
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
             litleBatchRequest.setLitleFile(mockedLitleFile);
             litleBatchRequest.setLitleTime(mockLitleTime.Object);
             litleBatchRequest.addAuthorization(authorization);
             litleBatchRequest.addAuthorization(authorization);
             litle.addBatch(litleBatchRequest);
 
-            string batchFileName = litle.sendToLitle();
+            var batchFileName = litle.sendToLitle();
 
-            litleResponse actualLitleResponse = litle.receiveFromLitle(batchFileName);
-            batchResponse actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
-            authorizationResponse actualAuthorizationResponse1 = actualLitleBatchResponse.nextAuthorizationResponse();
-            authorizationResponse actualAuthorizationResponse2 = actualLitleBatchResponse.nextAuthorizationResponse();
-            authorizationResponse nullAuthorizationResponse = actualLitleBatchResponse.nextAuthorizationResponse();
+            var actualLitleResponse = litle.receiveFromLitle(batchFileName);
+            var actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
+            var actualAuthorizationResponse1 = actualLitleBatchResponse.nextAuthorizationResponse();
+            var actualAuthorizationResponse2 = actualLitleBatchResponse.nextAuthorizationResponse();
+            var nullAuthorizationResponse = actualLitleBatchResponse.nextAuthorizationResponse();
 
             Assert.AreEqual(123, actualAuthorizationResponse1.litleTxnId);
             Assert.AreEqual("Default Report Group", actualAuthorizationResponse1.reportGroup);
@@ -1095,65 +1254,79 @@ namespace Litle.Sdk.Test.Unit
             Assert.AreEqual("Default Report Group", actualAuthorizationResponse2.reportGroup);
             Assert.IsNull(nullAuthorizationResponse);
 
-            mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, It.IsRegex(".*reportGroup=\"Default Report Group\".*", RegexOptions.Singleline)));
-            mockCommunications.Verify(Communications => Communications.FtpDropOff(It.IsAny<String>(), mockFileName, It.IsAny<Dictionary<String, String>>()));
-            mockCommunications.Verify(Communications => Communications.FtpPickUp(It.IsAny<String>(), It.IsAny<Dictionary<String, String>>(), mockFileName));
+            mockLitleFile.Verify(
+                litleFile =>
+                    litleFile.AppendLineToFile(mockFilePath,
+                        It.IsRegex(".*reportGroup=\"Default Report Group\".*", RegexOptions.Singleline)));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpDropOff(It.IsAny<string>(), mockFileName, It.IsAny<Dictionary<string, string>>()));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpPickUp(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), mockFileName));
         }
 
         [Test]
         public void testSerialize()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "12344";
             authorization.amount = 106;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000002";
             card.expDate = "1210";
             authorization.card = card;
 
-            litleFile mockedLitleFile = mockLitleFile.Object;
-            litleTime mockedLitleTime = mockLitleTime.Object;
+            var mockedLitleFile = mockLitleFile.Object;
+            var mockedLitleTime = mockLitleTime.Object;
 
             litle.setLitleTime(mockedLitleTime);
             litle.setLitleFile(mockedLitleFile);
 
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
             litleBatchRequest.setLitleFile(mockedLitleFile);
             litleBatchRequest.addAuthorization(authorization);
             litle.addBatch(litleBatchRequest);
 
-            string resultFile = litle.Serialize();
+            var resultFile = litle.Serialize();
 
             Assert.IsTrue(resultFile.Equals(mockFilePath));
 
-            mockLitleFile.Verify(litleFile => litleFile.AppendFileToFile(mockFilePath, It.IsAny<String>()));
+            mockLitleFile.Verify(litleFile => litleFile.AppendFileToFile(mockFilePath, It.IsAny<string>()));
         }
 
         [Test]
         public void testRFRRequest()
         {
-            RFRRequest rfrRequest = new RFRRequest(memoryStreams);
+            var rfrRequest = new RFRRequest(memoryStreams);
             rfrRequest.litleSessionId = 123456789;
 
             var mockBatchXmlReader = new Mock<XmlReader>();
             mockBatchXmlReader.Setup(XmlReader => XmlReader.ReadState).Returns(ReadState.Closed);
 
-            mockXmlReader.SetupSequence(XmlReader => XmlReader.ReadState).Returns(ReadState.Interactive).Returns(ReadState.Closed);
-            mockXmlReader.Setup(XmlReader => XmlReader.ReadOuterXml()).Returns("<RFRResponse response=\"1\" message=\"The account update file is not ready yet. Please try again later.\" xmlns='http://www.litle.com/schema'> </RFRResponse>");
+            mockXmlReader.SetupSequence(XmlReader => XmlReader.ReadState)
+                .Returns(ReadState.Interactive)
+                .Returns(ReadState.Closed);
+            mockXmlReader.Setup(XmlReader => XmlReader.ReadOuterXml())
+                .Returns(
+                    "<RFRResponse response=\"1\" message=\"The account update file is not ready yet. Please try again later.\" xmlns='http://www.litle.com/schema'> </RFRResponse>");
 
-            litleResponse mockedLitleResponse = new litleResponse();
+            var mockedLitleResponse = new litleResponse();
             mockedLitleResponse.setRfrResponseReader(mockXmlReader.Object);
             mockedLitleResponse.setBatchResponseReader(mockBatchXmlReader.Object);
 
             var mockLitleXmlSerializer = new Mock<litleXmlSerializer>();
-            mockLitleXmlSerializer.Setup(litleXmlSerializer => litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<String>())).Returns(mockedLitleResponse);
-            litleXmlSerializer mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
+            mockLitleXmlSerializer.Setup(
+                litleXmlSerializer =>
+                    litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<string>()))
+                .Returns(mockedLitleResponse);
+            var mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
 
-            litleFile mockedLitleFile = mockLitleFile.Object;
-            litleTime mockedLitleTime = mockLitleTime.Object;
-            Communications mockedCommunications = mockCommunications.Object;
+            var mockedLitleFile = mockLitleFile.Object;
+            var mockedLitleTime = mockLitleTime.Object;
+            var mockedCommunications = mockCommunications.Object;
 
             litle.setLitleFile(mockedLitleFile);
             litle.setLitleTime(mockedLitleTime);
@@ -1165,86 +1338,100 @@ namespace Litle.Sdk.Test.Unit
 
             litle.addRFRRequest(rfrRequest);
 
-            string batchFileName = litle.sendToLitle();
+            var batchFileName = litle.sendToLitle();
 
-            litleResponse actualLitleResponse = litle.receiveFromLitle(batchFileName);
-            batchResponse nullLitleBatchResponse = actualLitleResponse.nextBatchResponse();
-            RFRResponse actualRFRResponse = actualLitleResponse.nextRFRResponse();
-            RFRResponse nullRFRResponse = actualLitleResponse.nextRFRResponse();
+            var actualLitleResponse = litle.receiveFromLitle(batchFileName);
+            var nullLitleBatchResponse = actualLitleResponse.nextBatchResponse();
+            var actualRFRResponse = actualLitleResponse.nextRFRResponse();
+            var nullRFRResponse = actualLitleResponse.nextRFRResponse();
 
             Assert.IsNotNull(actualRFRResponse);
             Assert.AreEqual("1", actualRFRResponse.response);
-            Assert.AreEqual("The account update file is not ready yet. Please try again later.", actualRFRResponse.message);
+            Assert.AreEqual("The account update file is not ready yet. Please try again later.",
+                actualRFRResponse.message);
             Assert.IsNull(nullLitleBatchResponse);
             Assert.IsNull(nullRFRResponse);
 
-            mockCommunications.Verify(Communications => Communications.FtpDropOff(It.IsAny<String>(), mockFileName, It.IsAny<Dictionary<String, String>>()));
-            mockCommunications.Verify(Communications => Communications.FtpPickUp(It.IsAny<String>(), It.IsAny<Dictionary<String, String>>(), mockFileName));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpDropOff(It.IsAny<string>(), mockFileName, It.IsAny<Dictionary<string, string>>()));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpPickUp(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), mockFileName));
         }
 
         [Test]
         public void testCancelSubscription()
         {
-            cancelSubscription cancel = new cancelSubscription();
+            var cancel = new cancelSubscription();
             cancel.subscriptionId = 12345;
 
             var mockLitleResponse = new Mock<litleResponse>();
             var mockLitleXmlSerializer = new Mock<litleXmlSerializer>();
 
             mockXmlReader.SetupSequence(XmlReader => XmlReader.ReadOuterXml())
-                .Returns("<cancelSubscriptionResponse xmlns=\"http://www.litle.com/schema\"><litleTxnId>54321</litleTxnId><response>000</response><message>Approved</message><responseTime>2013-09-04T21:55:14</responseTime><subscriptionId>12345</subscriptionId></cancelSubscriptionResponse>")
-                .Returns("<cancelSubscriptionResponse xmlns=\"http://www.litle.com/schema\"><litleTxnId>12345</litleTxnId><response>000</response><message>Approved</message><responseTime>2013-09-04T21:55:14</responseTime><subscriptionId>54321</subscriptionId></cancelSubscriptionResponse>");
+                .Returns(
+                    "<cancelSubscriptionResponse xmlns=\"http://www.litle.com/schema\"><litleTxnId>54321</litleTxnId><response>000</response><message>Approved</message><responseTime>2013-09-04T21:55:14</responseTime><subscriptionId>12345</subscriptionId></cancelSubscriptionResponse>")
+                .Returns(
+                    "<cancelSubscriptionResponse xmlns=\"http://www.litle.com/schema\"><litleTxnId>12345</litleTxnId><response>000</response><message>Approved</message><responseTime>2013-09-04T21:55:14</responseTime><subscriptionId>54321</subscriptionId></cancelSubscriptionResponse>");
 
-            batchResponse mockLitleBatchResponse = new batchResponse();
+            var mockLitleBatchResponse = new batchResponse();
             mockLitleBatchResponse.setCancelSubscriptionResponseReader(mockXmlReader.Object);
 
             mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse()).Returns(mockLitleBatchResponse);
-            litleResponse mockedLitleResponse = mockLitleResponse.Object;
+            var mockedLitleResponse = mockLitleResponse.Object;
 
-            mockLitleXmlSerializer.Setup(litleXmlSerializer => litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<String>())).Returns(mockedLitleResponse);
+            mockLitleXmlSerializer.Setup(
+                litleXmlSerializer =>
+                    litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<string>()))
+                .Returns(mockedLitleResponse);
 
-            Communications mockedCommunication = mockCommunications.Object;
+            var mockedCommunication = mockCommunications.Object;
             litle.setCommunication(mockedCommunication);
 
-            litleXmlSerializer mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
+            var mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
             litle.setLitleXmlSerializer(mockedLitleXmlSerializer);
 
-            litleFile mockedLitleFile = mockLitleFile.Object;
+            var mockedLitleFile = mockLitleFile.Object;
             litle.setLitleFile(mockedLitleFile);
 
             litle.setLitleTime(mockLitleTime.Object);
 
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
             litleBatchRequest.setLitleFile(mockedLitleFile);
             litleBatchRequest.setLitleTime(mockLitleTime.Object);
             litleBatchRequest.addCancelSubscription(cancel);
             litle.addBatch(litleBatchRequest);
 
-            string batchFileName = litle.sendToLitle();
-            litleResponse actualLitleResponse = litle.receiveFromLitle(batchFileName);
-            batchResponse actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
+            var batchFileName = litle.sendToLitle();
+            var actualLitleResponse = litle.receiveFromLitle(batchFileName);
+            var actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
 
             Assert.AreSame(mockLitleBatchResponse, actualLitleBatchResponse);
             Assert.AreEqual("12345", actualLitleBatchResponse.nextCancelSubscriptionResponse().subscriptionId);
             Assert.AreEqual("54321", actualLitleBatchResponse.nextCancelSubscriptionResponse().subscriptionId);
             Assert.IsNull(actualLitleBatchResponse.nextCancelSubscriptionResponse());
 
-            mockCommunications.Verify(Communications => Communications.FtpDropOff(It.IsAny<String>(), mockFileName, It.IsAny<Dictionary<String, String>>()));
-            mockCommunications.Verify(Communications => Communications.FtpPickUp(It.IsAny<String>(), It.IsAny<Dictionary<String, String>>(), mockFileName));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpDropOff(It.IsAny<string>(), mockFileName, It.IsAny<Dictionary<string, string>>()));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpPickUp(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), mockFileName));
         }
 
         [Test]
         public void testUpdateSubscription()
         {
-            updateSubscription update = new updateSubscription();
+            var update = new updateSubscription();
             update.billingDate = new DateTime(2002, 10, 9);
-            contact billToAddress = new contact();
+            var billToAddress = new contact();
             billToAddress.name = "Greg Dake";
             billToAddress.city = "Lowell";
             billToAddress.state = "MA";
             billToAddress.email = "sdksupport@litle.com";
             update.billToAddress = billToAddress;
-            cardType card = new cardType();
+            var card = new cardType();
             card.number = "4100000000000001";
             card.expDate = "1215";
             card.type = methodOfPaymentTypeEnum.VI;
@@ -1256,51 +1443,60 @@ namespace Litle.Sdk.Test.Unit
             var mockLitleXmlSerializer = new Mock<litleXmlSerializer>();
 
             mockXmlReader.SetupSequence(XmlReader => XmlReader.ReadOuterXml())
-                .Returns("<updateSubscriptionResponse xmlns=\"http://www.litle.com/schema\"><litleTxnId>54321</litleTxnId><response>000</response><message>Approved</message><responseTime>2013-09-04T21:55:14</responseTime><subscriptionId>12345</subscriptionId></updateSubscriptionResponse>")
-                .Returns("<updateSubscriptionResponse xmlns=\"http://www.litle.com/schema\"><litleTxnId>12345</litleTxnId><response>000</response><message>Approved</message><responseTime>2013-09-04T21:55:14</responseTime><subscriptionId>54321</subscriptionId></updateSubscriptionResponse>");
+                .Returns(
+                    "<updateSubscriptionResponse xmlns=\"http://www.litle.com/schema\"><litleTxnId>54321</litleTxnId><response>000</response><message>Approved</message><responseTime>2013-09-04T21:55:14</responseTime><subscriptionId>12345</subscriptionId></updateSubscriptionResponse>")
+                .Returns(
+                    "<updateSubscriptionResponse xmlns=\"http://www.litle.com/schema\"><litleTxnId>12345</litleTxnId><response>000</response><message>Approved</message><responseTime>2013-09-04T21:55:14</responseTime><subscriptionId>54321</subscriptionId></updateSubscriptionResponse>");
 
-            batchResponse mockLitleBatchResponse = new batchResponse();
+            var mockLitleBatchResponse = new batchResponse();
             mockLitleBatchResponse.setUpdateSubscriptionResponseReader(mockXmlReader.Object);
 
             mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse()).Returns(mockLitleBatchResponse);
-            litleResponse mockedLitleResponse = mockLitleResponse.Object;
+            var mockedLitleResponse = mockLitleResponse.Object;
 
-            mockLitleXmlSerializer.Setup(litleXmlSerializer => litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<String>())).Returns(mockedLitleResponse);
+            mockLitleXmlSerializer.Setup(
+                litleXmlSerializer =>
+                    litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<string>()))
+                .Returns(mockedLitleResponse);
 
-            Communications mockedCommunication = mockCommunications.Object;
+            var mockedCommunication = mockCommunications.Object;
             litle.setCommunication(mockedCommunication);
 
-            litleXmlSerializer mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
+            var mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
             litle.setLitleXmlSerializer(mockedLitleXmlSerializer);
 
-            litleFile mockedLitleFile = mockLitleFile.Object;
+            var mockedLitleFile = mockLitleFile.Object;
             litle.setLitleFile(mockedLitleFile);
 
             litle.setLitleTime(mockLitleTime.Object);
 
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
             litleBatchRequest.setLitleFile(mockedLitleFile);
             litleBatchRequest.setLitleTime(mockLitleTime.Object);
             litleBatchRequest.addUpdateSubscription(update);
             litle.addBatch(litleBatchRequest);
 
-            string batchFileName = litle.sendToLitle();
-            litleResponse actualLitleResponse = litle.receiveFromLitle(batchFileName);
-            batchResponse actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
+            var batchFileName = litle.sendToLitle();
+            var actualLitleResponse = litle.receiveFromLitle(batchFileName);
+            var actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
 
             Assert.AreSame(mockLitleBatchResponse, actualLitleBatchResponse);
             Assert.AreEqual("12345", actualLitleBatchResponse.nextUpdateSubscriptionResponse().subscriptionId);
             Assert.AreEqual("54321", actualLitleBatchResponse.nextUpdateSubscriptionResponse().subscriptionId);
             Assert.IsNull(actualLitleBatchResponse.nextUpdateSubscriptionResponse());
 
-            mockCommunications.Verify(Communications => Communications.FtpDropOff(It.IsAny<String>(), mockFileName, It.IsAny<Dictionary<String, String>>()));
-            mockCommunications.Verify(Communications => Communications.FtpPickUp(It.IsAny<String>(), It.IsAny<Dictionary<String, String>>(), mockFileName));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpDropOff(It.IsAny<string>(), mockFileName, It.IsAny<Dictionary<string, string>>()));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpPickUp(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), mockFileName));
         }
 
         [Test]
         public void testCreatePlan()
         {
-            createPlan createPlan = new createPlan();
+            var createPlan = new createPlan();
             createPlan.planCode = "thePlanCode";
             createPlan.name = "theName";
             createPlan.intervalType = intervalType.ANNUAL;
@@ -1310,52 +1506,61 @@ namespace Litle.Sdk.Test.Unit
             var mockLitleXmlSerializer = new Mock<litleXmlSerializer>();
 
             mockXmlReader.SetupSequence(XmlReader => XmlReader.ReadOuterXml())
-                .Returns("<createPlanResponse xmlns=\"http://www.litle.com/schema\"><litleTxnId>123</litleTxnId></createPlanResponse>")
-                .Returns("<createPlanResponse xmlns=\"http://www.litle.com/schema\"><litleTxnId>124</litleTxnId></createPlanResponse>");
+                .Returns(
+                    "<createPlanResponse xmlns=\"http://www.litle.com/schema\"><litleTxnId>123</litleTxnId></createPlanResponse>")
+                .Returns(
+                    "<createPlanResponse xmlns=\"http://www.litle.com/schema\"><litleTxnId>124</litleTxnId></createPlanResponse>");
 
-            batchResponse mockLitleBatchResponse = new batchResponse();
+            var mockLitleBatchResponse = new batchResponse();
             mockLitleBatchResponse.setCreatePlanResponseReader(mockXmlReader.Object);
 
             mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse()).Returns(mockLitleBatchResponse);
-            litleResponse mockedLitleResponse = mockLitleResponse.Object;
+            var mockedLitleResponse = mockLitleResponse.Object;
 
-            mockLitleXmlSerializer.Setup(litleXmlSerializer => litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<String>())).Returns(mockedLitleResponse);
+            mockLitleXmlSerializer.Setup(
+                litleXmlSerializer =>
+                    litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<string>()))
+                .Returns(mockedLitleResponse);
 
-            Communications mockedCommunication = mockCommunications.Object;
+            var mockedCommunication = mockCommunications.Object;
             litle.setCommunication(mockedCommunication);
 
-            litleXmlSerializer mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
+            var mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
             litle.setLitleXmlSerializer(mockedLitleXmlSerializer);
 
-            litleFile mockedLitleFile = mockLitleFile.Object;
+            var mockedLitleFile = mockLitleFile.Object;
             litle.setLitleFile(mockedLitleFile);
 
             litle.setLitleTime(mockLitleTime.Object);
 
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
             litleBatchRequest.setLitleFile(mockedLitleFile);
             litleBatchRequest.setLitleTime(mockLitleTime.Object);
             litleBatchRequest.addCreatePlan(createPlan);
             litleBatchRequest.addCreatePlan(createPlan);
             litle.addBatch(litleBatchRequest);
 
-            string batchFileName = litle.sendToLitle();
-            litleResponse actualLitleResponse = litle.receiveFromLitle(batchFileName);
-            batchResponse actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
+            var batchFileName = litle.sendToLitle();
+            var actualLitleResponse = litle.receiveFromLitle(batchFileName);
+            var actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
 
             Assert.AreSame(mockLitleBatchResponse, actualLitleBatchResponse);
             Assert.AreEqual("123", actualLitleBatchResponse.nextCreatePlanResponse().litleTxnId);
             Assert.AreEqual("124", actualLitleBatchResponse.nextCreatePlanResponse().litleTxnId);
             Assert.IsNull(actualLitleBatchResponse.nextCreatePlanResponse());
 
-            mockCommunications.Verify(Communications => Communications.FtpDropOff(It.IsAny<String>(), mockFileName, It.IsAny<Dictionary<String, String>>()));
-            mockCommunications.Verify(Communications => Communications.FtpPickUp(It.IsAny<String>(), It.IsAny<Dictionary<String, String>>(), mockFileName));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpDropOff(It.IsAny<string>(), mockFileName, It.IsAny<Dictionary<string, string>>()));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpPickUp(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), mockFileName));
         }
 
         [Test]
         public void testUpdatePlan()
         {
-            updatePlan updatePlan = new updatePlan();
+            var updatePlan = new updatePlan();
             updatePlan.planCode = "thePlanCode";
             updatePlan.active = true;
 
@@ -1363,52 +1568,61 @@ namespace Litle.Sdk.Test.Unit
             var mockLitleXmlSerializer = new Mock<litleXmlSerializer>();
 
             mockXmlReader.SetupSequence(XmlReader => XmlReader.ReadOuterXml())
-                .Returns("<updatePlanResponse xmlns=\"http://www.litle.com/schema\"><litleTxnId>123</litleTxnId></updatePlanResponse>")
-                .Returns("<updatePlanResponse xmlns=\"http://www.litle.com/schema\"><litleTxnId>124</litleTxnId></updatePlanResponse>");
+                .Returns(
+                    "<updatePlanResponse xmlns=\"http://www.litle.com/schema\"><litleTxnId>123</litleTxnId></updatePlanResponse>")
+                .Returns(
+                    "<updatePlanResponse xmlns=\"http://www.litle.com/schema\"><litleTxnId>124</litleTxnId></updatePlanResponse>");
 
-            batchResponse mockLitleBatchResponse = new batchResponse();
+            var mockLitleBatchResponse = new batchResponse();
             mockLitleBatchResponse.setUpdatePlanResponseReader(mockXmlReader.Object);
 
             mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse()).Returns(mockLitleBatchResponse);
-            litleResponse mockedLitleResponse = mockLitleResponse.Object;
+            var mockedLitleResponse = mockLitleResponse.Object;
 
-            mockLitleXmlSerializer.Setup(litleXmlSerializer => litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<String>())).Returns(mockedLitleResponse);
+            mockLitleXmlSerializer.Setup(
+                litleXmlSerializer =>
+                    litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<string>()))
+                .Returns(mockedLitleResponse);
 
-            Communications mockedCommunication = mockCommunications.Object;
+            var mockedCommunication = mockCommunications.Object;
             litle.setCommunication(mockedCommunication);
 
-            litleXmlSerializer mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
+            var mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
             litle.setLitleXmlSerializer(mockedLitleXmlSerializer);
 
-            litleFile mockedLitleFile = mockLitleFile.Object;
+            var mockedLitleFile = mockLitleFile.Object;
             litle.setLitleFile(mockedLitleFile);
 
             litle.setLitleTime(mockLitleTime.Object);
 
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
             litleBatchRequest.setLitleFile(mockedLitleFile);
             litleBatchRequest.setLitleTime(mockLitleTime.Object);
             litleBatchRequest.addUpdatePlan(updatePlan);
             litleBatchRequest.addUpdatePlan(updatePlan);
             litle.addBatch(litleBatchRequest);
 
-            string batchFileName = litle.sendToLitle();
-            litleResponse actualLitleResponse = litle.receiveFromLitle(batchFileName);
-            batchResponse actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
+            var batchFileName = litle.sendToLitle();
+            var actualLitleResponse = litle.receiveFromLitle(batchFileName);
+            var actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
 
             Assert.AreSame(mockLitleBatchResponse, actualLitleBatchResponse);
             Assert.AreEqual("123", actualLitleBatchResponse.nextUpdatePlanResponse().litleTxnId);
             Assert.AreEqual("124", actualLitleBatchResponse.nextUpdatePlanResponse().litleTxnId);
             Assert.IsNull(actualLitleBatchResponse.nextUpdatePlanResponse());
 
-            mockCommunications.Verify(Communications => Communications.FtpDropOff(It.IsAny<String>(), mockFileName, It.IsAny<Dictionary<String, String>>()));
-            mockCommunications.Verify(Communications => Communications.FtpPickUp(It.IsAny<String>(), It.IsAny<Dictionary<String, String>>(), mockFileName));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpDropOff(It.IsAny<string>(), mockFileName, It.IsAny<Dictionary<string, string>>()));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpPickUp(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), mockFileName));
         }
 
         [Test]
         public void testActivate()
         {
-            activate activate = new activate();
+            var activate = new activate();
             activate.orderId = "theOrderId";
             activate.orderSource = orderSourceType.ecommerce;
             activate.card = new cardType();
@@ -1417,52 +1631,61 @@ namespace Litle.Sdk.Test.Unit
             var mockLitleXmlSerializer = new Mock<litleXmlSerializer>();
 
             mockXmlReader.SetupSequence(XmlReader => XmlReader.ReadOuterXml())
-                .Returns("<activateResponse xmlns=\"http://www.litle.com/schema\"><litleTxnId>123</litleTxnId></activateResponse>")
-                .Returns("<activateResponse xmlns=\"http://www.litle.com/schema\"><litleTxnId>124</litleTxnId></activateResponse>");
+                .Returns(
+                    "<activateResponse xmlns=\"http://www.litle.com/schema\"><litleTxnId>123</litleTxnId></activateResponse>")
+                .Returns(
+                    "<activateResponse xmlns=\"http://www.litle.com/schema\"><litleTxnId>124</litleTxnId></activateResponse>");
 
-            batchResponse mockLitleBatchResponse = new batchResponse();
+            var mockLitleBatchResponse = new batchResponse();
             mockLitleBatchResponse.setActivateResponseReader(mockXmlReader.Object);
 
             mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse()).Returns(mockLitleBatchResponse);
-            litleResponse mockedLitleResponse = mockLitleResponse.Object;
+            var mockedLitleResponse = mockLitleResponse.Object;
 
-            mockLitleXmlSerializer.Setup(litleXmlSerializer => litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<String>())).Returns(mockedLitleResponse);
+            mockLitleXmlSerializer.Setup(
+                litleXmlSerializer =>
+                    litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<string>()))
+                .Returns(mockedLitleResponse);
 
-            Communications mockedCommunication = mockCommunications.Object;
+            var mockedCommunication = mockCommunications.Object;
             litle.setCommunication(mockedCommunication);
 
-            litleXmlSerializer mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
+            var mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
             litle.setLitleXmlSerializer(mockedLitleXmlSerializer);
 
-            litleFile mockedLitleFile = mockLitleFile.Object;
+            var mockedLitleFile = mockLitleFile.Object;
             litle.setLitleFile(mockedLitleFile);
 
             litle.setLitleTime(mockLitleTime.Object);
 
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
             litleBatchRequest.setLitleFile(mockedLitleFile);
             litleBatchRequest.setLitleTime(mockLitleTime.Object);
             litleBatchRequest.addActivate(activate);
             litleBatchRequest.addActivate(activate);
             litle.addBatch(litleBatchRequest);
 
-            string batchFileName = litle.sendToLitle();
-            litleResponse actualLitleResponse = litle.receiveFromLitle(batchFileName);
-            batchResponse actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
+            var batchFileName = litle.sendToLitle();
+            var actualLitleResponse = litle.receiveFromLitle(batchFileName);
+            var actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
 
             Assert.AreSame(mockLitleBatchResponse, actualLitleBatchResponse);
             Assert.AreEqual("123", actualLitleBatchResponse.nextActivateResponse().litleTxnId);
             Assert.AreEqual("124", actualLitleBatchResponse.nextActivateResponse().litleTxnId);
             Assert.IsNull(actualLitleBatchResponse.nextActivateResponse());
 
-            mockCommunications.Verify(Communications => Communications.FtpDropOff(It.IsAny<String>(), mockFileName, It.IsAny<Dictionary<String, String>>()));
-            mockCommunications.Verify(Communications => Communications.FtpPickUp(It.IsAny<String>(), It.IsAny<Dictionary<String, String>>(), mockFileName));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpDropOff(It.IsAny<string>(), mockFileName, It.IsAny<Dictionary<string, string>>()));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpPickUp(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), mockFileName));
         }
 
         [Test]
         public void testDeactivate()
         {
-            deactivate deactivate = new deactivate();
+            var deactivate = new deactivate();
             deactivate.orderId = "theOrderId";
             deactivate.orderSource = orderSourceType.ecommerce;
             deactivate.card = new cardType();
@@ -1471,52 +1694,61 @@ namespace Litle.Sdk.Test.Unit
             var mockLitleXmlSerializer = new Mock<litleXmlSerializer>();
 
             mockXmlReader.SetupSequence(XmlReader => XmlReader.ReadOuterXml())
-                .Returns("<deactivateResponse xmlns=\"http://www.litle.com/schema\"><litleTxnId>123</litleTxnId></deactivateResponse>")
-                .Returns("<deactivateResponse xmlns=\"http://www.litle.com/schema\"><litleTxnId>124</litleTxnId></deactivateResponse>");
+                .Returns(
+                    "<deactivateResponse xmlns=\"http://www.litle.com/schema\"><litleTxnId>123</litleTxnId></deactivateResponse>")
+                .Returns(
+                    "<deactivateResponse xmlns=\"http://www.litle.com/schema\"><litleTxnId>124</litleTxnId></deactivateResponse>");
 
-            batchResponse mockLitleBatchResponse = new batchResponse();
+            var mockLitleBatchResponse = new batchResponse();
             mockLitleBatchResponse.setDeactivateResponseReader(mockXmlReader.Object);
 
             mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse()).Returns(mockLitleBatchResponse);
-            litleResponse mockedLitleResponse = mockLitleResponse.Object;
+            var mockedLitleResponse = mockLitleResponse.Object;
 
-            mockLitleXmlSerializer.Setup(litleXmlSerializer => litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<String>())).Returns(mockedLitleResponse);
+            mockLitleXmlSerializer.Setup(
+                litleXmlSerializer =>
+                    litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<string>()))
+                .Returns(mockedLitleResponse);
 
-            Communications mockedCommunication = mockCommunications.Object;
+            var mockedCommunication = mockCommunications.Object;
             litle.setCommunication(mockedCommunication);
 
-            litleXmlSerializer mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
+            var mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
             litle.setLitleXmlSerializer(mockedLitleXmlSerializer);
 
-            litleFile mockedLitleFile = mockLitleFile.Object;
+            var mockedLitleFile = mockLitleFile.Object;
             litle.setLitleFile(mockedLitleFile);
 
             litle.setLitleTime(mockLitleTime.Object);
 
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
             litleBatchRequest.setLitleFile(mockedLitleFile);
             litleBatchRequest.setLitleTime(mockLitleTime.Object);
             litleBatchRequest.addDeactivate(deactivate);
             litleBatchRequest.addDeactivate(deactivate);
             litle.addBatch(litleBatchRequest);
 
-            string batchFileName = litle.sendToLitle();
-            litleResponse actualLitleResponse = litle.receiveFromLitle(batchFileName);
-            batchResponse actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
+            var batchFileName = litle.sendToLitle();
+            var actualLitleResponse = litle.receiveFromLitle(batchFileName);
+            var actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
 
             Assert.AreSame(mockLitleBatchResponse, actualLitleBatchResponse);
             Assert.AreEqual("123", actualLitleBatchResponse.nextDeactivateResponse().litleTxnId);
             Assert.AreEqual("124", actualLitleBatchResponse.nextDeactivateResponse().litleTxnId);
             Assert.IsNull(actualLitleBatchResponse.nextDeactivateResponse());
 
-            mockCommunications.Verify(Communications => Communications.FtpDropOff(It.IsAny<String>(), mockFileName, It.IsAny<Dictionary<String, String>>()));
-            mockCommunications.Verify(Communications => Communications.FtpPickUp(It.IsAny<String>(), It.IsAny<Dictionary<String, String>>(), mockFileName));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpDropOff(It.IsAny<string>(), mockFileName, It.IsAny<Dictionary<string, string>>()));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpPickUp(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), mockFileName));
         }
 
         [Test]
         public void testLoad()
         {
-            load load = new load();
+            var load = new load();
             load.orderId = "theOrderId";
             load.orderSource = orderSourceType.ecommerce;
             load.card = new cardType();
@@ -1525,52 +1757,61 @@ namespace Litle.Sdk.Test.Unit
             var mockLitleXmlSerializer = new Mock<litleXmlSerializer>();
 
             mockXmlReader.SetupSequence(XmlReader => XmlReader.ReadOuterXml())
-                .Returns("<loadResponse xmlns=\"http://www.litle.com/schema\"><litleTxnId>123</litleTxnId></loadResponse>")
-                .Returns("<loadResponse xmlns=\"http://www.litle.com/schema\"><litleTxnId>124</litleTxnId></loadResponse>");
+                .Returns(
+                    "<loadResponse xmlns=\"http://www.litle.com/schema\"><litleTxnId>123</litleTxnId></loadResponse>")
+                .Returns(
+                    "<loadResponse xmlns=\"http://www.litle.com/schema\"><litleTxnId>124</litleTxnId></loadResponse>");
 
-            batchResponse mockLitleBatchResponse = new batchResponse();
+            var mockLitleBatchResponse = new batchResponse();
             mockLitleBatchResponse.setLoadResponseReader(mockXmlReader.Object);
 
             mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse()).Returns(mockLitleBatchResponse);
-            litleResponse mockedLitleResponse = mockLitleResponse.Object;
+            var mockedLitleResponse = mockLitleResponse.Object;
 
-            mockLitleXmlSerializer.Setup(litleXmlSerializer => litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<String>())).Returns(mockedLitleResponse);
+            mockLitleXmlSerializer.Setup(
+                litleXmlSerializer =>
+                    litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<string>()))
+                .Returns(mockedLitleResponse);
 
-            Communications mockedCommunication = mockCommunications.Object;
+            var mockedCommunication = mockCommunications.Object;
             litle.setCommunication(mockedCommunication);
 
-            litleXmlSerializer mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
+            var mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
             litle.setLitleXmlSerializer(mockedLitleXmlSerializer);
 
-            litleFile mockedLitleFile = mockLitleFile.Object;
+            var mockedLitleFile = mockLitleFile.Object;
             litle.setLitleFile(mockedLitleFile);
 
             litle.setLitleTime(mockLitleTime.Object);
 
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
             litleBatchRequest.setLitleFile(mockedLitleFile);
             litleBatchRequest.setLitleTime(mockLitleTime.Object);
             litleBatchRequest.addLoad(load);
             litleBatchRequest.addLoad(load);
             litle.addBatch(litleBatchRequest);
 
-            string batchFileName = litle.sendToLitle();
-            litleResponse actualLitleResponse = litle.receiveFromLitle(batchFileName);
-            batchResponse actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
+            var batchFileName = litle.sendToLitle();
+            var actualLitleResponse = litle.receiveFromLitle(batchFileName);
+            var actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
 
             Assert.AreSame(mockLitleBatchResponse, actualLitleBatchResponse);
             Assert.AreEqual("123", actualLitleBatchResponse.nextLoadResponse().litleTxnId);
             Assert.AreEqual("124", actualLitleBatchResponse.nextLoadResponse().litleTxnId);
             Assert.IsNull(actualLitleBatchResponse.nextLoadResponse());
 
-            mockCommunications.Verify(Communications => Communications.FtpDropOff(It.IsAny<String>(), mockFileName, It.IsAny<Dictionary<String, String>>()));
-            mockCommunications.Verify(Communications => Communications.FtpPickUp(It.IsAny<String>(), It.IsAny<Dictionary<String, String>>(), mockFileName));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpDropOff(It.IsAny<string>(), mockFileName, It.IsAny<Dictionary<string, string>>()));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpPickUp(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), mockFileName));
         }
 
         [Test]
         public void testUnload()
         {
-            unload unload = new unload();
+            var unload = new unload();
             unload.orderId = "theOrderId";
             unload.orderSource = orderSourceType.ecommerce;
             unload.card = new cardType();
@@ -1579,52 +1820,61 @@ namespace Litle.Sdk.Test.Unit
             var mockLitleXmlSerializer = new Mock<litleXmlSerializer>();
 
             mockXmlReader.SetupSequence(XmlReader => XmlReader.ReadOuterXml())
-                .Returns("<unloadResponse xmlns=\"http://www.litle.com/schema\"><litleTxnId>123</litleTxnId></unloadResponse>")
-                .Returns("<unloadResponse xmlns=\"http://www.litle.com/schema\"><litleTxnId>124</litleTxnId></unloadResponse>");
+                .Returns(
+                    "<unloadResponse xmlns=\"http://www.litle.com/schema\"><litleTxnId>123</litleTxnId></unloadResponse>")
+                .Returns(
+                    "<unloadResponse xmlns=\"http://www.litle.com/schema\"><litleTxnId>124</litleTxnId></unloadResponse>");
 
-            batchResponse mockLitleBatchResponse = new batchResponse();
+            var mockLitleBatchResponse = new batchResponse();
             mockLitleBatchResponse.setUnloadResponseReader(mockXmlReader.Object);
 
             mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse()).Returns(mockLitleBatchResponse);
-            litleResponse mockedLitleResponse = mockLitleResponse.Object;
+            var mockedLitleResponse = mockLitleResponse.Object;
 
-            mockLitleXmlSerializer.Setup(litleXmlSerializer => litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<String>())).Returns(mockedLitleResponse);
+            mockLitleXmlSerializer.Setup(
+                litleXmlSerializer =>
+                    litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<string>()))
+                .Returns(mockedLitleResponse);
 
-            Communications mockedCommunication = mockCommunications.Object;
+            var mockedCommunication = mockCommunications.Object;
             litle.setCommunication(mockedCommunication);
 
-            litleXmlSerializer mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
+            var mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
             litle.setLitleXmlSerializer(mockedLitleXmlSerializer);
 
-            litleFile mockedLitleFile = mockLitleFile.Object;
+            var mockedLitleFile = mockLitleFile.Object;
             litle.setLitleFile(mockedLitleFile);
 
             litle.setLitleTime(mockLitleTime.Object);
 
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
             litleBatchRequest.setLitleFile(mockedLitleFile);
             litleBatchRequest.setLitleTime(mockLitleTime.Object);
             litleBatchRequest.addUnload(unload);
             litleBatchRequest.addUnload(unload);
             litle.addBatch(litleBatchRequest);
 
-            string batchFileName = litle.sendToLitle();
-            litleResponse actualLitleResponse = litle.receiveFromLitle(batchFileName);
-            batchResponse actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
+            var batchFileName = litle.sendToLitle();
+            var actualLitleResponse = litle.receiveFromLitle(batchFileName);
+            var actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
 
             Assert.AreSame(mockLitleBatchResponse, actualLitleBatchResponse);
             Assert.AreEqual("123", actualLitleBatchResponse.nextUnloadResponse().litleTxnId);
             Assert.AreEqual("124", actualLitleBatchResponse.nextUnloadResponse().litleTxnId);
             Assert.IsNull(actualLitleBatchResponse.nextUnloadResponse());
 
-            mockCommunications.Verify(Communications => Communications.FtpDropOff(It.IsAny<String>(), mockFileName, It.IsAny<Dictionary<String, String>>()));
-            mockCommunications.Verify(Communications => Communications.FtpPickUp(It.IsAny<String>(), It.IsAny<Dictionary<String, String>>(), mockFileName));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpDropOff(It.IsAny<string>(), mockFileName, It.IsAny<Dictionary<string, string>>()));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpPickUp(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), mockFileName));
         }
 
         [Test]
         public void testBalanceInquiry()
         {
-            balanceInquiry balanceInquiry = new balanceInquiry();
+            var balanceInquiry = new balanceInquiry();
             balanceInquiry.orderId = "theOrderId";
             balanceInquiry.orderSource = orderSourceType.ecommerce;
             balanceInquiry.card = new cardType();
@@ -1633,61 +1883,70 @@ namespace Litle.Sdk.Test.Unit
             var mockLitleXmlSerializer = new Mock<litleXmlSerializer>();
 
             mockXmlReader.SetupSequence(XmlReader => XmlReader.ReadOuterXml())
-                .Returns("<balanceInquiryResponse xmlns=\"http://www.litle.com/schema\"><litleTxnId>123</litleTxnId></balanceInquiryResponse>")
-                .Returns("<balanceInquiryResponse xmlns=\"http://www.litle.com/schema\"><litleTxnId>124</litleTxnId></balanceInquiryResponse>");
+                .Returns(
+                    "<balanceInquiryResponse xmlns=\"http://www.litle.com/schema\"><litleTxnId>123</litleTxnId></balanceInquiryResponse>")
+                .Returns(
+                    "<balanceInquiryResponse xmlns=\"http://www.litle.com/schema\"><litleTxnId>124</litleTxnId></balanceInquiryResponse>");
 
-            batchResponse mockLitleBatchResponse = new batchResponse();
+            var mockLitleBatchResponse = new batchResponse();
             mockLitleBatchResponse.setBalanceInquiryResponseReader(mockXmlReader.Object);
 
             mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse()).Returns(mockLitleBatchResponse);
-            litleResponse mockedLitleResponse = mockLitleResponse.Object;
+            var mockedLitleResponse = mockLitleResponse.Object;
 
-            mockLitleXmlSerializer.Setup(litleXmlSerializer => litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<String>())).Returns(mockedLitleResponse);
+            mockLitleXmlSerializer.Setup(
+                litleXmlSerializer =>
+                    litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<string>()))
+                .Returns(mockedLitleResponse);
 
-            Communications mockedCommunication = mockCommunications.Object;
+            var mockedCommunication = mockCommunications.Object;
             litle.setCommunication(mockedCommunication);
 
-            litleXmlSerializer mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
+            var mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
             litle.setLitleXmlSerializer(mockedLitleXmlSerializer);
 
-            litleFile mockedLitleFile = mockLitleFile.Object;
+            var mockedLitleFile = mockLitleFile.Object;
             litle.setLitleFile(mockedLitleFile);
 
             litle.setLitleTime(mockLitleTime.Object);
 
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
             litleBatchRequest.setLitleFile(mockedLitleFile);
             litleBatchRequest.setLitleTime(mockLitleTime.Object);
             litleBatchRequest.addBalanceInquiry(balanceInquiry);
             litleBatchRequest.addBalanceInquiry(balanceInquiry);
             litle.addBatch(litleBatchRequest);
 
-            string batchFileName = litle.sendToLitle();
-            litleResponse actualLitleResponse = litle.receiveFromLitle(batchFileName);
-            batchResponse actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
+            var batchFileName = litle.sendToLitle();
+            var actualLitleResponse = litle.receiveFromLitle(batchFileName);
+            var actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
 
             Assert.AreSame(mockLitleBatchResponse, actualLitleBatchResponse);
             Assert.AreEqual("123", actualLitleBatchResponse.nextBalanceInquiryResponse().litleTxnId);
             Assert.AreEqual("124", actualLitleBatchResponse.nextBalanceInquiryResponse().litleTxnId);
             Assert.IsNull(actualLitleBatchResponse.nextBalanceInquiryResponse());
 
-            mockCommunications.Verify(Communications => Communications.FtpDropOff(It.IsAny<String>(), mockFileName, It.IsAny<Dictionary<String, String>>()));
-            mockCommunications.Verify(Communications => Communications.FtpPickUp(It.IsAny<String>(), It.IsAny<Dictionary<String, String>>(), mockFileName));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpDropOff(It.IsAny<string>(), mockFileName, It.IsAny<Dictionary<string, string>>()));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpPickUp(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), mockFileName));
         }
 
         [Test]
         public void testEcheckPreNoteSale()
         {
-            echeckPreNoteSale echeckPreNoteSale = new echeckPreNoteSale();
+            var echeckPreNoteSale = new echeckPreNoteSale();
             echeckPreNoteSale.orderId = "12345";
             echeckPreNoteSale.orderSource = orderSourceType.ecommerce;
-            echeckType echeck = new echeckType();
+            var echeck = new echeckType();
             echeck.accType = echeckAccountTypeEnum.Checking;
             echeck.accNum = "12345657890";
             echeck.routingNum = "123456789";
             echeck.checkNum = "123455";
             echeckPreNoteSale.echeck = echeck;
-            contact contact = new contact();
+            var contact = new contact();
             contact.name = "Bob";
             contact.city = "lowell";
             contact.state = "MA";
@@ -1698,63 +1957,73 @@ namespace Litle.Sdk.Test.Unit
             var mockLitleXmlSerializer = new Mock<litleXmlSerializer>();
 
             mockXmlReader.SetupSequence(XmlReader => XmlReader.ReadOuterXml())
-                .Returns("<echeckPreNoteSaleResponse xmlns='http://www.litle.com/schema'><litleTxnId>123</litleTxnId></echeckPreNoteSaleResponse>")
-                .Returns("<echeckPreNoteSaleResponse xmlns='http://www.litle.com/schema'><litleTxnId>124</litleTxnId></echeckPreNoteSaleResponse>");
+                .Returns(
+                    "<echeckPreNoteSaleResponse xmlns='http://www.litle.com/schema'><litleTxnId>123</litleTxnId></echeckPreNoteSaleResponse>")
+                .Returns(
+                    "<echeckPreNoteSaleResponse xmlns='http://www.litle.com/schema'><litleTxnId>124</litleTxnId></echeckPreNoteSaleResponse>");
 
-            batchResponse mockedLitleBatchResponse = new batchResponse();
+            var mockedLitleBatchResponse = new batchResponse();
             mockedLitleBatchResponse.setEcheckPreNoteSaleResponseReader(mockXmlReader.Object);
 
-            mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse()).Returns(mockedLitleBatchResponse);
-            litleResponse mockedLitleResponse = mockLitleResponse.Object;
+            mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse())
+                .Returns(mockedLitleBatchResponse);
+            var mockedLitleResponse = mockLitleResponse.Object;
 
-            Communications mockedCommunications = mockCommunications.Object;
+            var mockedCommunications = mockCommunications.Object;
 
-            mockLitleXmlSerializer.Setup(litleXmlSerializer => litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<String>())).Returns(mockedLitleResponse);
-            litleXmlSerializer mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
+            mockLitleXmlSerializer.Setup(
+                litleXmlSerializer =>
+                    litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<string>()))
+                .Returns(mockedLitleResponse);
+            var mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
 
-            litleFile mockedLitleFile = mockLitleFile.Object;
+            var mockedLitleFile = mockLitleFile.Object;
 
             litle.setCommunication(mockedCommunications);
             litle.setLitleXmlSerializer(mockedLitleXmlSerializer);
             litle.setLitleFile(mockedLitleFile);
             litle.setLitleTime(mockLitleTime.Object);
 
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
             litleBatchRequest.setLitleFile(mockedLitleFile);
             litleBatchRequest.setLitleTime(mockLitleTime.Object);
             litleBatchRequest.addEcheckPreNoteSale(echeckPreNoteSale);
             litleBatchRequest.addEcheckPreNoteSale(echeckPreNoteSale);
             litle.addBatch(litleBatchRequest);
 
-            string batchFileName = litle.sendToLitle();
+            var batchFileName = litle.sendToLitle();
 
-            litleResponse actualLitleResponse = litle.receiveFromLitle(batchFileName);
-            batchResponse actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
-            echeckPreNoteSaleResponse actualEcheckPreNoteSaleResponse1 = actualLitleBatchResponse.nextEcheckPreNoteSaleResponse();
-            echeckPreNoteSaleResponse actualEcheckPreNoteSaleResponse2 = actualLitleBatchResponse.nextEcheckPreNoteSaleResponse();
-            echeckPreNoteSaleResponse nullEcheckPreNoteSalesResponse = actualLitleBatchResponse.nextEcheckPreNoteSaleResponse();
+            var actualLitleResponse = litle.receiveFromLitle(batchFileName);
+            var actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
+            var actualEcheckPreNoteSaleResponse1 = actualLitleBatchResponse.nextEcheckPreNoteSaleResponse();
+            var actualEcheckPreNoteSaleResponse2 = actualLitleBatchResponse.nextEcheckPreNoteSaleResponse();
+            var nullEcheckPreNoteSalesResponse = actualLitleBatchResponse.nextEcheckPreNoteSaleResponse();
 
             Assert.AreEqual(123, actualEcheckPreNoteSaleResponse1.litleTxnId);
             Assert.AreEqual(124, actualEcheckPreNoteSaleResponse2.litleTxnId);
             Assert.IsNull(nullEcheckPreNoteSalesResponse);
 
-            mockCommunications.Verify(Communications => Communications.FtpDropOff(It.IsAny<String>(), mockFileName, It.IsAny<Dictionary<String, String>>()));
-            mockCommunications.Verify(Communications => Communications.FtpPickUp(It.IsAny<String>(), It.IsAny<Dictionary<String, String>>(), mockFileName));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpDropOff(It.IsAny<string>(), mockFileName, It.IsAny<Dictionary<string, string>>()));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpPickUp(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), mockFileName));
         }
 
         [Test]
         public void testEcheckPreNoteCredit()
         {
-            echeckPreNoteCredit echeckPreNoteCredit = new echeckPreNoteCredit();
+            var echeckPreNoteCredit = new echeckPreNoteCredit();
             echeckPreNoteCredit.orderId = "12345";
             echeckPreNoteCredit.orderSource = orderSourceType.ecommerce;
-            echeckType echeck = new echeckType();
+            var echeck = new echeckType();
             echeck.accType = echeckAccountTypeEnum.CorpSavings;
             echeck.accNum = "12345657890";
             echeck.routingNum = "123456789";
             echeck.checkNum = "123455";
             echeckPreNoteCredit.echeck = echeck;
-            contact contact = new contact();
+            var contact = new contact();
             contact.name = "Bob";
             contact.city = "lowell";
             contact.state = "MA";
@@ -1765,48 +2034,58 @@ namespace Litle.Sdk.Test.Unit
             var mockLitleXmlSerializer = new Mock<litleXmlSerializer>();
 
             mockXmlReader.SetupSequence(XmlReader => XmlReader.ReadOuterXml())
-                .Returns("<echeckPreNoteCreditResponse xmlns='http://www.litle.com/schema'><litleTxnId>123</litleTxnId></echeckPreNoteCreditResponse>")
-                .Returns("<echeckPreNoteCreditResponse xmlns='http://www.litle.com/schema'><litleTxnId>124</litleTxnId></echeckPreNoteCreditResponse>");
+                .Returns(
+                    "<echeckPreNoteCreditResponse xmlns='http://www.litle.com/schema'><litleTxnId>123</litleTxnId></echeckPreNoteCreditResponse>")
+                .Returns(
+                    "<echeckPreNoteCreditResponse xmlns='http://www.litle.com/schema'><litleTxnId>124</litleTxnId></echeckPreNoteCreditResponse>");
 
-            batchResponse mockedLitleBatchResponse = new batchResponse();
+            var mockedLitleBatchResponse = new batchResponse();
             mockedLitleBatchResponse.setEcheckPreNoteCreditResponseReader(mockXmlReader.Object);
 
-            mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse()).Returns(mockedLitleBatchResponse);
-            litleResponse mockedLitleResponse = mockLitleResponse.Object;
+            mockLitleResponse.Setup(litleResponse => litleResponse.nextBatchResponse())
+                .Returns(mockedLitleBatchResponse);
+            var mockedLitleResponse = mockLitleResponse.Object;
 
-            Communications mockedCommunications = mockCommunications.Object;
+            var mockedCommunications = mockCommunications.Object;
 
-            mockLitleXmlSerializer.Setup(litleXmlSerializer => litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<String>())).Returns(mockedLitleResponse);
-            litleXmlSerializer mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
+            mockLitleXmlSerializer.Setup(
+                litleXmlSerializer =>
+                    litleXmlSerializer.DeserializeObjectFromFile(mockCommunications.Object, It.IsAny<string>()))
+                .Returns(mockedLitleResponse);
+            var mockedLitleXmlSerializer = mockLitleXmlSerializer.Object;
 
-            litleFile mockedLitleFile = mockLitleFile.Object;
+            var mockedLitleFile = mockLitleFile.Object;
 
             litle.setCommunication(mockedCommunications);
             litle.setLitleXmlSerializer(mockedLitleXmlSerializer);
             litle.setLitleFile(mockedLitleFile);
             litle.setLitleTime(mockLitleTime.Object);
 
-            batchRequest litleBatchRequest = new batchRequest(memoryStreams);
+            var litleBatchRequest = new batchRequest(memoryStreams);
             litleBatchRequest.setLitleFile(mockedLitleFile);
             litleBatchRequest.setLitleTime(mockLitleTime.Object);
             litleBatchRequest.addEcheckPreNoteCredit(echeckPreNoteCredit);
             litleBatchRequest.addEcheckPreNoteCredit(echeckPreNoteCredit);
             litle.addBatch(litleBatchRequest);
 
-            string batchFileName = litle.sendToLitle();
+            var batchFileName = litle.sendToLitle();
 
-            litleResponse actualLitleResponse = litle.receiveFromLitle(batchFileName);
-            batchResponse actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
-            echeckPreNoteCreditResponse actualEcheckPreNoteCreditResponse1 = actualLitleBatchResponse.nextEcheckPreNoteCreditResponse();
-            echeckPreNoteCreditResponse actualEcheckPreNoteCreditResponse2 = actualLitleBatchResponse.nextEcheckPreNoteCreditResponse();
-            echeckPreNoteCreditResponse nullEcheckPreNoteCreditsResponse = actualLitleBatchResponse.nextEcheckPreNoteCreditResponse();
+            var actualLitleResponse = litle.receiveFromLitle(batchFileName);
+            var actualLitleBatchResponse = actualLitleResponse.nextBatchResponse();
+            var actualEcheckPreNoteCreditResponse1 = actualLitleBatchResponse.nextEcheckPreNoteCreditResponse();
+            var actualEcheckPreNoteCreditResponse2 = actualLitleBatchResponse.nextEcheckPreNoteCreditResponse();
+            var nullEcheckPreNoteCreditsResponse = actualLitleBatchResponse.nextEcheckPreNoteCreditResponse();
 
             Assert.AreEqual(123, actualEcheckPreNoteCreditResponse1.litleTxnId);
             Assert.AreEqual(124, actualEcheckPreNoteCreditResponse2.litleTxnId);
             Assert.IsNull(nullEcheckPreNoteCreditsResponse);
 
-            mockCommunications.Verify(Communications => Communications.FtpDropOff(It.IsAny<String>(), mockFileName, It.IsAny<Dictionary<String, String>>()));
-            mockCommunications.Verify(Communications => Communications.FtpPickUp(It.IsAny<String>(), It.IsAny<Dictionary<String, String>>(), mockFileName));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpDropOff(It.IsAny<string>(), mockFileName, It.IsAny<Dictionary<string, string>>()));
+            mockCommunications.Verify(
+                Communications =>
+                    Communications.FtpPickUp(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), mockFileName));
         }
     }
 }

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestBatchRequest.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestBatchRequest.cs
@@ -1,18 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Text;
-using NUnit.Framework;
-using Litle.Sdk;
 using Moq;
-using System.Text.RegularExpressions;
-using Moq.Language.Flow;
-
+using NUnit.Framework;
 
 namespace Litle.Sdk.Test.Unit
 {
     [TestFixture]
-    class TestBatchRequest
+    internal class TestBatchRequest
     {
         private batchRequest batchRequest;
         private const string timeFormat = "MM-dd-yyyy_HH-mm-ss-ffff_";
@@ -28,13 +23,16 @@ namespace Litle.Sdk.Test.Unit
         [TestFixtureSetUp]
         public void setUp()
         {
-
             memoryStreams = new Dictionary<string, StringBuilder>();
             mockLitleFile = new Mock<litleFile>(new Dictionary<string, StringBuilder>());
             mockLitleTime = new Mock<litleTime>();
 
-            mockLitleFile.Setup(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object)).Returns(mockFilePath);
-            mockLitleFile.Setup(litleFile => litleFile.AppendLineToFile(mockFilePath, It.IsAny<String>())).Returns(mockFilePath);
+            mockLitleFile.Setup(
+                litleFile =>
+                    litleFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        mockLitleTime.Object)).Returns(mockFilePath);
+            mockLitleFile.Setup(litleFile => litleFile.AppendLineToFile(mockFilePath, It.IsAny<string>()))
+                .Returns(mockFilePath);
         }
 
         [SetUp]
@@ -48,7 +46,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void testBatchRequestContainsMerchantSdkAttribute()
         {
-            Dictionary<String, String> mockConfig = new Dictionary<string, string>();
+            var mockConfig = new Dictionary<string, string>();
 
             mockConfig["merchantId"] = "01234";
             mockConfig["requestDirectory"] = "C:\\MockRequests";
@@ -56,8 +54,8 @@ namespace Litle.Sdk.Test.Unit
 
             batchRequest = new batchRequest(memoryStreams, mockConfig);
 
-            String actual = batchRequest.generateXmlHeader();
-            String expected = @"
+            var actual = batchRequest.generateXmlHeader();
+            var expected = @"
 <batchRequest id=""""
 merchantSdk=""DotNet;9.3.2""
 merchantId=""01234"">
@@ -68,7 +66,7 @@ merchantId=""01234"">
         [Test]
         public void testInitialization()
         {
-            Dictionary<String, String> mockConfig = new Dictionary<string, string>();
+            var mockConfig = new Dictionary<string, string>();
 
             mockConfig["url"] = "https://www.mockurl.com";
             mockConfig["reportGroup"] = "Mock Report Group";
@@ -100,12 +98,12 @@ merchantId=""01234"">
         [Test]
         public void testAddAuthorization()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.reportGroup = "Planets";
             authorization.orderId = "12344";
             authorization.amount = 106;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000002";
             card.expDate = "1210";
@@ -116,17 +114,20 @@ merchantId=""01234"">
             Assert.AreEqual(1, batchRequest.getNumAuthorization());
             Assert.AreEqual(authorization.amount, batchRequest.getSumOfAuthorization());
 
-            mockLitleFile.Verify(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object));
+            mockLitleFile.Verify(
+                litleFile =>
+                    litleFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        mockLitleTime.Object));
             mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, authorization.Serialize()));
         }
 
         [Test]
         public void testAddAccountUpdate()
         {
-            accountUpdate accountUpdate = new accountUpdate();
+            var accountUpdate = new accountUpdate();
             accountUpdate.reportGroup = "Planets";
             accountUpdate.orderId = "12344";
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000002";
             card.expDate = "1210";
@@ -136,14 +137,17 @@ merchantId=""01234"">
 
             Assert.AreEqual(1, batchRequest.getNumAccountUpdates());
 
-            mockLitleFile.Verify(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object));
+            mockLitleFile.Verify(
+                litleFile =>
+                    litleFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        mockLitleTime.Object));
             mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, accountUpdate.Serialize()));
         }
 
         [Test]
         public void testAuthReversal()
         {
-            authReversal authreversal = new authReversal();
+            var authreversal = new authReversal();
             authreversal.litleTxnId = 12345678000;
             authreversal.amount = 106;
             authreversal.payPalNotes = "Notes";
@@ -153,14 +157,17 @@ merchantId=""01234"">
             Assert.AreEqual(1, batchRequest.getNumAuthReversal());
             Assert.AreEqual(authreversal.amount, batchRequest.getSumOfAuthReversal());
 
-            mockLitleFile.Verify(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object));
+            mockLitleFile.Verify(
+                litleFile =>
+                    litleFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        mockLitleTime.Object));
             mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, authreversal.Serialize()));
         }
 
         [Test]
         public void testCapture()
         {
-            capture capture = new capture();
+            var capture = new capture();
             capture.litleTxnId = 12345678000;
             capture.amount = 106;
 
@@ -169,23 +176,26 @@ merchantId=""01234"">
             Assert.AreEqual(1, batchRequest.getNumCapture());
             Assert.AreEqual(capture.amount, batchRequest.getSumOfCapture());
 
-            mockLitleFile.Verify(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object));
+            mockLitleFile.Verify(
+                litleFile =>
+                    litleFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        mockLitleTime.Object));
             mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, capture.Serialize()));
         }
 
         [Test]
         public void testCaptureGivenAuth()
         {
-            captureGivenAuth capturegivenauth = new captureGivenAuth();
+            var capturegivenauth = new captureGivenAuth();
             capturegivenauth.orderId = "12344";
             capturegivenauth.amount = 106;
-            authInformation authinfo = new authInformation();
+            var authinfo = new authInformation();
             authinfo.authDate = new DateTime(2002, 10, 9);
             authinfo.authCode = "543216";
             authinfo.authAmount = 12345;
             capturegivenauth.authInformation = authinfo;
             capturegivenauth.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000001";
             card.expDate = "1210";
@@ -196,18 +206,21 @@ merchantId=""01234"">
             Assert.AreEqual(1, batchRequest.getNumCaptureGivenAuth());
             Assert.AreEqual(capturegivenauth.amount, batchRequest.getSumOfCaptureGivenAuth());
 
-            mockLitleFile.Verify(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object));
+            mockLitleFile.Verify(
+                litleFile =>
+                    litleFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        mockLitleTime.Object));
             mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, capturegivenauth.Serialize()));
         }
 
         [Test]
         public void testCredit()
         {
-            credit credit = new credit();
+            var credit = new credit();
             credit.orderId = "12344";
             credit.amount = 106;
             credit.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000001";
             card.expDate = "1210";
@@ -218,14 +231,17 @@ merchantId=""01234"">
             Assert.AreEqual(1, batchRequest.getNumCredit());
             Assert.AreEqual(credit.amount, batchRequest.getSumOfCredit());
 
-            mockLitleFile.Verify(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object));
+            mockLitleFile.Verify(
+                litleFile =>
+                    litleFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        mockLitleTime.Object));
             mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, credit.Serialize()));
         }
 
         [Test]
         public void testEcheckCredit()
         {
-            echeckCredit echeckcredit = new echeckCredit();
+            var echeckcredit = new echeckCredit();
             echeckcredit.amount = 12;
             echeckcredit.litleTxnId = 123456789101112;
 
@@ -234,38 +250,44 @@ merchantId=""01234"">
             Assert.AreEqual(1, batchRequest.getNumEcheckCredit());
             Assert.AreEqual(echeckcredit.amount, batchRequest.getSumOfEcheckCredit());
 
-            mockLitleFile.Verify(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object));
+            mockLitleFile.Verify(
+                litleFile =>
+                    litleFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        mockLitleTime.Object));
             mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, echeckcredit.Serialize()));
         }
 
         [Test]
         public void testEcheckRedeposit()
         {
-            echeckRedeposit echeckredeposit = new echeckRedeposit();
+            var echeckredeposit = new echeckRedeposit();
             echeckredeposit.litleTxnId = 123456;
 
             batchRequest.addEcheckRedeposit(echeckredeposit);
 
             Assert.AreEqual(1, batchRequest.getNumEcheckRedeposit());
 
-            mockLitleFile.Verify(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object));
+            mockLitleFile.Verify(
+                litleFile =>
+                    litleFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        mockLitleTime.Object));
             mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, echeckredeposit.Serialize()));
         }
 
         [Test]
         public void testEcheckSale()
         {
-            echeckSale echecksale = new echeckSale();
+            var echecksale = new echeckSale();
             echecksale.orderId = "12345";
             echecksale.amount = 123456;
             echecksale.orderSource = orderSourceType.ecommerce;
-            echeckType echeck = new echeckType();
+            var echeck = new echeckType();
             echeck.accType = echeckAccountTypeEnum.Checking;
             echeck.accNum = "12345657890";
             echeck.routingNum = "123456789";
             echeck.checkNum = "123455";
             echecksale.echeck = echeck;
-            contact contact = new contact();
+            var contact = new contact();
             contact.name = "Bob";
             contact.city = "lowell";
             contact.state = "MA";
@@ -277,24 +299,27 @@ merchantId=""01234"">
             Assert.AreEqual(1, batchRequest.getNumEcheckSale());
             Assert.AreEqual(echecksale.amount, batchRequest.getSumOfEcheckSale());
 
-            mockLitleFile.Verify(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object));
+            mockLitleFile.Verify(
+                litleFile =>
+                    litleFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        mockLitleTime.Object));
             mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, echecksale.Serialize()));
         }
 
         [Test]
         public void testEcheckVerification()
         {
-            echeckVerification echeckverification = new echeckVerification();
+            var echeckverification = new echeckVerification();
             echeckverification.orderId = "12345";
             echeckverification.amount = 123456;
             echeckverification.orderSource = orderSourceType.ecommerce;
-            echeckType echeck = new echeckType();
+            var echeck = new echeckType();
             echeck.accType = echeckAccountTypeEnum.Checking;
             echeck.accNum = "12345657890";
             echeck.routingNum = "123456789";
             echeck.checkNum = "123455";
             echeckverification.echeck = echeck;
-            contact contact = new contact();
+            var contact = new contact();
             contact.name = "Bob";
             contact.city = "lowell";
             contact.state = "MA";
@@ -306,18 +331,21 @@ merchantId=""01234"">
             Assert.AreEqual(1, batchRequest.getNumEcheckVerification());
             Assert.AreEqual(echeckverification.amount, batchRequest.getSumOfEcheckVerification());
 
-            mockLitleFile.Verify(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object));
+            mockLitleFile.Verify(
+                litleFile =>
+                    litleFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        mockLitleTime.Object));
             mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, echeckverification.Serialize()));
         }
 
         [Test]
         public void testForceCapture()
         {
-            forceCapture forcecapture = new forceCapture();
+            var forcecapture = new forceCapture();
             forcecapture.orderId = "12344";
             forcecapture.amount = 106;
             forcecapture.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000001";
             card.expDate = "1210";
@@ -328,18 +356,21 @@ merchantId=""01234"">
             Assert.AreEqual(1, batchRequest.getNumForceCapture());
             Assert.AreEqual(forcecapture.amount, batchRequest.getSumOfForceCapture());
 
-            mockLitleFile.Verify(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object));
+            mockLitleFile.Verify(
+                litleFile =>
+                    litleFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        mockLitleTime.Object));
             mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, forcecapture.Serialize()));
         }
 
         [Test]
         public void testSale()
         {
-            sale sale = new sale();
+            var sale = new sale();
             sale.orderId = "12344";
             sale.amount = 106;
             sale.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000002";
             card.expDate = "1210";
@@ -350,14 +381,17 @@ merchantId=""01234"">
             Assert.AreEqual(1, batchRequest.getNumSale());
             Assert.AreEqual(sale.amount, batchRequest.getSumOfSale());
 
-            mockLitleFile.Verify(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object));
+            mockLitleFile.Verify(
+                litleFile =>
+                    litleFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        mockLitleTime.Object));
             mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, sale.Serialize()));
         }
 
         [Test]
         public void testToken()
         {
-            registerTokenRequestType token = new registerTokenRequestType();
+            var token = new registerTokenRequestType();
             token.orderId = "12344";
             token.accountNumber = "1233456789103801";
 
@@ -365,14 +399,17 @@ merchantId=""01234"">
 
             Assert.AreEqual(1, batchRequest.getNumRegisterTokenRequest());
 
-            mockLitleFile.Verify(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object));
+            mockLitleFile.Verify(
+                litleFile =>
+                    litleFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        mockLitleTime.Object));
             mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, token.Serialize()));
         }
 
         [Test]
         public void testUpdateCardValidationNumOnToken()
         {
-            updateCardValidationNumOnToken updateCardValidationNumOnToken = new updateCardValidationNumOnToken();
+            var updateCardValidationNumOnToken = new updateCardValidationNumOnToken();
             updateCardValidationNumOnToken.orderId = "12344";
             updateCardValidationNumOnToken.litleToken = "123";
 
@@ -380,22 +417,26 @@ merchantId=""01234"">
 
             Assert.AreEqual(1, batchRequest.getNumUpdateCardValidationNumOnToken());
 
-            mockLitleFile.Verify(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object));
-            mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, updateCardValidationNumOnToken.Serialize()));
+            mockLitleFile.Verify(
+                litleFile =>
+                    litleFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        mockLitleTime.Object));
+            mockLitleFile.Verify(
+                litleFile => litleFile.AppendLineToFile(mockFilePath, updateCardValidationNumOnToken.Serialize()));
         }
 
         [Test]
         public void testUpdateSubscription()
         {
-            updateSubscription update = new updateSubscription();
+            var update = new updateSubscription();
             update.billingDate = new DateTime(2002, 10, 9);
-            contact billToAddress = new contact();
+            var billToAddress = new contact();
             billToAddress.name = "Greg Dake";
             billToAddress.city = "Lowell";
             billToAddress.state = "MA";
             billToAddress.email = "sdksupport@litle.com";
             update.billToAddress = billToAddress;
-            cardType card = new cardType();
+            var card = new cardType();
             card.number = "4100000000000001";
             card.expDate = "1215";
             card.type = methodOfPaymentTypeEnum.VI;
@@ -407,40 +448,49 @@ merchantId=""01234"">
 
             Assert.AreEqual(1, batchRequest.getNumUpdateSubscriptions());
 
-            mockLitleFile.Verify(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object));
+            mockLitleFile.Verify(
+                litleFile =>
+                    litleFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        mockLitleTime.Object));
             mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, update.Serialize()));
         }
 
         [Test]
         public void testCreatePlan()
         {
-            createPlan createPlan = new createPlan();
+            var createPlan = new createPlan();
 
             batchRequest.addCreatePlan(createPlan);
 
             Assert.AreEqual(1, batchRequest.getNumCreatePlans());
 
-            mockLitleFile.Verify(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object));
+            mockLitleFile.Verify(
+                litleFile =>
+                    litleFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        mockLitleTime.Object));
             mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, createPlan.Serialize()));
         }
 
         [Test]
         public void testUpdatePlan()
         {
-            updatePlan updatePlan = new updatePlan();
+            var updatePlan = new updatePlan();
 
             batchRequest.addUpdatePlan(updatePlan);
 
             Assert.AreEqual(1, batchRequest.getNumUpdatePlans());
 
-            mockLitleFile.Verify(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object));
+            mockLitleFile.Verify(
+                litleFile =>
+                    litleFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        mockLitleTime.Object));
             mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, updatePlan.Serialize()));
         }
 
         [Test]
         public void testActivate()
         {
-            activate activate = new activate();
+            var activate = new activate();
             activate.amount = 500;
             activate.orderSource = orderSourceType.ecommerce;
             activate.card = new cardType();
@@ -450,14 +500,17 @@ merchantId=""01234"">
             Assert.AreEqual(1, batchRequest.getNumActivates());
             Assert.AreEqual(500, batchRequest.getActivateAmount());
 
-            mockLitleFile.Verify(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object));
+            mockLitleFile.Verify(
+                litleFile =>
+                    litleFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        mockLitleTime.Object));
             mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, activate.Serialize()));
         }
 
         [Test]
         public void testDeactivate()
         {
-            deactivate deactivate = new deactivate();
+            var deactivate = new deactivate();
             deactivate.orderSource = orderSourceType.ecommerce;
             deactivate.card = new cardType();
 
@@ -465,14 +518,17 @@ merchantId=""01234"">
 
             Assert.AreEqual(1, batchRequest.getNumDeactivates());
 
-            mockLitleFile.Verify(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object));
+            mockLitleFile.Verify(
+                litleFile =>
+                    litleFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        mockLitleTime.Object));
             mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, deactivate.Serialize()));
         }
 
         [Test]
         public void testLoad()
         {
-            load load = new load();
+            var load = new load();
             load.amount = 600;
             load.orderSource = orderSourceType.ecommerce;
             load.card = new cardType();
@@ -482,14 +538,17 @@ merchantId=""01234"">
             Assert.AreEqual(1, batchRequest.getNumLoads());
             Assert.AreEqual(600, batchRequest.getLoadAmount());
 
-            mockLitleFile.Verify(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object));
+            mockLitleFile.Verify(
+                litleFile =>
+                    litleFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        mockLitleTime.Object));
             mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, load.Serialize()));
         }
 
         [Test]
         public void testUnload()
         {
-            unload unload = new unload();
+            var unload = new unload();
             unload.amount = 700;
             unload.orderSource = orderSourceType.ecommerce;
             unload.card = new cardType();
@@ -499,14 +558,17 @@ merchantId=""01234"">
             Assert.AreEqual(1, batchRequest.getNumUnloads());
             Assert.AreEqual(700, batchRequest.getUnloadAmount());
 
-            mockLitleFile.Verify(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object));
+            mockLitleFile.Verify(
+                litleFile =>
+                    litleFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        mockLitleTime.Object));
             mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, unload.Serialize()));
         }
 
         [Test]
         public void testBalanceInquiry()
         {
-            balanceInquiry balanceInquiry = new balanceInquiry();
+            var balanceInquiry = new balanceInquiry();
             balanceInquiry.orderSource = orderSourceType.ecommerce;
             balanceInquiry.card = new cardType();
 
@@ -514,37 +576,43 @@ merchantId=""01234"">
 
             Assert.AreEqual(1, batchRequest.getNumBalanceInquiries());
 
-            mockLitleFile.Verify(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object));
+            mockLitleFile.Verify(
+                litleFile =>
+                    litleFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        mockLitleTime.Object));
             mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, balanceInquiry.Serialize()));
         }
 
         [Test]
         public void testCancelSubscription()
         {
-            cancelSubscription cancel = new cancelSubscription();
+            var cancel = new cancelSubscription();
             cancel.subscriptionId = 12345;
 
             batchRequest.addCancelSubscription(cancel);
 
             Assert.AreEqual(1, batchRequest.getNumCancelSubscriptions());
 
-            mockLitleFile.Verify(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object));
+            mockLitleFile.Verify(
+                litleFile =>
+                    litleFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        mockLitleTime.Object));
             mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, cancel.Serialize()));
         }
 
         [Test]
         public void testAddEcheckPreNoteSale()
         {
-            echeckPreNoteSale echeckPreNoteSale = new echeckPreNoteSale();
+            var echeckPreNoteSale = new echeckPreNoteSale();
             echeckPreNoteSale.orderId = "12345";
             echeckPreNoteSale.orderSource = orderSourceType.ecommerce;
-            echeckType echeck = new echeckType();
+            var echeck = new echeckType();
             echeck.accType = echeckAccountTypeEnum.Checking;
             echeck.accNum = "12345657890";
             echeck.routingNum = "123456789";
             echeck.checkNum = "123455";
             echeckPreNoteSale.echeck = echeck;
-            contact contact = new contact();
+            var contact = new contact();
             contact.name = "Bob";
             contact.city = "lowell";
             contact.state = "MA";
@@ -555,23 +623,26 @@ merchantId=""01234"">
 
             Assert.AreEqual(1, batchRequest.getNumEcheckPreNoteSale());
 
-            mockLitleFile.Verify(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object));
+            mockLitleFile.Verify(
+                litleFile =>
+                    litleFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        mockLitleTime.Object));
             mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, echeckPreNoteSale.Serialize()));
         }
 
         [Test]
         public void testAddEcheckPreNoteCredit()
         {
-            echeckPreNoteCredit echeckPreNoteCredit = new echeckPreNoteCredit();
+            var echeckPreNoteCredit = new echeckPreNoteCredit();
             echeckPreNoteCredit.orderId = "12345";
             echeckPreNoteCredit.orderSource = orderSourceType.ecommerce;
-            echeckType echeck = new echeckType();
+            var echeck = new echeckType();
             echeck.accType = echeckAccountTypeEnum.Checking;
             echeck.accNum = "12345657890";
             echeck.routingNum = "123456789";
             echeck.checkNum = "123455";
             echeckPreNoteCredit.echeck = echeck;
-            contact contact = new contact();
+            var contact = new contact();
             contact.name = "Bob";
             contact.city = "lowell";
             contact.state = "MA";
@@ -582,19 +653,22 @@ merchantId=""01234"">
 
             Assert.AreEqual(1, batchRequest.getNumEcheckPreNoteCredit());
 
-            mockLitleFile.Verify(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object));
+            mockLitleFile.Verify(
+                litleFile =>
+                    litleFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        mockLitleTime.Object));
             mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, echeckPreNoteCredit.Serialize()));
         }
 
         [Test]
         public void testAddSubmerchantCredit()
         {
-            submerchantCredit submerchantCredit = new submerchantCredit();
+            var submerchantCredit = new submerchantCredit();
             submerchantCredit.fundingSubmerchantId = "123456";
             submerchantCredit.submerchantName = "merchant";
             submerchantCredit.fundsTransferId = "123467";
             submerchantCredit.amount = 106L;
-            echeckType echeck = new echeckType();
+            var echeck = new echeckType();
             echeck.accType = echeckAccountTypeEnum.Checking;
             echeck.accNum = "12345657890";
             echeck.routingNum = "123456789";
@@ -606,14 +680,17 @@ merchantId=""01234"">
             Assert.AreEqual(1, batchRequest.getNumSubmerchantCredit());
             Assert.AreEqual(106L, batchRequest.getSubmerchantCreditAmount());
 
-            mockLitleFile.Verify(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object));
+            mockLitleFile.Verify(
+                litleFile =>
+                    litleFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        mockLitleTime.Object));
             mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, submerchantCredit.Serialize()));
         }
 
         [Test]
         public void testAddPayFacCredit()
         {
-            payFacCredit payFacCredit = new payFacCredit();
+            var payFacCredit = new payFacCredit();
             payFacCredit.fundingSubmerchantId = "123456";
             payFacCredit.fundsTransferId = "123467";
             payFacCredit.amount = 107L;
@@ -623,14 +700,17 @@ merchantId=""01234"">
             Assert.AreEqual(1, batchRequest.getNumPayFacCredit());
             Assert.AreEqual(107L, batchRequest.getPayFacCreditAmount());
 
-            mockLitleFile.Verify(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object));
+            mockLitleFile.Verify(
+                litleFile =>
+                    litleFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        mockLitleTime.Object));
             mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, payFacCredit.Serialize()));
         }
 
         [Test]
         public void testAddReserveCredit()
         {
-            reserveCredit reserveCredit = new reserveCredit();
+            var reserveCredit = new reserveCredit();
             reserveCredit.fundingSubmerchantId = "123456";
             reserveCredit.fundsTransferId = "123467";
             reserveCredit.amount = 107L;
@@ -640,19 +720,22 @@ merchantId=""01234"">
             Assert.AreEqual(1, batchRequest.getNumReserveCredit());
             Assert.AreEqual(107L, batchRequest.getReserveCreditAmount());
 
-            mockLitleFile.Verify(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object));
+            mockLitleFile.Verify(
+                litleFile =>
+                    litleFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        mockLitleTime.Object));
             mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, reserveCredit.Serialize()));
         }
 
         [Test]
         public void testAddVendorCredit()
         {
-            vendorCredit vendorCredit = new vendorCredit();
+            var vendorCredit = new vendorCredit();
             vendorCredit.fundingSubmerchantId = "123456";
             vendorCredit.vendorName = "merchant";
             vendorCredit.fundsTransferId = "123467";
             vendorCredit.amount = 106L;
-            echeckType echeck = new echeckType();
+            var echeck = new echeckType();
             echeck.accType = echeckAccountTypeEnum.Checking;
             echeck.accNum = "12345657890";
             echeck.routingNum = "123456789";
@@ -664,14 +747,17 @@ merchantId=""01234"">
             Assert.AreEqual(1, batchRequest.getNumVendorCredit());
             Assert.AreEqual(106L, batchRequest.getVendorCreditAmount());
 
-            mockLitleFile.Verify(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object));
+            mockLitleFile.Verify(
+                litleFile =>
+                    litleFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        mockLitleTime.Object));
             mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, vendorCredit.Serialize()));
         }
 
         [Test]
         public void testAddPhysicalCheckCredit()
         {
-            physicalCheckCredit physicalCheckCredit = new physicalCheckCredit();
+            var physicalCheckCredit = new physicalCheckCredit();
             physicalCheckCredit.fundingSubmerchantId = "123456";
             physicalCheckCredit.fundsTransferId = "123467";
             physicalCheckCredit.amount = 107L;
@@ -681,19 +767,22 @@ merchantId=""01234"">
             Assert.AreEqual(1, batchRequest.getNumPhysicalCheckCredit());
             Assert.AreEqual(107L, batchRequest.getPhysicalCheckCreditAmount());
 
-            mockLitleFile.Verify(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object));
+            mockLitleFile.Verify(
+                litleFile =>
+                    litleFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        mockLitleTime.Object));
             mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, physicalCheckCredit.Serialize()));
         }
 
         [Test]
         public void testAddSubmerchantDebit()
         {
-            submerchantDebit submerchantDebit = new submerchantDebit();
+            var submerchantDebit = new submerchantDebit();
             submerchantDebit.fundingSubmerchantId = "123456";
             submerchantDebit.submerchantName = "merchant";
             submerchantDebit.fundsTransferId = "123467";
             submerchantDebit.amount = 106L;
-            echeckType echeck = new echeckType();
+            var echeck = new echeckType();
             echeck.accType = echeckAccountTypeEnum.Checking;
             echeck.accNum = "12345657890";
             echeck.routingNum = "123456789";
@@ -705,14 +794,17 @@ merchantId=""01234"">
             Assert.AreEqual(1, batchRequest.getNumSubmerchantDebit());
             Assert.AreEqual(106L, batchRequest.getSubmerchantDebitAmount());
 
-            mockLitleFile.Verify(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object));
+            mockLitleFile.Verify(
+                litleFile =>
+                    litleFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        mockLitleTime.Object));
             mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, submerchantDebit.Serialize()));
         }
 
         [Test]
         public void testAddPayFacDebit()
         {
-            payFacDebit payFacDebit = new payFacDebit();
+            var payFacDebit = new payFacDebit();
             payFacDebit.fundingSubmerchantId = "123456";
             payFacDebit.fundsTransferId = "123467";
             payFacDebit.amount = 107L;
@@ -722,14 +814,17 @@ merchantId=""01234"">
             Assert.AreEqual(1, batchRequest.getNumPayFacDebit());
             Assert.AreEqual(107L, batchRequest.getPayFacDebitAmount());
 
-            mockLitleFile.Verify(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object));
+            mockLitleFile.Verify(
+                litleFile =>
+                    litleFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        mockLitleTime.Object));
             mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, payFacDebit.Serialize()));
         }
 
         [Test]
         public void testAddReserveDebit()
         {
-            reserveDebit reserveDebit = new reserveDebit();
+            var reserveDebit = new reserveDebit();
             reserveDebit.fundingSubmerchantId = "123456";
             reserveDebit.fundsTransferId = "123467";
             reserveDebit.amount = 107L;
@@ -739,19 +834,22 @@ merchantId=""01234"">
             Assert.AreEqual(1, batchRequest.getNumReserveDebit());
             Assert.AreEqual(107L, batchRequest.getReserveDebitAmount());
 
-            mockLitleFile.Verify(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object));
+            mockLitleFile.Verify(
+                litleFile =>
+                    litleFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        mockLitleTime.Object));
             mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, reserveDebit.Serialize()));
         }
 
         [Test]
         public void testAddVendorDebit()
         {
-            vendorDebit vendorDebit = new vendorDebit();
+            var vendorDebit = new vendorDebit();
             vendorDebit.fundingSubmerchantId = "123456";
             vendorDebit.vendorName = "merchant";
             vendorDebit.fundsTransferId = "123467";
             vendorDebit.amount = 106L;
-            echeckType echeck = new echeckType();
+            var echeck = new echeckType();
             echeck.accType = echeckAccountTypeEnum.Checking;
             echeck.accNum = "12345657890";
             echeck.routingNum = "123456789";
@@ -763,14 +861,17 @@ merchantId=""01234"">
             Assert.AreEqual(1, batchRequest.getNumVendorDebit());
             Assert.AreEqual(106L, batchRequest.getVendorDebitAmount());
 
-            mockLitleFile.Verify(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object));
+            mockLitleFile.Verify(
+                litleFile =>
+                    litleFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        mockLitleTime.Object));
             mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, vendorDebit.Serialize()));
         }
 
         [Test]
         public void testAddPhysicalCheckDebit()
         {
-            physicalCheckDebit physicalCheckDebit = new physicalCheckDebit();
+            var physicalCheckDebit = new physicalCheckDebit();
             physicalCheckDebit.fundingSubmerchantId = "123456";
             physicalCheckDebit.fundsTransferId = "123467";
             physicalCheckDebit.amount = 107L;
@@ -780,7 +881,10 @@ merchantId=""01234"">
             Assert.AreEqual(1, batchRequest.getNumPhysicalCheckDebit());
             Assert.AreEqual(107L, batchRequest.getPhysicalCheckDebitAmount());
 
-            mockLitleFile.Verify(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object));
+            mockLitleFile.Verify(
+                litleFile =>
+                    litleFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        mockLitleTime.Object));
             mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, physicalCheckDebit.Serialize()));
         }
     }

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestBatchRequest.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestBatchRequest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -22,11 +23,14 @@ namespace Litle.Sdk.Test.Unit
 
         private Mock<litleFile> mockLitleFile;
         private Mock<litleTime> mockLitleTime;
+        private IDictionary<string, StringBuilder> memoryStreams;
 
         [TestFixtureSetUp]
         public void setUp()
         {
-            mockLitleFile = new Mock<litleFile>();
+
+            memoryStreams = new Dictionary<string, StringBuilder>();
+            mockLitleFile = new Mock<litleFile>(new Dictionary<string, StringBuilder>());
             mockLitleTime = new Mock<litleTime>();
 
             mockLitleFile.Setup(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object)).Returns(mockFilePath);
@@ -36,7 +40,7 @@ namespace Litle.Sdk.Test.Unit
         [SetUp]
         public void beforeTestSetup()
         {
-            batchRequest = new batchRequest();
+            batchRequest = new batchRequest(memoryStreams);
             batchRequest.setLitleFile(mockLitleFile.Object);
             batchRequest.setLitleTime(mockLitleTime.Object);
         }
@@ -50,7 +54,7 @@ namespace Litle.Sdk.Test.Unit
             mockConfig["requestDirectory"] = "C:\\MockRequests";
             mockConfig["responseDirectory"] = "C:\\MockResponses";
 
-            batchRequest = new batchRequest(mockConfig);
+            batchRequest = new batchRequest(memoryStreams, mockConfig);
 
             String actual = batchRequest.generateXmlHeader();
             String expected = @"
@@ -84,7 +88,7 @@ merchantId=""01234"">
             mockConfig["requestDirectory"] = "C:\\MockRequests";
             mockConfig["responseDirectory"] = "C:\\MockResponses";
 
-            batchRequest = new batchRequest(mockConfig);
+            batchRequest = new batchRequest(memoryStreams, mockConfig);
 
             Assert.AreEqual("C:\\MockRequests\\Requests\\", batchRequest.getRequestDirectory());
             Assert.AreEqual("C:\\MockResponses\\Responses\\", batchRequest.getResponseDirectory());

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestCancelSubscription.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestCancelSubscription.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -13,11 +14,13 @@ namespace Litle.Sdk.Test.Unit
     class TestCancelSubscription
     {        
         private LitleOnline litle;
+        private IDictionary<string, StringBuilder> _memoryStreams;
 
         [TestFixtureSetUp]
         public void SetUpLitle()
         {
-            litle = new LitleOnline();
+            _memoryStreams = new Dictionary<string, StringBuilder>();
+            litle = new LitleOnline(_memoryStreams);
         }
 
         [Test]
@@ -26,7 +29,7 @@ namespace Litle.Sdk.Test.Unit
             cancelSubscription update = new cancelSubscription();
             update.subscriptionId = 12345;
            
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(new Dictionary<string, StringBuilder>());
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<litleOnlineRequest.*?<cancelSubscription>\r\n<subscriptionId>12345</subscriptionId>\r\n</cancelSubscription>\r\n</litleOnlineRequest>.*?.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.20' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><cancelSubscriptionResponse><subscriptionId>12345</subscriptionId></cancelSubscriptionResponse></litleOnlineResponse>");

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestCancelSubscription.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestCancelSubscription.cs
@@ -1,18 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Text;
-using NUnit.Framework;
-using Litle.Sdk;
-using Moq;
 using System.Text.RegularExpressions;
-
+using Moq;
+using NUnit.Framework;
 
 namespace Litle.Sdk.Test.Unit
 {
     [TestFixture]
-    class TestCancelSubscription
-    {        
+    internal class TestCancelSubscription
+    {
         private LitleOnline litle;
         private IDictionary<string, StringBuilder> _memoryStreams;
 
@@ -26,19 +22,23 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestSimple()
         {
-            cancelSubscription update = new cancelSubscription();
+            var update = new cancelSubscription();
             update.subscriptionId = 12345;
-           
+
             var mock = new Mock<Communications>(new Dictionary<string, StringBuilder>());
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<litleOnlineRequest.*?<cancelSubscription>\r\n<subscriptionId>12345</subscriptionId>\r\n</cancelSubscription>\r\n</litleOnlineRequest>.*?.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.20' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><cancelSubscriptionResponse><subscriptionId>12345</subscriptionId></cancelSubscriptionResponse></litleOnlineResponse>");
-     
-            Communications mockedCommunication = mock.Object;
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*<litleOnlineRequest.*?<cancelSubscription>\r\n<subscriptionId>12345</subscriptionId>\r\n</cancelSubscription>\r\n</litleOnlineRequest>.*?.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.20' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><cancelSubscriptionResponse><subscriptionId>12345</subscriptionId></cancelSubscriptionResponse></litleOnlineResponse>");
+
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.CancelSubscription(update);
         }
-
-
     }
 }

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestCapture.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestCapture.cs
@@ -1,19 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Text;
-using NUnit.Framework;
-using Litle.Sdk;
-using Moq;
 using System.Text.RegularExpressions;
-
+using Moq;
+using NUnit.Framework;
 
 namespace Litle.Sdk.Test.Unit
 {
     [TestFixture]
-    class TestCapture
+    internal class TestCapture
     {
-        
         private LitleOnline litle;
         private IDictionary<string, StringBuilder> _memoryStreams;
 
@@ -27,7 +22,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestSurchargeAmount()
         {
-            capture capture = new capture();
+            var capture = new capture();
             capture.litleTxnId = 3;
             capture.amount = 2;
             capture.surchargeAmount = 1;
@@ -36,10 +31,16 @@ namespace Litle.Sdk.Test.Unit
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<surchargeAmount>1</surchargeAmount>\r\n<payPalNotes>note</payPalNotes>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><captureResponse><litleTxnId>123</litleTxnId></captureResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*<amount>2</amount>\r\n<surchargeAmount>1</surchargeAmount>\r\n<payPalNotes>note</payPalNotes>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><captureResponse><litleTxnId>123</litleTxnId></captureResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.Capture(capture);
         }
@@ -47,7 +48,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestSurchargeAmount_Optional()
         {
-            capture capture = new capture();
+            var capture = new capture();
             capture.litleTxnId = 3;
             capture.amount = 2;
             capture.payPalNotes = "note";
@@ -55,13 +56,17 @@ namespace Litle.Sdk.Test.Unit
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<payPalNotes>note</payPalNotes>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><captureResponse><litleTxnId>123</litleTxnId></captureResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(".*<amount>2</amount>\r\n<payPalNotes>note</payPalNotes>.*", RegexOptions.Singleline),
+                        It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><captureResponse><litleTxnId>123</litleTxnId></captureResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.Capture(capture);
         }
-
     }
 }

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestCapture.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestCapture.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -14,11 +15,13 @@ namespace Litle.Sdk.Test.Unit
     {
         
         private LitleOnline litle;
+        private IDictionary<string, StringBuilder> _memoryStreams;
 
         [TestFixtureSetUp]
         public void SetUpLitle()
         {
-            litle = new LitleOnline();
+            _memoryStreams = new Dictionary<string, StringBuilder>();
+            litle = new LitleOnline(_memoryStreams);
         }
 
         [Test]
@@ -31,7 +34,7 @@ namespace Litle.Sdk.Test.Unit
             capture.payPalNotes = "note";
             capture.reportGroup = "Planets";
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<surchargeAmount>1</surchargeAmount>\r\n<payPalNotes>note</payPalNotes>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><captureResponse><litleTxnId>123</litleTxnId></captureResponse></litleOnlineResponse>");
@@ -50,7 +53,7 @@ namespace Litle.Sdk.Test.Unit
             capture.payPalNotes = "note";
             capture.reportGroup = "Planets";
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<payPalNotes>note</payPalNotes>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><captureResponse><litleTxnId>123</litleTxnId></captureResponse></litleOnlineResponse>");

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestCaptureGivenAuth.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestCaptureGivenAuth.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -14,11 +15,13 @@ namespace Litle.Sdk.Test.Unit
     {
         
         private LitleOnline litle;
+        private IDictionary<string, StringBuilder> _memoryStreams;
 
         [TestFixtureSetUp]
         public void SetUpLitle()
         {
-            litle = new LitleOnline();
+            _memoryStreams = new Dictionary<string, StringBuilder>();
+            litle = new LitleOnline(_memoryStreams);
         }
 
         [Test]
@@ -30,7 +33,7 @@ namespace Litle.Sdk.Test.Unit
             capture.orderSource = orderSourceType.ecommerce;
             capture.reportGroup = "Planets";
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<secondaryAmount>1</secondaryAmount>\r\n<orderSource>ecommerce</orderSource>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><captureGivenAuthResponse><litleTxnId>123</litleTxnId></captureGivenAuthResponse></litleOnlineResponse>");
@@ -49,7 +52,7 @@ namespace Litle.Sdk.Test.Unit
             capture.orderSource = orderSourceType.ecommerce;
             capture.reportGroup = "Planets";
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<surchargeAmount>1</surchargeAmount>\r\n<orderSource>ecommerce</orderSource>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><captureGivenAuthResponse><litleTxnId>123</litleTxnId></captureGivenAuthResponse></litleOnlineResponse>");
@@ -67,7 +70,7 @@ namespace Litle.Sdk.Test.Unit
             capture.orderSource = orderSourceType.ecommerce;
             capture.reportGroup = "Planets";
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<orderSource>ecommerce</orderSource>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><captureGivenAuthResponse><litleTxnId>123</litleTxnId></captureGivenAuthResponse></litleOnlineResponse>");
@@ -84,7 +87,7 @@ namespace Litle.Sdk.Test.Unit
             captureGivenAuth.merchantData = new merchantDataType();
             captureGivenAuth.debtRepayment = true;
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*</merchantData>\r\n<debtRepayment>true</debtRepayment>\r\n</captureGivenAuth>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.19' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><captureGivenAuthResponse><litleTxnId>123</litleTxnId></captureGivenAuthResponse></litleOnlineResponse>");
@@ -101,7 +104,7 @@ namespace Litle.Sdk.Test.Unit
             captureGivenAuth.merchantData = new merchantDataType();
             captureGivenAuth.debtRepayment = false;
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*</merchantData>\r\n<debtRepayment>false</debtRepayment>\r\n</captureGivenAuth>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.19' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><captureGivenAuthResponse><litleTxnId>123</litleTxnId></captureGivenAuthResponse></litleOnlineResponse>");
@@ -117,7 +120,7 @@ namespace Litle.Sdk.Test.Unit
             captureGivenAuth captureGivenAuth = new captureGivenAuth();
             captureGivenAuth.merchantData = new merchantDataType();
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*</merchantData>\r\n</captureGivenAuth>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.19' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><captureGivenAuthResponse><litleTxnId>123</litleTxnId></captureGivenAuthResponse></litleOnlineResponse>");

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestCaptureGivenAuth.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestCaptureGivenAuth.cs
@@ -1,19 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Text;
-using NUnit.Framework;
-using Litle.Sdk;
-using Moq;
 using System.Text.RegularExpressions;
-
+using Moq;
+using NUnit.Framework;
 
 namespace Litle.Sdk.Test.Unit
 {
     [TestFixture]
-    class TestCaptureGivenAuth
+    internal class TestCaptureGivenAuth
     {
-        
         private LitleOnline litle;
         private IDictionary<string, StringBuilder> _memoryStreams;
 
@@ -27,7 +22,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestSecondaryAmount()
         {
-            captureGivenAuth capture = new captureGivenAuth();
+            var capture = new captureGivenAuth();
             capture.amount = 2;
             capture.secondaryAmount = 1;
             capture.orderSource = orderSourceType.ecommerce;
@@ -35,10 +30,16 @@ namespace Litle.Sdk.Test.Unit
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<secondaryAmount>1</secondaryAmount>\r\n<orderSource>ecommerce</orderSource>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><captureGivenAuthResponse><litleTxnId>123</litleTxnId></captureGivenAuthResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*<amount>2</amount>\r\n<secondaryAmount>1</secondaryAmount>\r\n<orderSource>ecommerce</orderSource>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><captureGivenAuthResponse><litleTxnId>123</litleTxnId></captureGivenAuthResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.CaptureGivenAuth(capture);
         }
@@ -46,7 +47,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestSurchargeAmount()
         {
-            captureGivenAuth capture = new captureGivenAuth();
+            var capture = new captureGivenAuth();
             capture.amount = 2;
             capture.surchargeAmount = 1;
             capture.orderSource = orderSourceType.ecommerce;
@@ -54,10 +55,16 @@ namespace Litle.Sdk.Test.Unit
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<surchargeAmount>1</surchargeAmount>\r\n<orderSource>ecommerce</orderSource>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><captureGivenAuthResponse><litleTxnId>123</litleTxnId></captureGivenAuthResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*<amount>2</amount>\r\n<surchargeAmount>1</surchargeAmount>\r\n<orderSource>ecommerce</orderSource>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><captureGivenAuthResponse><litleTxnId>123</litleTxnId></captureGivenAuthResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.CaptureGivenAuth(capture);
         }
@@ -65,17 +72,22 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestSurchargeAmount_Optional()
         {
-            captureGivenAuth capture = new captureGivenAuth();
+            var capture = new captureGivenAuth();
             capture.amount = 2;
             capture.orderSource = orderSourceType.ecommerce;
             capture.reportGroup = "Planets";
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<orderSource>ecommerce</orderSource>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><captureGivenAuthResponse><litleTxnId>123</litleTxnId></captureGivenAuthResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(".*<amount>2</amount>\r\n<orderSource>ecommerce</orderSource>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><captureGivenAuthResponse><litleTxnId>123</litleTxnId></captureGivenAuthResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.CaptureGivenAuth(capture);
         }
@@ -83,16 +95,21 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestDebtRepayment_True()
         {
-            captureGivenAuth captureGivenAuth = new captureGivenAuth();
+            var captureGivenAuth = new captureGivenAuth();
             captureGivenAuth.merchantData = new merchantDataType();
             captureGivenAuth.debtRepayment = true;
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*</merchantData>\r\n<debtRepayment>true</debtRepayment>\r\n</captureGivenAuth>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.19' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><captureGivenAuthResponse><litleTxnId>123</litleTxnId></captureGivenAuthResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(".*</merchantData>\r\n<debtRepayment>true</debtRepayment>\r\n</captureGivenAuth>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.19' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><captureGivenAuthResponse><litleTxnId>123</litleTxnId></captureGivenAuthResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.CaptureGivenAuth(captureGivenAuth);
         }
@@ -100,16 +117,22 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestDebtRepayment_False()
         {
-            captureGivenAuth captureGivenAuth = new captureGivenAuth();
+            var captureGivenAuth = new captureGivenAuth();
             captureGivenAuth.merchantData = new merchantDataType();
             captureGivenAuth.debtRepayment = false;
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*</merchantData>\r\n<debtRepayment>false</debtRepayment>\r\n</captureGivenAuth>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.19' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><captureGivenAuthResponse><litleTxnId>123</litleTxnId></captureGivenAuthResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*</merchantData>\r\n<debtRepayment>false</debtRepayment>\r\n</captureGivenAuth>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.19' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><captureGivenAuthResponse><litleTxnId>123</litleTxnId></captureGivenAuthResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.CaptureGivenAuth(captureGivenAuth);
         }
@@ -117,18 +140,22 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestDebtRepayment_Optional()
         {
-            captureGivenAuth captureGivenAuth = new captureGivenAuth();
+            var captureGivenAuth = new captureGivenAuth();
             captureGivenAuth.merchantData = new merchantDataType();
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*</merchantData>\r\n</captureGivenAuth>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.19' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><captureGivenAuthResponse><litleTxnId>123</litleTxnId></captureGivenAuthResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(".*</merchantData>\r\n</captureGivenAuth>.*", RegexOptions.Singleline),
+                        It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.19' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><captureGivenAuthResponse><litleTxnId>123</litleTxnId></captureGivenAuthResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.CaptureGivenAuth(captureGivenAuth);
         }
-
     }
 }

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestCommunications.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestCommunications.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -13,11 +14,13 @@ namespace Litle.Sdk.Test.Unit
     class TestCommunications
     {
         private Communications objectUnderTest;
+        private IDictionary<string, StringBuilder> memoryStreams;
 
         [TestFixtureSetUp]
         public void SetUpLitle()
         {
-            objectUnderTest = new Communications();
+            memoryStreams = new Dictionary<string, StringBuilder>();
+            objectUnderTest = new Communications(memoryStreams);
         }
 
         [Test]

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestCommunications.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestCommunications.cs
@@ -1,17 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Text;
 using NUnit.Framework;
-using Litle.Sdk;
-using Moq;
-using System.Text.RegularExpressions;
-
 
 namespace Litle.Sdk.Test.Unit
 {
     [TestFixture]
-    class TestCommunications
+    internal class TestCommunications
     {
         private Communications objectUnderTest;
         private IDictionary<string, StringBuilder> memoryStreams;
@@ -26,13 +20,11 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestSettingProxyPropertiesToNullShouldTurnOffProxy()
         {
-            Dictionary<string, string> config = new Dictionary<string, string>();
+            var config = new Dictionary<string, string>();
             config.Add("proxyHost", null);
             config.Add("proxyPort", null);
 
             Assert.IsFalse(objectUnderTest.isProxyOn(config));
         }
-
-
     }
 }

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestCredit.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestCredit.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -14,11 +15,13 @@ namespace Litle.Sdk.Test.Unit
     {
         
         private LitleOnline litle;
+        private IDictionary<string, StringBuilder> _memoryStreams;
 
         [TestFixtureSetUp]
         public void SetUpLitle()
         {
-            litle = new LitleOnline();
+            _memoryStreams = new Dictionary<string, StringBuilder>();
+            litle = new LitleOnline(_memoryStreams);
         }
 
         [Test]
@@ -31,7 +34,7 @@ namespace Litle.Sdk.Test.Unit
             credit.reportGroup = "Planets";
             credit.actionReason = "SUSPECT_FRAUD";
            
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<actionReason>SUSPECT_FRAUD</actionReason>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><creditResponse><litleTxnId>123</litleTxnId></creditResponse></litleOnlineResponse>");
@@ -50,7 +53,7 @@ namespace Litle.Sdk.Test.Unit
             credit.orderSource = orderSourceType.ecommerce;
             credit.reportGroup = "Planets";
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<credit.*<amount>2</amount>.*<orderSource>ecommerce</orderSource>.*</credit>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><creditResponse><litleTxnId>123</litleTxnId></creditResponse></litleOnlineResponse>");
@@ -70,7 +73,7 @@ namespace Litle.Sdk.Test.Unit
             credit.orderSource = orderSourceType.ecommerce;
             credit.reportGroup = "Planets";
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<orderId>3</orderId>\r\n<amount>2</amount>\r\n<secondaryAmount>1</secondaryAmount>\r\n<orderSource>ecommerce</orderSource>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><creditResponse><litleTxnId>123</litleTxnId></creditResponse></litleOnlineResponse>");
@@ -90,7 +93,7 @@ namespace Litle.Sdk.Test.Unit
             credit.processingInstructions = new processingInstructions();
             credit.reportGroup = "Planets";
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<litleTxnId>3</litleTxnId>\r\n<amount>2</amount>\r\n<secondaryAmount>1</secondaryAmount>\r\n<process.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><creditResponse><litleTxnId>123</litleTxnId></creditResponse></litleOnlineResponse>");
@@ -110,7 +113,7 @@ namespace Litle.Sdk.Test.Unit
             credit.processingInstructions = new processingInstructions();
             credit.reportGroup = "Planets";
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<litleTxnId>3</litleTxnId>\r\n<amount>2</amount>\r\n<surchargeAmount>1</surchargeAmount>\r\n<process.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><creditResponse><litleTxnId>123</litleTxnId></creditResponse></litleOnlineResponse>");
@@ -129,7 +132,7 @@ namespace Litle.Sdk.Test.Unit
             credit.reportGroup = "Planets";
             credit.processingInstructions = new processingInstructions();
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<litleTxnId>3</litleTxnId>\r\n<amount>2</amount>\r\n<processi.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><creditResponse><litleTxnId>123</litleTxnId></creditResponse></litleOnlineResponse>");
@@ -149,7 +152,7 @@ namespace Litle.Sdk.Test.Unit
             credit.orderSource = orderSourceType.ecommerce;
             credit.reportGroup = "Planets";
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<orderId>3</orderId>\r\n<amount>2</amount>\r\n<surchargeAmount>1</surchargeAmount>\r\n<orderSource>ecommerce</orderSource>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><creditResponse><litleTxnId>123</litleTxnId></creditResponse></litleOnlineResponse>");
@@ -168,7 +171,7 @@ namespace Litle.Sdk.Test.Unit
             credit.orderSource = orderSourceType.ecommerce;
             credit.reportGroup = "Planets";
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<orderId>3</orderId>\r\n<amount>2</amount>\r\n<orderSource>ecommerce</orderSource>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><creditResponse><litleTxnId>123</litleTxnId></creditResponse></litleOnlineResponse>");
@@ -189,7 +192,7 @@ namespace Litle.Sdk.Test.Unit
             credit.reportGroup = "Planets";
             credit.payPalNotes = "notes";
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<litleTxnId>3</litleTxnId>\r\n<amount>2</amount>\r\n<pos>\r\n<terminalId>abc123</terminalId></pos>\r\n<payPalNotes>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><creditResponse><litleTxnId>123</litleTxnId></creditResponse></litleOnlineResponse>");
@@ -208,7 +211,7 @@ namespace Litle.Sdk.Test.Unit
             credit.reportGroup = "Planets";
             credit.payPalNotes = "notes";
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<litleTxnId>3</litleTxnId>\r\n<amount>2</amount>\r\n<payPalNotes>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><creditResponse><litleTxnId>123</litleTxnId></creditResponse></litleOnlineResponse>");

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestCredit.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestCredit.cs
@@ -1,19 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Text;
-using NUnit.Framework;
-using Litle.Sdk;
-using Moq;
 using System.Text.RegularExpressions;
-
+using Moq;
+using NUnit.Framework;
 
 namespace Litle.Sdk.Test.Unit
 {
     [TestFixture]
-    class TestCredit
+    internal class TestCredit
     {
-        
         private LitleOnline litle;
         private IDictionary<string, StringBuilder> _memoryStreams;
 
@@ -27,19 +22,24 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestActionReasonOnOrphanedRefund()
         {
-            credit credit = new credit();
+            var credit = new credit();
             credit.orderId = "12344";
             credit.amount = 2;
             credit.orderSource = orderSourceType.ecommerce;
             credit.reportGroup = "Planets";
             credit.actionReason = "SUSPECT_FRAUD";
-           
+
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<actionReason>SUSPECT_FRAUD</actionReason>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><creditResponse><litleTxnId>123</litleTxnId></creditResponse></litleOnlineResponse>");
-     
-            Communications mockedCommunication = mock.Object;
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(".*<actionReason>SUSPECT_FRAUD</actionReason>.*", RegexOptions.Singleline),
+                        It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><creditResponse><litleTxnId>123</litleTxnId></creditResponse></litleOnlineResponse>");
+
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.Credit(credit);
         }
@@ -47,7 +47,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestOrderSource_Set()
         {
-            credit credit = new credit();
+            var credit = new credit();
             credit.orderId = "12344";
             credit.amount = 2;
             credit.orderSource = orderSourceType.ecommerce;
@@ -55,10 +55,15 @@ namespace Litle.Sdk.Test.Unit
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<credit.*<amount>2</amount>.*<orderSource>ecommerce</orderSource>.*</credit>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><creditResponse><litleTxnId>123</litleTxnId></creditResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(".*<credit.*<amount>2</amount>.*<orderSource>ecommerce</orderSource>.*</credit>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><creditResponse><litleTxnId>123</litleTxnId></creditResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.Credit(credit);
         }
@@ -66,7 +71,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestSecondaryAmount_Orphan()
         {
-            credit credit = new credit();
+            var credit = new credit();
             credit.amount = 2;
             credit.secondaryAmount = 1;
             credit.orderId = "3";
@@ -75,10 +80,16 @@ namespace Litle.Sdk.Test.Unit
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<orderId>3</orderId>\r\n<amount>2</amount>\r\n<secondaryAmount>1</secondaryAmount>\r\n<orderSource>ecommerce</orderSource>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><creditResponse><litleTxnId>123</litleTxnId></creditResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*<orderId>3</orderId>\r\n<amount>2</amount>\r\n<secondaryAmount>1</secondaryAmount>\r\n<orderSource>ecommerce</orderSource>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><creditResponse><litleTxnId>123</litleTxnId></creditResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.Credit(credit);
         }
@@ -86,7 +97,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestSecondaryAmount_Tied()
         {
-            credit credit = new credit();
+            var credit = new credit();
             credit.amount = 2;
             credit.secondaryAmount = 1;
             credit.litleTxnId = 3;
@@ -95,10 +106,16 @@ namespace Litle.Sdk.Test.Unit
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<litleTxnId>3</litleTxnId>\r\n<amount>2</amount>\r\n<secondaryAmount>1</secondaryAmount>\r\n<process.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><creditResponse><litleTxnId>123</litleTxnId></creditResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*<litleTxnId>3</litleTxnId>\r\n<amount>2</amount>\r\n<secondaryAmount>1</secondaryAmount>\r\n<process.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><creditResponse><litleTxnId>123</litleTxnId></creditResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.Credit(credit);
         }
@@ -106,7 +123,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestSurchargeAmount_Tied()
         {
-            credit credit = new credit();
+            var credit = new credit();
             credit.amount = 2;
             credit.surchargeAmount = 1;
             credit.litleTxnId = 3;
@@ -115,10 +132,16 @@ namespace Litle.Sdk.Test.Unit
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<litleTxnId>3</litleTxnId>\r\n<amount>2</amount>\r\n<surchargeAmount>1</surchargeAmount>\r\n<process.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><creditResponse><litleTxnId>123</litleTxnId></creditResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*<litleTxnId>3</litleTxnId>\r\n<amount>2</amount>\r\n<surchargeAmount>1</surchargeAmount>\r\n<process.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><creditResponse><litleTxnId>123</litleTxnId></creditResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.Credit(credit);
         }
@@ -126,7 +149,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestSurchargeAmount_TiedOptional()
         {
-            credit credit = new credit();
+            var credit = new credit();
             credit.amount = 2;
             credit.litleTxnId = 3;
             credit.reportGroup = "Planets";
@@ -134,10 +157,15 @@ namespace Litle.Sdk.Test.Unit
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<litleTxnId>3</litleTxnId>\r\n<amount>2</amount>\r\n<processi.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><creditResponse><litleTxnId>123</litleTxnId></creditResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(".*<litleTxnId>3</litleTxnId>\r\n<amount>2</amount>\r\n<processi.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><creditResponse><litleTxnId>123</litleTxnId></creditResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.Credit(credit);
         }
@@ -145,7 +173,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestSurchargeAmount_Orphan()
         {
-            credit credit = new credit();
+            var credit = new credit();
             credit.amount = 2;
             credit.surchargeAmount = 1;
             credit.orderId = "3";
@@ -154,10 +182,16 @@ namespace Litle.Sdk.Test.Unit
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<orderId>3</orderId>\r\n<amount>2</amount>\r\n<surchargeAmount>1</surchargeAmount>\r\n<orderSource>ecommerce</orderSource>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><creditResponse><litleTxnId>123</litleTxnId></creditResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*<orderId>3</orderId>\r\n<amount>2</amount>\r\n<surchargeAmount>1</surchargeAmount>\r\n<orderSource>ecommerce</orderSource>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><creditResponse><litleTxnId>123</litleTxnId></creditResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.Credit(credit);
         }
@@ -165,7 +199,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestSurchargeAmount_OrphanOptional()
         {
-            credit credit = new credit();
+            var credit = new credit();
             credit.amount = 2;
             credit.orderId = "3";
             credit.orderSource = orderSourceType.ecommerce;
@@ -173,10 +207,16 @@ namespace Litle.Sdk.Test.Unit
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<orderId>3</orderId>\r\n<amount>2</amount>\r\n<orderSource>ecommerce</orderSource>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><creditResponse><litleTxnId>123</litleTxnId></creditResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*<orderId>3</orderId>\r\n<amount>2</amount>\r\n<orderSource>ecommerce</orderSource>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><creditResponse><litleTxnId>123</litleTxnId></creditResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.Credit(credit);
         }
@@ -184,7 +224,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestPos_Tied()
         {
-            credit credit = new credit();
+            var credit = new credit();
             credit.amount = 2;
             credit.pos = new pos();
             credit.pos.terminalId = "abc123";
@@ -194,10 +234,16 @@ namespace Litle.Sdk.Test.Unit
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<litleTxnId>3</litleTxnId>\r\n<amount>2</amount>\r\n<pos>\r\n<terminalId>abc123</terminalId></pos>\r\n<payPalNotes>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><creditResponse><litleTxnId>123</litleTxnId></creditResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*<litleTxnId>3</litleTxnId>\r\n<amount>2</amount>\r\n<pos>\r\n<terminalId>abc123</terminalId></pos>\r\n<payPalNotes>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><creditResponse><litleTxnId>123</litleTxnId></creditResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.Credit(credit);
         }
@@ -205,7 +251,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestPos_TiedOptional()
         {
-            credit credit = new credit();
+            var credit = new credit();
             credit.amount = 2;
             credit.litleTxnId = 3;
             credit.reportGroup = "Planets";
@@ -213,14 +259,17 @@ namespace Litle.Sdk.Test.Unit
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<litleTxnId>3</litleTxnId>\r\n<amount>2</amount>\r\n<payPalNotes>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><creditResponse><litleTxnId>123</litleTxnId></creditResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(".*<litleTxnId>3</litleTxnId>\r\n<amount>2</amount>\r\n<payPalNotes>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><creditResponse><litleTxnId>123</litleTxnId></creditResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.Credit(credit);
         }
-
-
     }
 }

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestDeactivateReversal.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestDeactivateReversal.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -11,13 +12,15 @@ namespace Litle.Sdk.Test.Unit
 {
     [TestFixture]
     class TestDeactivateReversal
-    {        
+    {
         private LitleOnline litle;
+        private IDictionary<string, StringBuilder> _memoryStreams;
 
         [TestFixtureSetUp]
         public void SetUpLitle()
         {
-            litle = new LitleOnline();
+            _memoryStreams = new Dictionary<string, StringBuilder>();
+            litle = new LitleOnline(_memoryStreams);
         }
 
         [Test]
@@ -28,7 +31,7 @@ namespace Litle.Sdk.Test.Unit
             deactivateReversal.reportGroup = "b";
             deactivateReversal.litleTxnId = "123";
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<litleTxnId>123</litleTxnId>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><deactivateReversalResponse><litleTxnId>123</litleTxnId></deactivateReversalResponse></litleOnlineResponse>");

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestDeactivateReversal.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestDeactivateReversal.cs
@@ -1,17 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Text;
-using NUnit.Framework;
-using Litle.Sdk;
-using Moq;
 using System.Text.RegularExpressions;
-
+using Moq;
+using NUnit.Framework;
 
 namespace Litle.Sdk.Test.Unit
 {
     [TestFixture]
-    class TestDeactivateReversal
+    internal class TestDeactivateReversal
     {
         private LitleOnline litle;
         private IDictionary<string, StringBuilder> _memoryStreams;
@@ -26,22 +22,24 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestSimple()
         {
-            deactivateReversal deactivateReversal = new deactivateReversal();
+            var deactivateReversal = new deactivateReversal();
             deactivateReversal.id = "a";
             deactivateReversal.reportGroup = "b";
             deactivateReversal.litleTxnId = "123";
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<litleTxnId>123</litleTxnId>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><deactivateReversalResponse><litleTxnId>123</litleTxnId></deactivateReversalResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(It.IsRegex(".*<litleTxnId>123</litleTxnId>.*", RegexOptions.Singleline),
+                        It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><deactivateReversalResponse><litleTxnId>123</litleTxnId></deactivateReversalResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            deactivateReversalResponse response = litle.DeactivateReversal(deactivateReversal);
+            var response = litle.DeactivateReversal(deactivateReversal);
             Assert.AreEqual("123", response.litleTxnId);
         }
-
-
     }
 }

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestDepositReversal.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestDepositReversal.cs
@@ -1,17 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Text;
-using NUnit.Framework;
-using Litle.Sdk;
-using Moq;
 using System.Text.RegularExpressions;
-
+using Moq;
+using NUnit.Framework;
 
 namespace Litle.Sdk.Test.Unit
 {
     [TestFixture]
-    class TestDepositReversal
+    internal class TestDepositReversal
     {
         private LitleOnline litle;
         private IDictionary<string, StringBuilder> _memoryStreams;
@@ -26,22 +22,24 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestSimple()
         {
-            depositReversal depositReversal = new depositReversal();
+            var depositReversal = new depositReversal();
             depositReversal.id = "a";
             depositReversal.reportGroup = "b";
             depositReversal.litleTxnId = "123";
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<litleTxnId>123</litleTxnId>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><depositReversalResponse><litleTxnId>123</litleTxnId></depositReversalResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(It.IsRegex(".*<litleTxnId>123</litleTxnId>.*", RegexOptions.Singleline),
+                        It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><depositReversalResponse><litleTxnId>123</litleTxnId></depositReversalResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            depositReversalResponse response = litle.DepositReversal(depositReversal);
+            var response = litle.DepositReversal(depositReversal);
             Assert.AreEqual("123", response.litleTxnId);
         }
-
-
     }
 }

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestDepositReversal.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestDepositReversal.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -11,13 +12,15 @@ namespace Litle.Sdk.Test.Unit
 {
     [TestFixture]
     class TestDepositReversal
-    {        
+    {
         private LitleOnline litle;
+        private IDictionary<string, StringBuilder> _memoryStreams;
 
         [TestFixtureSetUp]
         public void SetUpLitle()
         {
-            litle = new LitleOnline();
+            _memoryStreams = new Dictionary<string, StringBuilder>();
+            litle = new LitleOnline(_memoryStreams);
         }
 
         [Test]
@@ -28,7 +31,7 @@ namespace Litle.Sdk.Test.Unit
             depositReversal.reportGroup = "b";
             depositReversal.litleTxnId = "123";
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<litleTxnId>123</litleTxnId>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><depositReversalResponse><litleTxnId>123</litleTxnId></depositReversalResponse></litleOnlineResponse>");

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestEcheckRedeposit.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestEcheckRedeposit.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -12,15 +13,16 @@ namespace Litle.Sdk.Test.Unit
     [TestFixture]
     class TestEcheckRedeposit
     {
-        
+
         private LitleOnline litle;
+        private IDictionary<string, StringBuilder> _memoryStreams;
 
         [TestFixtureSetUp]
         public void SetUpLitle()
         {
-            litle = new LitleOnline();
+            _memoryStreams = new Dictionary<string, StringBuilder>();
+            litle = new LitleOnline(_memoryStreams);
         }
-
         [Test]
         public void TestMerchantData()
         {
@@ -31,7 +33,7 @@ namespace Litle.Sdk.Test.Unit
             echeckRedeposit.merchantData.affiliate = "affil";
             echeckRedeposit.merchantData.merchantGroupingId = "mgi";
            
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<echeckRedeposit.*<litleTxnId>1</litleTxnId>.*<merchantData>.*<campaign>camp</campaign>.*<affiliate>affil</affiliate>.*<merchantGroupingId>mgi</merchantGroupingId>.*</merchantData>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.13' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><echeckRedepositResponse><litleTxnId>123</litleTxnId></echeckRedepositResponse></litleOnlineResponse>");

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestEcheckRedeposit.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestEcheckRedeposit.cs
@@ -1,19 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Text;
-using NUnit.Framework;
-using Litle.Sdk;
-using Moq;
 using System.Text.RegularExpressions;
-
+using Moq;
+using NUnit.Framework;
 
 namespace Litle.Sdk.Test.Unit
 {
     [TestFixture]
-    class TestEcheckRedeposit
+    internal class TestEcheckRedeposit
     {
-
         private LitleOnline litle;
         private IDictionary<string, StringBuilder> _memoryStreams;
 
@@ -23,24 +18,31 @@ namespace Litle.Sdk.Test.Unit
             _memoryStreams = new Dictionary<string, StringBuilder>();
             litle = new LitleOnline(_memoryStreams);
         }
+
         [Test]
         public void TestMerchantData()
         {
-            echeckRedeposit echeckRedeposit = new echeckRedeposit();
+            var echeckRedeposit = new echeckRedeposit();
             echeckRedeposit.litleTxnId = 1;
             echeckRedeposit.merchantData = new merchantDataType();
             echeckRedeposit.merchantData.campaign = "camp";
             echeckRedeposit.merchantData.affiliate = "affil";
             echeckRedeposit.merchantData.merchantGroupingId = "mgi";
-           
+
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<echeckRedeposit.*<litleTxnId>1</litleTxnId>.*<merchantData>.*<campaign>camp</campaign>.*<affiliate>affil</affiliate>.*<merchantGroupingId>mgi</merchantGroupingId>.*</merchantData>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.13' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><echeckRedepositResponse><litleTxnId>123</litleTxnId></echeckRedepositResponse></litleOnlineResponse>");
-     
-            Communications mockedCommunication = mock.Object;
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*<echeckRedeposit.*<litleTxnId>1</litleTxnId>.*<merchantData>.*<campaign>camp</campaign>.*<affiliate>affil</affiliate>.*<merchantGroupingId>mgi</merchantGroupingId>.*</merchantData>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.13' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><echeckRedepositResponse><litleTxnId>123</litleTxnId></echeckRedepositResponse></litleOnlineResponse>");
+
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.EcheckRedeposit(echeckRedeposit);
-        }            
+        }
     }
 }

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestEcheckVerification.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestEcheckVerification.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -12,13 +13,15 @@ namespace Litle.Sdk.Test.Unit
     [TestFixture]
     class TestEcheckVerification
     {
-        
+
         private LitleOnline litle;
+        private IDictionary<string, StringBuilder> _memoryStreams;
 
         [TestFixtureSetUp]
         public void SetUpLitle()
         {
-            litle = new LitleOnline();
+            _memoryStreams = new Dictionary<string, StringBuilder>();
+            litle = new LitleOnline(_memoryStreams);
         }
 
         [Test]
@@ -37,7 +40,7 @@ namespace Litle.Sdk.Test.Unit
             echeckVerification.merchantData.affiliate = "affil";
             echeckVerification.merchantData.merchantGroupingId = "mgi";
            
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<echeckVerification.*<orderId>1</orderId>.*<amount>2</amount.*<merchantData>.*<campaign>camp</campaign>.*<affiliate>affil</affiliate>.*<merchantGroupingId>mgi</merchantGroupingId>.*</merchantData>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.13' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><echeckVerificationResponse><litleTxnId>123</litleTxnId></echeckVerificationResponse></litleOnlineResponse>");

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestEcheckVerification.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestEcheckVerification.cs
@@ -1,19 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Text;
-using NUnit.Framework;
-using Litle.Sdk;
-using Moq;
 using System.Text.RegularExpressions;
-
+using Moq;
+using NUnit.Framework;
 
 namespace Litle.Sdk.Test.Unit
 {
     [TestFixture]
-    class TestEcheckVerification
+    internal class TestEcheckVerification
     {
-
         private LitleOnline litle;
         private IDictionary<string, StringBuilder> _memoryStreams;
 
@@ -27,7 +22,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestMerchantData()
         {
-            echeckVerification echeckVerification = new echeckVerification();
+            var echeckVerification = new echeckVerification();
             echeckVerification.orderId = "1";
             echeckVerification.amount = 2;
             echeckVerification.orderSource = orderSourceType.ecommerce;
@@ -39,15 +34,21 @@ namespace Litle.Sdk.Test.Unit
             echeckVerification.merchantData.campaign = "camp";
             echeckVerification.merchantData.affiliate = "affil";
             echeckVerification.merchantData.merchantGroupingId = "mgi";
-           
+
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<echeckVerification.*<orderId>1</orderId>.*<amount>2</amount.*<merchantData>.*<campaign>camp</campaign>.*<affiliate>affil</affiliate>.*<merchantGroupingId>mgi</merchantGroupingId>.*</merchantData>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.13' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><echeckVerificationResponse><litleTxnId>123</litleTxnId></echeckVerificationResponse></litleOnlineResponse>");
-     
-            Communications mockedCommunication = mock.Object;
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*<echeckVerification.*<orderId>1</orderId>.*<amount>2</amount.*<merchantData>.*<campaign>camp</campaign>.*<affiliate>affil</affiliate>.*<merchantGroupingId>mgi</merchantGroupingId>.*</merchantData>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.13' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><echeckVerificationResponse><litleTxnId>123</litleTxnId></echeckVerificationResponse></litleOnlineResponse>");
+
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.EcheckVerification(echeckVerification);
-        }            
+        }
     }
 }

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestEcheckVoid.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestEcheckVoid.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -12,13 +13,14 @@ namespace Litle.Sdk.Test.Unit
     [TestFixture]
     class TestEcheckVoid
     {
-        
         private LitleOnline litle;
+        private IDictionary<string, StringBuilder> _memoryStreams;
 
         [TestFixtureSetUp]
         public void SetUpLitle()
         {
-            litle = new LitleOnline();
+            _memoryStreams = new Dictionary<string, StringBuilder>();
+            litle = new LitleOnline(_memoryStreams);
         }
 
         [Test]
@@ -27,7 +29,7 @@ namespace Litle.Sdk.Test.Unit
             echeckVoid echeckVoid = new echeckVoid();
             echeckVoid.litleTxnId = 123456789;
            
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<echeckVoid.*<litleTxnId>123456789.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.13' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><echeckVoidResponse><litleTxnId>123</litleTxnId></echeckVoidResponse></litleOnlineResponse>");

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestEcheckVoid.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestEcheckVoid.cs
@@ -1,17 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Text;
-using NUnit.Framework;
-using Litle.Sdk;
-using Moq;
 using System.Text.RegularExpressions;
-
+using Moq;
+using NUnit.Framework;
 
 namespace Litle.Sdk.Test.Unit
 {
     [TestFixture]
-    class TestEcheckVoid
+    internal class TestEcheckVoid
     {
         private LitleOnline litle;
         private IDictionary<string, StringBuilder> _memoryStreams;
@@ -26,15 +22,20 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestFraudFilterOverride()
         {
-            echeckVoid echeckVoid = new echeckVoid();
+            var echeckVoid = new echeckVoid();
             echeckVoid.litleTxnId = 123456789;
-           
+
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<echeckVoid.*<litleTxnId>123456789.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.13' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><echeckVoidResponse><litleTxnId>123</litleTxnId></echeckVoidResponse></litleOnlineResponse>");
-     
-            Communications mockedCommunication = mock.Object;
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(".*<echeckVoid.*<litleTxnId>123456789.*", RegexOptions.Singleline),
+                        It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.13' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><echeckVoidResponse><litleTxnId>123</litleTxnId></echeckVoidResponse></litleOnlineResponse>");
+
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.EcheckVoid(echeckVoid);
         }
@@ -42,17 +43,17 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void simpleForceCaptureWithSecondaryAmount()
         {
-            forceCapture forcecapture = new forceCapture();
+            var forcecapture = new forceCapture();
             forcecapture.amount = 106;
             forcecapture.secondaryAmount = 50;
             forcecapture.orderId = "12344";
             forcecapture.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000001";
             card.expDate = "1210";
             forcecapture.card = card;
-            forceCaptureResponse response = litle.ForceCapture(forcecapture);
+            var response = litle.ForceCapture(forcecapture);
             Assert.AreEqual("Approved", response.message);
         }
     }

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestForceCapture.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestForceCapture.cs
@@ -1,17 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Text;
-using NUnit.Framework;
-using Litle.Sdk;
-using Moq;
 using System.Text.RegularExpressions;
-
+using Moq;
+using NUnit.Framework;
 
 namespace Litle.Sdk.Test.Unit
 {
     [TestFixture]
-    class TestForceCapture
+    internal class TestForceCapture
     {
         private LitleOnline litle;
         private IDictionary<string, StringBuilder> _memoryStreams;
@@ -26,7 +22,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestSecondaryAmount()
         {
-            forceCapture capture = new forceCapture();
+            var capture = new forceCapture();
             capture.amount = 2;
             capture.secondaryAmount = 1;
             capture.orderSource = orderSourceType.ecommerce;
@@ -34,10 +30,16 @@ namespace Litle.Sdk.Test.Unit
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<secondaryAmount>1</secondaryAmount>\r\n<orderSource>ecommerce</orderSource>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><forceCaptureResponse><litleTxnId>123</litleTxnId></forceCaptureResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*<amount>2</amount>\r\n<secondaryAmount>1</secondaryAmount>\r\n<orderSource>ecommerce</orderSource>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><forceCaptureResponse><litleTxnId>123</litleTxnId></forceCaptureResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.ForceCapture(capture);
         }
@@ -45,7 +47,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestSurchargeAmount()
         {
-            forceCapture capture = new forceCapture();
+            var capture = new forceCapture();
             capture.amount = 2;
             capture.surchargeAmount = 1;
             capture.orderSource = orderSourceType.ecommerce;
@@ -53,10 +55,16 @@ namespace Litle.Sdk.Test.Unit
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<surchargeAmount>1</surchargeAmount>\r\n<orderSource>ecommerce</orderSource>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><forceCaptureResponse><litleTxnId>123</litleTxnId></forceCaptureResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*<amount>2</amount>\r\n<surchargeAmount>1</surchargeAmount>\r\n<orderSource>ecommerce</orderSource>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><forceCaptureResponse><litleTxnId>123</litleTxnId></forceCaptureResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.ForceCapture(capture);
         }
@@ -65,17 +73,22 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestSurchargeAmount_Optional()
         {
-            forceCapture capture = new forceCapture();
+            var capture = new forceCapture();
             capture.amount = 2;
             capture.orderSource = orderSourceType.ecommerce;
             capture.reportGroup = "Planets";
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<orderSource>ecommerce</orderSource>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><forceCaptureResponse><litleTxnId>123</litleTxnId></forceCaptureResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(".*<amount>2</amount>\r\n<orderSource>ecommerce</orderSource>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><forceCaptureResponse><litleTxnId>123</litleTxnId></forceCaptureResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.ForceCapture(capture);
         }
@@ -83,16 +96,21 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestDebtRepayment_True()
         {
-            forceCapture forceCapture = new forceCapture();
+            var forceCapture = new forceCapture();
             forceCapture.merchantData = new merchantDataType();
             forceCapture.debtRepayment = true;
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*</merchantData>\r\n<debtRepayment>true</debtRepayment>\r\n</forceCapture>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.19' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><forceCaptureResponse><litleTxnId>123</litleTxnId></forceCaptureResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(".*</merchantData>\r\n<debtRepayment>true</debtRepayment>\r\n</forceCapture>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.19' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><forceCaptureResponse><litleTxnId>123</litleTxnId></forceCaptureResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.ForceCapture(forceCapture);
         }
@@ -100,16 +118,21 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestDebtRepayment_False()
         {
-            forceCapture forceCapture = new forceCapture();
+            var forceCapture = new forceCapture();
             forceCapture.merchantData = new merchantDataType();
             forceCapture.debtRepayment = false;
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*</merchantData>\r\n<debtRepayment>false</debtRepayment>\r\n</forceCapture>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.19' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><forceCaptureResponse><litleTxnId>123</litleTxnId></forceCaptureResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(".*</merchantData>\r\n<debtRepayment>false</debtRepayment>\r\n</forceCapture>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.19' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><forceCaptureResponse><litleTxnId>123</litleTxnId></forceCaptureResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.ForceCapture(forceCapture);
         }
@@ -117,20 +140,22 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestDebtRepayment_Optional()
         {
-            forceCapture forceCapture = new forceCapture();
+            var forceCapture = new forceCapture();
             forceCapture.merchantData = new merchantDataType();
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*</merchantData>\r\n</forceCapture>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.19' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><forceCaptureResponse><litleTxnId>123</litleTxnId></forceCaptureResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(".*</merchantData>\r\n</forceCapture>.*", RegexOptions.Singleline),
+                        It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.19' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><forceCaptureResponse><litleTxnId>123</litleTxnId></forceCaptureResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.ForceCapture(forceCapture);
         }
-
-
-
     }
 }

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestForceCapture.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestForceCapture.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -12,13 +13,14 @@ namespace Litle.Sdk.Test.Unit
     [TestFixture]
     class TestForceCapture
     {
-        
         private LitleOnline litle;
+        private IDictionary<string, StringBuilder> _memoryStreams;
 
         [TestFixtureSetUp]
         public void SetUpLitle()
         {
-            litle = new LitleOnline();
+            _memoryStreams = new Dictionary<string, StringBuilder>();
+            litle = new LitleOnline(_memoryStreams);
         }
 
         [Test]
@@ -30,7 +32,7 @@ namespace Litle.Sdk.Test.Unit
             capture.orderSource = orderSourceType.ecommerce;
             capture.reportGroup = "Planets";
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<secondaryAmount>1</secondaryAmount>\r\n<orderSource>ecommerce</orderSource>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><forceCaptureResponse><litleTxnId>123</litleTxnId></forceCaptureResponse></litleOnlineResponse>");
@@ -49,7 +51,7 @@ namespace Litle.Sdk.Test.Unit
             capture.orderSource = orderSourceType.ecommerce;
             capture.reportGroup = "Planets";
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<surchargeAmount>1</surchargeAmount>\r\n<orderSource>ecommerce</orderSource>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><forceCaptureResponse><litleTxnId>123</litleTxnId></forceCaptureResponse></litleOnlineResponse>");
@@ -68,7 +70,7 @@ namespace Litle.Sdk.Test.Unit
             capture.orderSource = orderSourceType.ecommerce;
             capture.reportGroup = "Planets";
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<orderSource>ecommerce</orderSource>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><forceCaptureResponse><litleTxnId>123</litleTxnId></forceCaptureResponse></litleOnlineResponse>");
@@ -85,7 +87,7 @@ namespace Litle.Sdk.Test.Unit
             forceCapture.merchantData = new merchantDataType();
             forceCapture.debtRepayment = true;
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*</merchantData>\r\n<debtRepayment>true</debtRepayment>\r\n</forceCapture>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.19' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><forceCaptureResponse><litleTxnId>123</litleTxnId></forceCaptureResponse></litleOnlineResponse>");
@@ -102,7 +104,7 @@ namespace Litle.Sdk.Test.Unit
             forceCapture.merchantData = new merchantDataType();
             forceCapture.debtRepayment = false;
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*</merchantData>\r\n<debtRepayment>false</debtRepayment>\r\n</forceCapture>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.19' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><forceCaptureResponse><litleTxnId>123</litleTxnId></forceCaptureResponse></litleOnlineResponse>");
@@ -118,7 +120,7 @@ namespace Litle.Sdk.Test.Unit
             forceCapture forceCapture = new forceCapture();
             forceCapture.merchantData = new merchantDataType();
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*</merchantData>\r\n</forceCapture>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.19' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><forceCaptureResponse><litleTxnId>123</litleTxnId></forceCaptureResponse></litleOnlineResponse>");

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestLitleOnline.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestLitleOnline.cs
@@ -1,17 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Text;
-using NUnit.Framework;
-using Litle.Sdk;
-using Moq;
 using System.Text.RegularExpressions;
-
+using Moq;
+using NUnit.Framework;
 
 namespace Litle.Sdk.Test.Unit
 {
     [TestFixture]
-    class TestLitleOnline
+    internal class TestLitleOnline
     {
         private LitleOnline litle;
         private IDictionary<string, StringBuilder> _memoryStreams;
@@ -26,52 +23,64 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestAuth()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.reportGroup = "Planets";
             authorization.orderId = "12344";
             authorization.amount = 106;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000002";
             card.expDate = "1210";
             authorization.card = card;
-           
+
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<litleOnlineRequest.*<authorization.*<card>.*<number>4100000000000002</number>.*</card>.*</authorization>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
-     
-            Communications mockedCommunication = mock.Object;
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*<litleOnlineRequest.*<authorization.*<card>.*<number>4100000000000002</number>.*</card>.*</authorization>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
+
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            authorizationResponse authorize = litle.Authorize(authorization);
+            var authorize = litle.Authorize(authorization);
             Assert.AreEqual(123, authorize.litleTxnId);
         }
 
         [Test]
         public void testAuthReversal()
         {
-            authReversal authreversal = new authReversal();
+            var authreversal = new authReversal();
             authreversal.litleTxnId = 12345678000;
             authreversal.amount = 106;
             authreversal.payPalNotes = "Notes";
-            
+
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<authReversal.*?<litleTxnId>12345678000</litleTxnId>.*?</authReversal>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authReversalResponse><litleTxnId>123</litleTxnId></authReversalResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*?<litleOnlineRequest.*?<authReversal.*?<litleTxnId>12345678000</litleTxnId>.*?</authReversal>.*?",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authReversalResponse><litleTxnId>123</litleTxnId></authReversalResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            authReversalResponse authreversalresponse = litle.AuthReversal(authreversal);
+            var authreversalresponse = litle.AuthReversal(authreversal);
             Assert.AreEqual(123, authreversalresponse.litleTxnId);
         }
 
         [Test]
         public void testCapture()
         {
-            capture caputure = new capture();
+            var caputure = new capture();
             caputure.litleTxnId = 123456000;
             caputure.amount = 106;
             caputure.payPalNotes = "Notes";
@@ -79,28 +88,34 @@ namespace Litle.Sdk.Test.Unit
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<capture.*?<litleTxnId>123456000</litleTxnId>.*?</capture>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><captureResponse><litleTxnId>123</litleTxnId></captureResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*?<litleOnlineRequest.*?<capture.*?<litleTxnId>123456000</litleTxnId>.*?</capture>.*?",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><captureResponse><litleTxnId>123</litleTxnId></captureResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            captureResponse captureresponse = litle.Capture(caputure);
+            var captureresponse = litle.Capture(caputure);
             Assert.AreEqual(123, captureresponse.litleTxnId);
         }
 
         [Test]
         public void testCaptureGivenAuth()
         {
-            captureGivenAuth capturegivenauth = new captureGivenAuth();
+            var capturegivenauth = new captureGivenAuth();
             capturegivenauth.orderId = "12344";
             capturegivenauth.amount = 106;
-            authInformation authinfo = new authInformation();
+            var authinfo = new authInformation();
             authinfo.authDate = new DateTime(2002, 10, 9);
             authinfo.authCode = "543216";
             authinfo.authAmount = 12345;
             capturegivenauth.authInformation = authinfo;
             capturegivenauth.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000001";
             card.expDate = "1210";
@@ -108,23 +123,29 @@ namespace Litle.Sdk.Test.Unit
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<captureGivenAuth.*?<card>.*?<number>4100000000000001</number>.*?</card>.*?</captureGivenAuth>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><captureGivenAuthResponse><litleTxnId>123</litleTxnId></captureGivenAuthResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*?<litleOnlineRequest.*?<captureGivenAuth.*?<card>.*?<number>4100000000000001</number>.*?</card>.*?</captureGivenAuth>.*?",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><captureGivenAuthResponse><litleTxnId>123</litleTxnId></captureGivenAuthResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            captureGivenAuthResponse caputregivenauthresponse = litle.CaptureGivenAuth(capturegivenauth);
+            var caputregivenauthresponse = litle.CaptureGivenAuth(capturegivenauth);
             Assert.AreEqual(123, caputregivenauthresponse.litleTxnId);
         }
 
         [Test]
         public void testCredit()
         {
-            credit credit = new credit();
+            var credit = new credit();
             credit.orderId = "12344";
             credit.amount = 106;
             credit.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000001";
             card.expDate = "1210";
@@ -132,96 +153,120 @@ namespace Litle.Sdk.Test.Unit
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<credit.*?<card>.*?<number>4100000000000001</number>.*?</card>.*?</credit>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><creditResponse><litleTxnId>123</litleTxnId></creditResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*?<litleOnlineRequest.*?<credit.*?<card>.*?<number>4100000000000001</number>.*?</card>.*?</credit>.*?",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><creditResponse><litleTxnId>123</litleTxnId></creditResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            creditResponse creditresponse = litle.Credit(credit);
+            var creditresponse = litle.Credit(credit);
             Assert.AreEqual(123, creditresponse.litleTxnId);
         }
 
         [Test]
         public void testEcheckCredit()
         {
-            echeckCredit echeckcredit = new echeckCredit();
+            var echeckcredit = new echeckCredit();
             echeckcredit.amount = 12;
             echeckcredit.litleTxnId = 123456789101112;
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<echeckCredit.*?<litleTxnId>123456789101112</litleTxnId>.*?</echeckCredit>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><echeckCreditResponse><litleTxnId>123</litleTxnId></echeckCreditResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*?<litleOnlineRequest.*?<echeckCredit.*?<litleTxnId>123456789101112</litleTxnId>.*?</echeckCredit>.*?",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><echeckCreditResponse><litleTxnId>123</litleTxnId></echeckCreditResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            echeckCreditResponse echeckcreditresponse = litle.EcheckCredit(echeckcredit);
+            var echeckcreditresponse = litle.EcheckCredit(echeckcredit);
             Assert.AreEqual(123, echeckcreditresponse.litleTxnId);
         }
 
         [Test]
         public void testEcheckRedeposit()
         {
-            echeckRedeposit echeckredeposit = new echeckRedeposit();
+            var echeckredeposit = new echeckRedeposit();
             echeckredeposit.litleTxnId = 123456;
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<echeckRedeposit.*?<litleTxnId>123456</litleTxnId>.*?</echeckRedeposit>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><echeckRedepositResponse><litleTxnId>123</litleTxnId></echeckRedepositResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*?<litleOnlineRequest.*?<echeckRedeposit.*?<litleTxnId>123456</litleTxnId>.*?</echeckRedeposit>.*?",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><echeckRedepositResponse><litleTxnId>123</litleTxnId></echeckRedepositResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            echeckRedepositResponse echeckredepositresponse = litle.EcheckRedeposit(echeckredeposit);
+            var echeckredepositresponse = litle.EcheckRedeposit(echeckredeposit);
             Assert.AreEqual(123, echeckredepositresponse.litleTxnId);
         }
 
         [Test]
         public void testEcheckSale()
         {
-            echeckSale echecksale = new echeckSale();
+            var echecksale = new echeckSale();
             echecksale.orderId = "12345";
             echecksale.amount = 123456;
             echecksale.orderSource = orderSourceType.ecommerce;
-            echeckType echeck = new echeckType();
+            var echeck = new echeckType();
             echeck.accType = echeckAccountTypeEnum.Checking;
             echeck.accNum = "12345657890";
             echeck.routingNum = "123456789";
             echeck.checkNum = "123455";
             echecksale.echeck = echeck;
-            contact contact = new contact();
+            var contact = new contact();
             contact.name = "Bob";
             contact.city = "lowell";
             contact.state = "MA";
             contact.email = "litle.com";
             echecksale.billToAddress = contact;
-            
+
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<echeckSale.*?<echeck>.*?<accNum>12345657890</accNum>.*?</echeck>.*?</echeckSale>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><echeckSalesResponse><litleTxnId>123</litleTxnId></echeckSalesResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*?<litleOnlineRequest.*?<echeckSale.*?<echeck>.*?<accNum>12345657890</accNum>.*?</echeck>.*?</echeckSale>.*?",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><echeckSalesResponse><litleTxnId>123</litleTxnId></echeckSalesResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            echeckSalesResponse echecksaleresponse = litle.EcheckSale(echecksale);
+            var echecksaleresponse = litle.EcheckSale(echecksale);
             Assert.AreEqual(123, echecksaleresponse.litleTxnId);
         }
 
         [Test]
         public void testEcheckVerification()
         {
-            echeckVerification echeckverification = new echeckVerification();
+            var echeckverification = new echeckVerification();
             echeckverification.orderId = "12345";
             echeckverification.amount = 123456;
             echeckverification.orderSource = orderSourceType.ecommerce;
-            echeckType echeck = new echeckType();
+            var echeck = new echeckType();
             echeck.accType = echeckAccountTypeEnum.Checking;
             echeck.accNum = "12345657890";
             echeck.routingNum = "123456789";
             echeck.checkNum = "123455";
             echeckverification.echeck = echeck;
-            contact contact = new contact();
+            var contact = new contact();
             contact.name = "Bob";
             contact.city = "lowell";
             contact.state = "MA";
@@ -231,23 +276,29 @@ namespace Litle.Sdk.Test.Unit
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<echeckVerification.*?<echeck>.*?<accNum>12345657890</accNum>.*?</echeck>.*?</echeckVerification>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><echeckVerificationResponse><litleTxnId>123</litleTxnId></echeckVerificationResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*?<litleOnlineRequest.*?<echeckVerification.*?<echeck>.*?<accNum>12345657890</accNum>.*?</echeck>.*?</echeckVerification>.*?",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><echeckVerificationResponse><litleTxnId>123</litleTxnId></echeckVerificationResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            echeckVerificationResponse echeckverificaitonresponse = litle.EcheckVerification(echeckverification);
+            var echeckverificaitonresponse = litle.EcheckVerification(echeckverification);
             Assert.AreEqual(123, echeckverificaitonresponse.litleTxnId);
         }
 
         [Test]
         public void testForceCapture()
         {
-            forceCapture forcecapture = new forceCapture();
+            var forcecapture = new forceCapture();
             forcecapture.orderId = "12344";
             forcecapture.amount = 106;
             forcecapture.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000001";
             card.expDate = "1210";
@@ -255,23 +306,29 @@ namespace Litle.Sdk.Test.Unit
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<forceCapture.*?<card>.*?<number>4100000000000001</number>.*?</card>.*?</forceCapture>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><forceCaptureResponse><litleTxnId>123</litleTxnId></forceCaptureResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*?<litleOnlineRequest.*?<forceCapture.*?<card>.*?<number>4100000000000001</number>.*?</card>.*?</forceCapture>.*?",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><forceCaptureResponse><litleTxnId>123</litleTxnId></forceCaptureResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            forceCaptureResponse forcecaptureresponse = litle.ForceCapture(forcecapture);
+            var forcecaptureresponse = litle.ForceCapture(forcecapture);
             Assert.AreEqual(123, forcecaptureresponse.litleTxnId);
         }
 
         [Test]
         public void testSale()
         {
-            sale sale = new sale();
+            var sale = new sale();
             sale.orderId = "12344";
             sale.amount = 106;
             sale.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000002";
             card.expDate = "1210";
@@ -279,31 +336,43 @@ namespace Litle.Sdk.Test.Unit
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<sale.*?<card>.*?<number>4100000000000002</number>.*?</card>.*?</sale>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*?<litleOnlineRequest.*?<sale.*?<card>.*?<number>4100000000000002</number>.*?</card>.*?</sale>.*?",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            saleResponse saleresponse = litle.Sale(sale);
+            var saleresponse = litle.Sale(sale);
             Assert.AreEqual(123, saleresponse.litleTxnId);
         }
 
         [Test]
         public void testToken()
         {
-            registerTokenRequestType token = new registerTokenRequestType();
+            var token = new registerTokenRequestType();
             token.orderId = "12344";
             token.accountNumber = "1233456789103801";
-            
+
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<registerTokenRequest.*?<accountNumber>1233456789103801</accountNumber>.*?</registerTokenRequest>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><registerTokenResponse><litleTxnId>123</litleTxnId></registerTokenResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*?<litleOnlineRequest.*?<registerTokenRequest.*?<accountNumber>1233456789103801</accountNumber>.*?</registerTokenRequest>.*?",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><registerTokenResponse><litleTxnId>123</litleTxnId></registerTokenResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            registerTokenResponse registertokenresponse = litle.RegisterToken(token);
+            var registertokenresponse = litle.RegisterToken(token);
             Assert.AreEqual(123, registertokenresponse.litleTxnId);
             Assert.IsNull(registertokenresponse.type);
         }
@@ -311,141 +380,179 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void testActivate()
         {
-            activate activate = new activate();
+            var activate = new activate();
             activate.orderId = "2";
             activate.orderSource = orderSourceType.ecommerce;
             activate.card = new cardType();
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<activate.*?<orderId>2</orderId>.*?</activate>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.21' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><activateResponse><litleTxnId>123</litleTxnId></activateResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(".*?<litleOnlineRequest.*?<activate.*?<orderId>2</orderId>.*?</activate>.*?",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.21' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><activateResponse><litleTxnId>123</litleTxnId></activateResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            activateResponse activateResponse = litle.Activate(activate);
+            var activateResponse = litle.Activate(activate);
             Assert.AreEqual("123", activateResponse.litleTxnId);
         }
 
         [Test]
         public void testDeactivate()
         {
-            deactivate deactivate = new deactivate();
+            var deactivate = new deactivate();
             deactivate.orderId = "2";
             deactivate.orderSource = orderSourceType.ecommerce;
             deactivate.card = new cardType();
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<deactivate.*?<orderId>2</orderId>.*?</deactivate>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.21' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><deactivateResponse><litleTxnId>123</litleTxnId></deactivateResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(".*?<litleOnlineRequest.*?<deactivate.*?<orderId>2</orderId>.*?</deactivate>.*?",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.21' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><deactivateResponse><litleTxnId>123</litleTxnId></deactivateResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            deactivateResponse deactivateResponse = litle.Deactivate(deactivate);
+            var deactivateResponse = litle.Deactivate(deactivate);
             Assert.AreEqual("123", deactivateResponse.litleTxnId);
         }
 
         [Test]
         public void testLoad()
         {
-            load load = new load();
+            var load = new load();
             load.orderId = "2";
             load.orderSource = orderSourceType.ecommerce;
             load.card = new cardType();
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<load.*?<orderId>2</orderId>.*?</load>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.21' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><loadResponse><litleTxnId>123</litleTxnId></loadResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(".*?<litleOnlineRequest.*?<load.*?<orderId>2</orderId>.*?</load>.*?",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.21' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><loadResponse><litleTxnId>123</litleTxnId></loadResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            loadResponse loadResponse = litle.Load(load);
+            var loadResponse = litle.Load(load);
             Assert.AreEqual("123", loadResponse.litleTxnId);
         }
 
         [Test]
         public void testUnload()
         {
-            unload unload = new unload();
+            var unload = new unload();
             unload.orderId = "2";
             unload.orderSource = orderSourceType.ecommerce;
             unload.card = new cardType();
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<unload.*?<orderId>2</orderId>.*?</unload>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.21' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><unloadResponse><litleTxnId>123</litleTxnId></unloadResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(".*?<litleOnlineRequest.*?<unload.*?<orderId>2</orderId>.*?</unload>.*?",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.21' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><unloadResponse><litleTxnId>123</litleTxnId></unloadResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            unloadResponse unloadResponse = litle.Unload(unload);
+            var unloadResponse = litle.Unload(unload);
             Assert.AreEqual("123", unloadResponse.litleTxnId);
         }
 
         [Test]
         public void testBalanceInquiry()
         {
-            balanceInquiry balanceInquiry = new balanceInquiry();
+            var balanceInquiry = new balanceInquiry();
             balanceInquiry.orderId = "2";
             balanceInquiry.orderSource = orderSourceType.ecommerce;
             balanceInquiry.card = new cardType();
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<balanceInquiry.*?<orderId>2</orderId>.*?</balanceInquiry>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.21' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><balanceInquiryResponse><litleTxnId>123</litleTxnId></balanceInquiryResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*?<litleOnlineRequest.*?<balanceInquiry.*?<orderId>2</orderId>.*?</balanceInquiry>.*?",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.21' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><balanceInquiryResponse><litleTxnId>123</litleTxnId></balanceInquiryResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            balanceInquiryResponse balanceInquiryResponse = litle.BalanceInquiry(balanceInquiry);
+            var balanceInquiryResponse = litle.BalanceInquiry(balanceInquiry);
             Assert.AreEqual("123", balanceInquiryResponse.litleTxnId);
         }
 
         [Test]
         public void testCreatePlan()
         {
-            createPlan createPlan = new createPlan();
+            var createPlan = new createPlan();
             createPlan.planCode = "theCode";
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<createPlan.*?<planCode>theCode</planCode>.*?</createPlan>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.21' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><createPlanResponse><planCode>theCode</planCode></createPlanResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*?<litleOnlineRequest.*?<createPlan.*?<planCode>theCode</planCode>.*?</createPlan>.*?",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.21' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><createPlanResponse><planCode>theCode</planCode></createPlanResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            createPlanResponse createPlanResponse = litle.CreatePlan(createPlan);
+            var createPlanResponse = litle.CreatePlan(createPlan);
             Assert.AreEqual("theCode", createPlanResponse.planCode);
         }
 
         [Test]
         public void testUpdatePlan()
         {
-            updatePlan updatePlan = new updatePlan();
+            var updatePlan = new updatePlan();
             updatePlan.planCode = "theCode";
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<updatePlan.*?<planCode>theCode</planCode>.*?</updatePlan>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.21' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><updatePlanResponse><planCode>theCode</planCode></updatePlanResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*?<litleOnlineRequest.*?<updatePlan.*?<planCode>theCode</planCode>.*?</updatePlan>.*?",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.21' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><updatePlanResponse><planCode>theCode</planCode></updatePlanResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            updatePlanResponse updatePlanResponse = litle.UpdatePlan(updatePlan);
+            var updatePlanResponse = litle.UpdatePlan(updatePlan);
             Assert.AreEqual("theCode", updatePlanResponse.planCode);
         }
 
         [Test]
         public void testLitleOnlineException()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.reportGroup = "Planets";
             authorization.orderId = "12344";
             authorization.amount = 106;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000002";
             card.expDate = "1210";
@@ -453,10 +560,16 @@ namespace Litle.Sdk.Test.Unit
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<authorization.*?<card>.*?<number>4100000000000002</number>.*?</card>.*?</authorization>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.10' response='1' message='Error validating xml data against the schema' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*?<litleOnlineRequest.*?<authorization.*?<card>.*?<number>4100000000000002</number>.*?</card>.*?</authorization>.*?",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.10' response='1' message='Error validating xml data against the schema' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             try
             {
@@ -471,12 +584,12 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void testInvalidOperationException()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.reportGroup = "Planets";
             authorization.orderId = "12344";
             authorization.amount = 106;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000002";
             card.expDate = "1210";
@@ -484,10 +597,15 @@ namespace Litle.Sdk.Test.Unit
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<authorization.*?<card>.*?<number>4100000000000002</number>.*?</card>.*?</authorization>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*?<litleOnlineRequest.*?<authorization.*?<card>.*?<number>4100000000000002</number>.*?</card>.*?</authorization>.*?",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
                 .Returns("no xml");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             try
             {
@@ -502,11 +620,11 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void testDefaultReportGroup()
         {
-            authorization authorization = new authorization();
+            var authorization = new authorization();
             authorization.orderId = "12344";
             authorization.amount = 106;
             authorization.orderSource = orderSourceType.ecommerce;
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.VI;
             card.number = "4100000000000002";
             card.expDate = "1210";
@@ -514,20 +632,24 @@ namespace Litle.Sdk.Test.Unit
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<authorization.*? reportGroup=\"Default Report Group\">.*?<card>.*?<number>4100000000000002</number>.*?</card>.*?</authorization>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse reportGroup='Default Report Group'></authorizationResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*?<litleOnlineRequest.*?<authorization.*? reportGroup=\"Default Report Group\">.*?<card>.*?<number>4100000000000002</number>.*?</card>.*?</authorization>.*?",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse reportGroup='Default Report Group'></authorizationResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            authorizationResponse authorize = litle.Authorize(authorization);
+            var authorize = litle.Authorize(authorization);
             Assert.AreEqual("Default Report Group", authorize.reportGroup);
         }
 
         [Test]
         public void testSetMerchantSdk()
         {
-
         }
-            
     }
 }

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestLitleOnline.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestLitleOnline.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -12,13 +13,14 @@ namespace Litle.Sdk.Test.Unit
     [TestFixture]
     class TestLitleOnline
     {
-        
         private LitleOnline litle;
+        private IDictionary<string, StringBuilder> _memoryStreams;
 
         [TestFixtureSetUp]
         public void SetUpLitle()
         {
-            litle = new LitleOnline();
+            _memoryStreams = new Dictionary<string, StringBuilder>();
+            litle = new LitleOnline(_memoryStreams);
         }
 
         [Test]
@@ -35,7 +37,7 @@ namespace Litle.Sdk.Test.Unit
             card.expDate = "1210";
             authorization.card = card;
            
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<litleOnlineRequest.*<authorization.*<card>.*<number>4100000000000002</number>.*</card>.*</authorization>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
@@ -55,7 +57,7 @@ namespace Litle.Sdk.Test.Unit
             authreversal.payPalNotes = "Notes";
             
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<authReversal.*?<litleTxnId>12345678000</litleTxnId>.*?</authReversal>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authReversalResponse><litleTxnId>123</litleTxnId></authReversalResponse></litleOnlineResponse>");
@@ -75,7 +77,7 @@ namespace Litle.Sdk.Test.Unit
             caputure.payPalNotes = "Notes";
 
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<capture.*?<litleTxnId>123456000</litleTxnId>.*?</capture>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><captureResponse><litleTxnId>123</litleTxnId></captureResponse></litleOnlineResponse>");
@@ -104,7 +106,7 @@ namespace Litle.Sdk.Test.Unit
             card.expDate = "1210";
             capturegivenauth.card = card;
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<captureGivenAuth.*?<card>.*?<number>4100000000000001</number>.*?</card>.*?</captureGivenAuth>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><captureGivenAuthResponse><litleTxnId>123</litleTxnId></captureGivenAuthResponse></litleOnlineResponse>");
@@ -128,7 +130,7 @@ namespace Litle.Sdk.Test.Unit
             card.expDate = "1210";
             credit.card = card;
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<credit.*?<card>.*?<number>4100000000000001</number>.*?</card>.*?</credit>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><creditResponse><litleTxnId>123</litleTxnId></creditResponse></litleOnlineResponse>");
@@ -146,7 +148,7 @@ namespace Litle.Sdk.Test.Unit
             echeckcredit.amount = 12;
             echeckcredit.litleTxnId = 123456789101112;
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<echeckCredit.*?<litleTxnId>123456789101112</litleTxnId>.*?</echeckCredit>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><echeckCreditResponse><litleTxnId>123</litleTxnId></echeckCreditResponse></litleOnlineResponse>");
@@ -163,7 +165,7 @@ namespace Litle.Sdk.Test.Unit
             echeckRedeposit echeckredeposit = new echeckRedeposit();
             echeckredeposit.litleTxnId = 123456;
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<echeckRedeposit.*?<litleTxnId>123456</litleTxnId>.*?</echeckRedeposit>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><echeckRedepositResponse><litleTxnId>123</litleTxnId></echeckRedepositResponse></litleOnlineResponse>");
@@ -195,7 +197,7 @@ namespace Litle.Sdk.Test.Unit
             echecksale.billToAddress = contact;
             
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<echeckSale.*?<echeck>.*?<accNum>12345657890</accNum>.*?</echeck>.*?</echeckSale>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><echeckSalesResponse><litleTxnId>123</litleTxnId></echeckSalesResponse></litleOnlineResponse>");
@@ -227,7 +229,7 @@ namespace Litle.Sdk.Test.Unit
             echeckverification.billToAddress = contact;
 
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<echeckVerification.*?<echeck>.*?<accNum>12345657890</accNum>.*?</echeck>.*?</echeckVerification>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><echeckVerificationResponse><litleTxnId>123</litleTxnId></echeckVerificationResponse></litleOnlineResponse>");
@@ -251,7 +253,7 @@ namespace Litle.Sdk.Test.Unit
             card.expDate = "1210";
             forcecapture.card = card;
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<forceCapture.*?<card>.*?<number>4100000000000001</number>.*?</card>.*?</forceCapture>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><forceCaptureResponse><litleTxnId>123</litleTxnId></forceCaptureResponse></litleOnlineResponse>");
@@ -275,7 +277,7 @@ namespace Litle.Sdk.Test.Unit
             card.expDate = "1210";
             sale.card = card;
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<sale.*?<card>.*?<number>4100000000000002</number>.*?</card>.*?</sale>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");
@@ -294,7 +296,7 @@ namespace Litle.Sdk.Test.Unit
             token.accountNumber = "1233456789103801";
             
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<registerTokenRequest.*?<accountNumber>1233456789103801</accountNumber>.*?</registerTokenRequest>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><registerTokenResponse><litleTxnId>123</litleTxnId></registerTokenResponse></litleOnlineResponse>");
@@ -314,7 +316,7 @@ namespace Litle.Sdk.Test.Unit
             activate.orderSource = orderSourceType.ecommerce;
             activate.card = new cardType();
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<activate.*?<orderId>2</orderId>.*?</activate>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.21' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><activateResponse><litleTxnId>123</litleTxnId></activateResponse></litleOnlineResponse>");
@@ -333,7 +335,7 @@ namespace Litle.Sdk.Test.Unit
             deactivate.orderSource = orderSourceType.ecommerce;
             deactivate.card = new cardType();
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<deactivate.*?<orderId>2</orderId>.*?</deactivate>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.21' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><deactivateResponse><litleTxnId>123</litleTxnId></deactivateResponse></litleOnlineResponse>");
@@ -352,7 +354,7 @@ namespace Litle.Sdk.Test.Unit
             load.orderSource = orderSourceType.ecommerce;
             load.card = new cardType();
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<load.*?<orderId>2</orderId>.*?</load>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.21' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><loadResponse><litleTxnId>123</litleTxnId></loadResponse></litleOnlineResponse>");
@@ -371,7 +373,7 @@ namespace Litle.Sdk.Test.Unit
             unload.orderSource = orderSourceType.ecommerce;
             unload.card = new cardType();
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<unload.*?<orderId>2</orderId>.*?</unload>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.21' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><unloadResponse><litleTxnId>123</litleTxnId></unloadResponse></litleOnlineResponse>");
@@ -390,7 +392,7 @@ namespace Litle.Sdk.Test.Unit
             balanceInquiry.orderSource = orderSourceType.ecommerce;
             balanceInquiry.card = new cardType();
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<balanceInquiry.*?<orderId>2</orderId>.*?</balanceInquiry>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.21' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><balanceInquiryResponse><litleTxnId>123</litleTxnId></balanceInquiryResponse></litleOnlineResponse>");
@@ -407,7 +409,7 @@ namespace Litle.Sdk.Test.Unit
             createPlan createPlan = new createPlan();
             createPlan.planCode = "theCode";
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<createPlan.*?<planCode>theCode</planCode>.*?</createPlan>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.21' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><createPlanResponse><planCode>theCode</planCode></createPlanResponse></litleOnlineResponse>");
@@ -424,7 +426,7 @@ namespace Litle.Sdk.Test.Unit
             updatePlan updatePlan = new updatePlan();
             updatePlan.planCode = "theCode";
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<updatePlan.*?<planCode>theCode</planCode>.*?</updatePlan>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.21' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><updatePlanResponse><planCode>theCode</planCode></updatePlanResponse></litleOnlineResponse>");
@@ -449,7 +451,7 @@ namespace Litle.Sdk.Test.Unit
             card.expDate = "1210";
             authorization.card = card;
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<authorization.*?<card>.*?<number>4100000000000002</number>.*?</card>.*?</authorization>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.10' response='1' message='Error validating xml data against the schema' xmlns='http://www.litle.com/schema'><authorizationResponse><litleTxnId>123</litleTxnId></authorizationResponse></litleOnlineResponse>");
@@ -480,7 +482,7 @@ namespace Litle.Sdk.Test.Unit
             card.expDate = "1210";
             authorization.card = card;
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<authorization.*?<card>.*?<number>4100000000000002</number>.*?</card>.*?</authorization>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("no xml");
@@ -510,7 +512,7 @@ namespace Litle.Sdk.Test.Unit
             card.expDate = "1210";
             authorization.card = card;
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<authorization.*? reportGroup=\"Default Report Group\">.*?<card>.*?<number>4100000000000002</number>.*?</card>.*?</authorization>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><authorizationResponse reportGroup='Default Report Group'></authorizationResponse></litleOnlineResponse>");

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestLoadReversal.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestLoadReversal.cs
@@ -1,17 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Text;
-using NUnit.Framework;
-using Litle.Sdk;
-using Moq;
 using System.Text.RegularExpressions;
-
+using Moq;
+using NUnit.Framework;
 
 namespace Litle.Sdk.Test.Unit
 {
     [TestFixture]
-    class TestLoadReversal
+    internal class TestLoadReversal
     {
         private LitleOnline litle;
         private IDictionary<string, StringBuilder> _memoryStreams;
@@ -26,22 +22,24 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestSimple()
         {
-            loadReversal loadReversal = new loadReversal();
+            var loadReversal = new loadReversal();
             loadReversal.id = "a";
             loadReversal.reportGroup = "b";
             loadReversal.litleTxnId = "123";
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<litleTxnId>123</litleTxnId>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><loadReversalResponse><litleTxnId>123</litleTxnId></loadReversalResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(It.IsRegex(".*<litleTxnId>123</litleTxnId>.*", RegexOptions.Singleline),
+                        It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><loadReversalResponse><litleTxnId>123</litleTxnId></loadReversalResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            loadReversalResponse response = litle.LoadReversal(loadReversal);
+            var response = litle.LoadReversal(loadReversal);
             Assert.AreEqual("123", response.litleTxnId);
         }
-
-
     }
 }

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestLoadReversal.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestLoadReversal.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -11,13 +12,15 @@ namespace Litle.Sdk.Test.Unit
 {
     [TestFixture]
     class TestLoadReversal
-    {        
+    {
         private LitleOnline litle;
+        private IDictionary<string, StringBuilder> _memoryStreams;
 
         [TestFixtureSetUp]
         public void SetUpLitle()
         {
-            litle = new LitleOnline();
+            _memoryStreams = new Dictionary<string, StringBuilder>();
+            litle = new LitleOnline(_memoryStreams);
         }
 
         [Test]
@@ -28,7 +31,7 @@ namespace Litle.Sdk.Test.Unit
             loadReversal.reportGroup = "b";
             loadReversal.litleTxnId = "123";
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<litleTxnId>123</litleTxnId>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><loadReversalResponse><litleTxnId>123</litleTxnId></loadReversalResponse></litleOnlineResponse>");

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestRFRRequest.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestRFRRequest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -21,11 +22,13 @@ namespace Litle.Sdk.Test.Unit
 
         private Mock<litleFile> mockLitleFile;
         private Mock<litleTime> mockLitleTime;
+        private IDictionary<string, StringBuilder> _memoryCache;
 
         [TestFixtureSetUp]
         public void setUp()
         {
-            mockLitleFile = new Mock<litleFile>();
+            _memoryCache = new Dictionary<string, StringBuilder>();
+            mockLitleFile = new Mock<litleFile>(_memoryCache);
             mockLitleTime = new Mock<litleTime>();
 
             mockLitleFile.Setup(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object)).Returns(mockFilePath);
@@ -35,7 +38,7 @@ namespace Litle.Sdk.Test.Unit
         [SetUp]
         public void setUpBeforeTest()
         {
-            rfrRequest = new RFRRequest();
+            rfrRequest = new RFRRequest(_memoryCache);
         }
 
         [Test]
@@ -61,7 +64,7 @@ namespace Litle.Sdk.Test.Unit
             mockConfig["requestDirectory"] = "C:\\MockRequests";
             mockConfig["responseDirectory"] = "C:\\MockResponses";
 
-            rfrRequest = new RFRRequest(mockConfig);
+            rfrRequest = new RFRRequest(_memoryCache, mockConfig);
 
             Assert.AreEqual("C:\\MockRequests\\Requests\\", rfrRequest.getRequestDirectory());
             Assert.AreEqual("C:\\MockResponses\\Responses\\", rfrRequest.getResponseDirectory());

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestRFRRequest.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestRFRRequest.cs
@@ -1,16 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Text;
-using NUnit.Framework;
-using Litle.Sdk;
+using Litle.Sdk.Properties;
 using Moq;
-using System.Text.RegularExpressions;
+using NUnit.Framework;
 
 namespace Litle.Sdk.Test.Unit
 {
     [TestFixture]
-    class TestRFRRequest
+    internal class TestRFRRequest
     {
         private RFRRequest rfrRequest;
 
@@ -31,8 +28,12 @@ namespace Litle.Sdk.Test.Unit
             mockLitleFile = new Mock<litleFile>(_memoryCache);
             mockLitleTime = new Mock<litleTime>();
 
-            mockLitleFile.Setup(litleFile => litleFile.createRandomFile(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<String>(), mockLitleTime.Object)).Returns(mockFilePath);
-            mockLitleFile.Setup(litleFile => litleFile.AppendLineToFile(mockFilePath, It.IsAny<String>())).Returns(mockFilePath);
+            mockLitleFile.Setup(
+                litleFile =>
+                    litleFile.createRandomFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        mockLitleTime.Object)).Returns(mockFilePath);
+            mockLitleFile.Setup(litleFile => litleFile.AppendLineToFile(mockFilePath, It.IsAny<string>()))
+                .Returns(mockFilePath);
         }
 
         [SetUp]
@@ -44,7 +45,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void testInitialization()
         {
-            Dictionary<String, String> mockConfig = new Dictionary<string, string>();
+            var mockConfig = new Dictionary<string, string>();
 
             mockConfig["url"] = "https://www.mockurl.com";
             mockConfig["reportGroup"] = "Mock Report Group";
@@ -76,8 +77,8 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void testSerialize()
         {
-            litleFile mockedLitleFile = mockLitleFile.Object;
-            litleTime mockedLitleTime = mockLitleTime.Object;
+            var mockedLitleFile = mockLitleFile.Object;
+            var mockedLitleTime = mockLitleTime.Object;
 
             rfrRequest.litleSessionId = 123456789;
             rfrRequest.setLitleFile(mockedLitleFile);
@@ -85,15 +86,18 @@ namespace Litle.Sdk.Test.Unit
 
             Assert.AreEqual(mockFilePath, rfrRequest.Serialize());
 
-            mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, "\r\n<RFRRequest xmlns=\"http://www.litle.com/schema\">"));
-            mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, "\r\n<litleSessionId>123456789</litleSessionId>"));
+            mockLitleFile.Verify(
+                litleFile =>
+                    litleFile.AppendLineToFile(mockFilePath, "\r\n<RFRRequest xmlns=\"http://www.litle.com/schema\">"));
+            mockLitleFile.Verify(
+                litleFile => litleFile.AppendLineToFile(mockFilePath, "\r\n<litleSessionId>123456789</litleSessionId>"));
             mockLitleFile.Verify(litleFile => litleFile.AppendLineToFile(mockFilePath, "\r\n</RFRRequest>"));
         }
 
         [Test]
-        public void testAccountUpdateFileRequestData() 
+        public void testAccountUpdateFileRequestData()
         {
-            Dictionary<String, String> mockConfig = new Dictionary<string, string>();
+            var mockConfig = new Dictionary<string, string>();
 
             mockConfig["url"] = "https://www.mockurl.com";
             mockConfig["reportGroup"] = "Mock Report Group";
@@ -113,10 +117,10 @@ namespace Litle.Sdk.Test.Unit
             mockConfig["requestDirectory"] = "C:\\MockRequests";
             mockConfig["responseDirectory"] = "C:\\MockResponses";
 
-            accountUpdateFileRequestData accountUpdateFileRequest = new accountUpdateFileRequestData(mockConfig);
-            accountUpdateFileRequestData accountUpdateFileRequestDefault = new accountUpdateFileRequestData();
+            var accountUpdateFileRequest = new accountUpdateFileRequestData(mockConfig);
+            var accountUpdateFileRequestDefault = new accountUpdateFileRequestData();
 
-            Assert.AreEqual(accountUpdateFileRequestDefault.merchantId, Properties.Settings.Default.merchantId);
+            Assert.AreEqual(accountUpdateFileRequestDefault.merchantId, Settings.Default.merchantId);
             Assert.AreEqual(accountUpdateFileRequest.merchantId, mockConfig["merchantId"]);
         }
     }

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestRefundReversal.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestRefundReversal.cs
@@ -1,17 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Text;
-using NUnit.Framework;
-using Litle.Sdk;
-using Moq;
 using System.Text.RegularExpressions;
-
+using Moq;
+using NUnit.Framework;
 
 namespace Litle.Sdk.Test.Unit
 {
     [TestFixture]
-    class TestRefundReversal
+    internal class TestRefundReversal
     {
         private LitleOnline litle;
         private IDictionary<string, StringBuilder> _memoryStreams;
@@ -26,22 +22,24 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestSimple()
         {
-            refundReversal refundReversal = new refundReversal();
+            var refundReversal = new refundReversal();
             refundReversal.id = "a";
             refundReversal.reportGroup = "b";
             refundReversal.litleTxnId = "123";
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<litleTxnId>123</litleTxnId>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><refundReversalResponse><litleTxnId>123</litleTxnId></refundReversalResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(It.IsRegex(".*<litleTxnId>123</litleTxnId>.*", RegexOptions.Singleline),
+                        It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><refundReversalResponse><litleTxnId>123</litleTxnId></refundReversalResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            refundReversalResponse response = litle.RefundReversal(refundReversal);
+            var response = litle.RefundReversal(refundReversal);
             Assert.AreEqual("123", response.litleTxnId);
         }
-
-
     }
 }

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestRefundReversal.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestRefundReversal.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -11,13 +12,15 @@ namespace Litle.Sdk.Test.Unit
 {
     [TestFixture]
     class TestRefundReversal
-    {        
+    {
         private LitleOnline litle;
+        private IDictionary<string, StringBuilder> _memoryStreams;
 
         [TestFixtureSetUp]
         public void SetUpLitle()
         {
-            litle = new LitleOnline();
+            _memoryStreams = new Dictionary<string, StringBuilder>();
+            litle = new LitleOnline(_memoryStreams);
         }
 
         [Test]
@@ -28,7 +31,7 @@ namespace Litle.Sdk.Test.Unit
             refundReversal.reportGroup = "b";
             refundReversal.litleTxnId = "123";
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<litleTxnId>123</litleTxnId>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><refundReversalResponse><litleTxnId>123</litleTxnId></refundReversalResponse></litleOnlineResponse>");

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestRegisterTokenRequest.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestRegisterTokenRequest.cs
@@ -1,19 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Text;
-using NUnit.Framework;
-using Litle.Sdk;
-using Moq;
 using System.Text.RegularExpressions;
-
+using Moq;
+using NUnit.Framework;
 
 namespace Litle.Sdk.Test.Unit
 {
     [TestFixture]
-    class TestRegisterTokenRequest
+    internal class TestRegisterTokenRequest
     {
-
         private LitleOnline litle;
         private IDictionary<string, StringBuilder> _memoryStreams;
 
@@ -27,16 +22,22 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestSimpleRequest()
         {
-            registerTokenRequestType register = new registerTokenRequestType();
+            var register = new registerTokenRequestType();
             register.orderId = "12344";
             register.accountNumber = "4100000000000001";
-           
+
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<registerTokenRequest.*<accountNumber>4100000000000001</accountNumber>.*</registerTokenRequest>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><registerTokenResponse><litleTxnId>4</litleTxnId><response>801</response><message>Token Successfully Registered</message><responseTime>2012-10-10T10:17:03</responseTime></registerTokenResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*<registerTokenRequest.*<accountNumber>4100000000000001</accountNumber>.*</registerTokenRequest>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><registerTokenResponse><litleTxnId>4</litleTxnId><response>801</response><message>Token Successfully Registered</message><responseTime>2012-10-10T10:17:03</responseTime></registerTokenResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.RegisterToken(register);
         }
@@ -44,17 +45,23 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestCanContainCardValidationNum()
         {
-            registerTokenRequestType register = new registerTokenRequestType();
+            var register = new registerTokenRequestType();
             register.orderId = "12344";
             register.accountNumber = "4100000000000001";
             register.cardValidationNum = "123";
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<registerTokenRequest.*<accountNumber>4100000000000001</accountNumber>.*<cardValidationNum>123</cardValidationNum>.*</registerTokenRequest>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><registerTokenResponse><litleTxnId>4</litleTxnId><response>801</response><message>Token Successfully Registered</message><responseTime>2012-10-10T10:17:03</responseTime></registerTokenResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*<registerTokenRequest.*<accountNumber>4100000000000001</accountNumber>.*<cardValidationNum>123</cardValidationNum>.*</registerTokenRequest>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><registerTokenResponse><litleTxnId>4</litleTxnId><response>801</response><message>Token Successfully Registered</message><responseTime>2012-10-10T10:17:03</responseTime></registerTokenResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.RegisterToken(register);
         }
@@ -62,10 +69,10 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestSimpleRequestWithApplepay()
         {
-            registerTokenRequestType register = new registerTokenRequestType();
+            var register = new registerTokenRequestType();
             register.orderId = "12344";
-            applepayType applepay = new applepayType();
-            applepayHeaderType applepayHeaderType = new applepayHeaderType();
+            var applepay = new applepayType();
+            var applepayHeaderType = new applepayHeaderType();
             applepayHeaderType.applicationData = "454657413164";
             applepayHeaderType.ephemeralPublicKey = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
             applepayHeaderType.publicKeyHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
@@ -78,13 +85,18 @@ namespace Litle.Sdk.Test.Unit
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<registerTokenRequest.*<applepay>.*?<data>user</data>.*?</applepay>.*?</registerTokenRequest>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><registerTokenResponse><litleTxnId>4</litleTxnId><response>801</response><message>Token Successfully Registered</message><responseTime>2012-10-10T10:17:03</responseTime></registerTokenResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*<registerTokenRequest.*<applepay>.*?<data>user</data>.*?</applepay>.*?</registerTokenRequest>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><registerTokenResponse><litleTxnId>4</litleTxnId><response>801</response><message>Token Successfully Registered</message><responseTime>2012-10-10T10:17:03</responseTime></registerTokenResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.RegisterToken(register);
         }
-
     }
 }

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestRegisterTokenRequest.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestRegisterTokenRequest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -12,13 +13,15 @@ namespace Litle.Sdk.Test.Unit
     [TestFixture]
     class TestRegisterTokenRequest
     {
-        
+
         private LitleOnline litle;
+        private IDictionary<string, StringBuilder> _memoryStreams;
 
         [TestFixtureSetUp]
         public void SetUpLitle()
         {
-            litle = new LitleOnline();
+            _memoryStreams = new Dictionary<string, StringBuilder>();
+            litle = new LitleOnline(_memoryStreams);
         }
 
         [Test]
@@ -28,7 +31,7 @@ namespace Litle.Sdk.Test.Unit
             register.orderId = "12344";
             register.accountNumber = "4100000000000001";
            
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<registerTokenRequest.*<accountNumber>4100000000000001</accountNumber>.*</registerTokenRequest>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><registerTokenResponse><litleTxnId>4</litleTxnId><response>801</response><message>Token Successfully Registered</message><responseTime>2012-10-10T10:17:03</responseTime></registerTokenResponse></litleOnlineResponse>");
@@ -46,7 +49,7 @@ namespace Litle.Sdk.Test.Unit
             register.accountNumber = "4100000000000001";
             register.cardValidationNum = "123";
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<registerTokenRequest.*<accountNumber>4100000000000001</accountNumber>.*<cardValidationNum>123</cardValidationNum>.*</registerTokenRequest>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><registerTokenResponse><litleTxnId>4</litleTxnId><response>801</response><message>Token Successfully Registered</message><responseTime>2012-10-10T10:17:03</responseTime></registerTokenResponse></litleOnlineResponse>");
@@ -73,7 +76,7 @@ namespace Litle.Sdk.Test.Unit
             applepay.version = "1";
             register.applepay = applepay;
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<registerTokenRequest.*<applepay>.*?<data>user</data>.*?</applepay>.*?</registerTokenRequest>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><registerTokenResponse><litleTxnId>4</litleTxnId><response>801</response><message>Token Successfully Registered</message><responseTime>2012-10-10T10:17:03</responseTime></registerTokenResponse></litleOnlineResponse>");

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestSale.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestSale.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -12,13 +13,14 @@ namespace Litle.Sdk.Test.Unit
     [TestFixture]
     class TestSale
     {
-        
         private LitleOnline litle;
+        private IDictionary<string, StringBuilder> _memoryStreams;
 
         [TestFixtureSetUp]
         public void SetUpLitle()
         {
-            litle = new LitleOnline();
+            _memoryStreams = new Dictionary<string, StringBuilder>();
+            litle = new LitleOnline(_memoryStreams);
         }
 
         [Test]
@@ -31,7 +33,7 @@ namespace Litle.Sdk.Test.Unit
             sale.reportGroup = "Planets";
             sale.fraudFilterOverride = false;
            
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);;
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<fraudFilterOverride>false</fraudFilterOverride>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");
@@ -50,7 +52,7 @@ namespace Litle.Sdk.Test.Unit
             sale.orderSource = orderSourceType.ecommerce;
             sale.reportGroup = "Planets";
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);;
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<surchargeAmount>1</surchargeAmount>\r\n<orderSource>ecommerce</orderSource>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");
@@ -68,7 +70,7 @@ namespace Litle.Sdk.Test.Unit
             sale.orderSource = orderSourceType.ecommerce;
             sale.reportGroup = "Planets";
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);;
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<orderSource>ecommerce</orderSource>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");
@@ -95,7 +97,7 @@ namespace Litle.Sdk.Test.Unit
             sale.recurringRequest.subscription.planCode = "abc123";
             sale.recurringRequest.subscription.numberOfPayments = 12;
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);;
             
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<fraudFilterOverride>true</fraudFilterOverride>\r\n<recurringRequest>\r\n<subscription>\r\n<planCode>abc123</planCode>\r\n<numberOfPayments>12</numberOfPayments>\r\n</subscription>\r\n</recurringRequest>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.18' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");
@@ -145,7 +147,7 @@ namespace Litle.Sdk.Test.Unit
             sale.orderSource = orderSourceType.ecommerce;
             sale.fraudFilterOverride = true;
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);;
             
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<fraudFilterOverride>true</fraudFilterOverride>\r\n</sale>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");
@@ -171,7 +173,7 @@ namespace Litle.Sdk.Test.Unit
             sale.litleInternalRecurringRequest.subscriptionId = "123";
             sale.litleInternalRecurringRequest.recurringTxnId = "456";
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);;
             
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex("<fraudFilterOverride>true</fraudFilterOverride>\r\n<litleInternalRecurringRequest>\r\n<subscriptionId>123</subscriptionId>\r\n<recurringTxnId>456</recurringTxnId>\r\n</litleInternalRecurringRequest>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");
@@ -193,7 +195,7 @@ namespace Litle.Sdk.Test.Unit
             sale.orderSource = orderSourceType.ecommerce;
             sale.fraudFilterOverride = true;
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);;
             
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<fraudFilterOverride>true</fraudFilterOverride>\r\n</sale>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");
@@ -210,7 +212,7 @@ namespace Litle.Sdk.Test.Unit
             sale.litleInternalRecurringRequest = new litleInternalRecurringRequest();
             sale.debtRepayment = true;
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);;
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*</litleInternalRecurringRequest>\r\n<debtRepayment>true</debtRepayment>\r\n</sale>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.19' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");
@@ -227,7 +229,7 @@ namespace Litle.Sdk.Test.Unit
             sale.litleInternalRecurringRequest = new litleInternalRecurringRequest();
             sale.debtRepayment = false;
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);;
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*</litleInternalRecurringRequest>\r\n<debtRepayment>false</debtRepayment>\r\n</sale>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.19' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");
@@ -243,7 +245,7 @@ namespace Litle.Sdk.Test.Unit
             sale sale = new sale();
             sale.litleInternalRecurringRequest = new litleInternalRecurringRequest();
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);;
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*</litleInternalRecurringRequest>\r\n</sale>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.19' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");
@@ -262,7 +264,7 @@ namespace Litle.Sdk.Test.Unit
             sale.orderSource = orderSourceType.ecommerce;
             sale.reportGroup = "Planets";
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);;
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<secondaryAmount>1</secondaryAmount>\r\n<orderSource>ecommerce</orderSource>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");
@@ -293,7 +295,7 @@ namespace Litle.Sdk.Test.Unit
             wallet.walletSourceTypeId = "123";
             sale.wallet = wallet;
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);;
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<sale.*?<applepay>.*?<data>user</data>.*?</applepay>.*?<walletSourceTypeId>123</walletSourceTypeId>.*?</wallet>.*?</sale>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestSale.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestSale.cs
@@ -1,17 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Text;
-using NUnit.Framework;
-using Litle.Sdk;
-using Moq;
 using System.Text.RegularExpressions;
-
+using Moq;
+using NUnit.Framework;
 
 namespace Litle.Sdk.Test.Unit
 {
     [TestFixture]
-    class TestSale
+    internal class TestSale
     {
         private LitleOnline litle;
         private IDictionary<string, StringBuilder> _memoryStreams;
@@ -26,19 +22,25 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestFraudFilterOverride()
         {
-            sale sale = new sale();
+            var sale = new sale();
             sale.orderId = "12344";
             sale.amount = 2;
             sale.orderSource = orderSourceType.ecommerce;
             sale.reportGroup = "Planets";
             sale.fraudFilterOverride = false;
-           
-            var mock = new Mock<Communications>(_memoryStreams);;
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<fraudFilterOverride>false</fraudFilterOverride>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");
-     
-            Communications mockedCommunication = mock.Object;
+            var mock = new Mock<Communications>(_memoryStreams);
+            ;
+
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(".*<fraudFilterOverride>false</fraudFilterOverride>.*", RegexOptions.Singleline),
+                        It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.10' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");
+
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.Sale(sale);
         }
@@ -46,18 +48,25 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestSurchargeAmount()
         {
-            sale sale = new sale();
+            var sale = new sale();
             sale.amount = 2;
             sale.surchargeAmount = 1;
             sale.orderSource = orderSourceType.ecommerce;
             sale.reportGroup = "Planets";
 
-            var mock = new Mock<Communications>(_memoryStreams);;
+            var mock = new Mock<Communications>(_memoryStreams);
+            ;
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<surchargeAmount>1</surchargeAmount>\r\n<orderSource>ecommerce</orderSource>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*<amount>2</amount>\r\n<surchargeAmount>1</surchargeAmount>\r\n<orderSource>ecommerce</orderSource>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.Sale(sale);
         }
@@ -65,17 +74,23 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestSurchargeAmount_Optional()
         {
-            sale sale = new sale();
+            var sale = new sale();
             sale.amount = 2;
             sale.orderSource = orderSourceType.ecommerce;
             sale.reportGroup = "Planets";
 
-            var mock = new Mock<Communications>(_memoryStreams);;
+            var mock = new Mock<Communications>(_memoryStreams);
+            ;
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<orderSource>ecommerce</orderSource>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(".*<amount>2</amount>\r\n<orderSource>ecommerce</orderSource>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.Sale(sale);
         }
@@ -83,7 +98,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestRecurringRequest()
         {
-            sale sale = new sale();
+            var sale = new sale();
             sale.card = new cardType();
             sale.card.type = methodOfPaymentTypeEnum.VI;
             sale.card.number = "4100000000000001";
@@ -97,21 +112,30 @@ namespace Litle.Sdk.Test.Unit
             sale.recurringRequest.subscription.planCode = "abc123";
             sale.recurringRequest.subscription.numberOfPayments = 12;
 
-            var mock = new Mock<Communications>(_memoryStreams);;
-            
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<fraudFilterOverride>true</fraudFilterOverride>\r\n<recurringRequest>\r\n<subscription>\r\n<planCode>abc123</planCode>\r\n<numberOfPayments>12</numberOfPayments>\r\n</subscription>\r\n</recurringRequest>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.18' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");
+            var mock = new Mock<Communications>(_memoryStreams);
+            ;
 
-            Communications mockedCommunication = mock.Object;
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*<fraudFilterOverride>true</fraudFilterOverride>\r\n<recurringRequest>\r\n<subscription>\r\n<planCode>abc123</planCode>\r\n<numberOfPayments>12</numberOfPayments>\r\n</subscription>\r\n</recurringRequest>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.18' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");
+
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.Sale(sale);
         }
 
         [Test]
-        public void TestRecurringResponse_Full() {
-            String xmlResponse = "<litleOnlineResponse version='8.18' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId><recurringResponse><subscriptionId>12</subscriptionId><responseCode>345</responseCode><responseMessage>Foo</responseMessage><recurringTxnId>678</recurringTxnId></recurringResponse></saleResponse></litleOnlineResponse>";
-            litleOnlineResponse litleOnlineResponse = LitleOnline.DeserializeObject(xmlResponse);
-            saleResponse saleResponse = (saleResponse)litleOnlineResponse.saleResponse;
+        public void TestRecurringResponse_Full()
+        {
+            var xmlResponse =
+                "<litleOnlineResponse version='8.18' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId><recurringResponse><subscriptionId>12</subscriptionId><responseCode>345</responseCode><responseMessage>Foo</responseMessage><recurringTxnId>678</recurringTxnId></recurringResponse></saleResponse></litleOnlineResponse>";
+            var litleOnlineResponse = LitleOnline.DeserializeObject(xmlResponse);
+            var saleResponse = litleOnlineResponse.saleResponse;
 
             Assert.AreEqual(123, saleResponse.litleTxnId);
             Assert.AreEqual(12, saleResponse.recurringResponse.subscriptionId);
@@ -123,21 +147,22 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestRecurringResponse_NoRecurringTxnId()
         {
-            String xmlResponse = "<litleOnlineResponse version='8.18' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId><recurringResponse><subscriptionId>12</subscriptionId><responseCode>345</responseCode><responseMessage>Foo</responseMessage></recurringResponse></saleResponse></litleOnlineResponse>";
-            litleOnlineResponse litleOnlineResponse = LitleOnline.DeserializeObject(xmlResponse);
-            saleResponse saleResponse = (saleResponse)litleOnlineResponse.saleResponse;
+            var xmlResponse =
+                "<litleOnlineResponse version='8.18' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId><recurringResponse><subscriptionId>12</subscriptionId><responseCode>345</responseCode><responseMessage>Foo</responseMessage></recurringResponse></saleResponse></litleOnlineResponse>";
+            var litleOnlineResponse = LitleOnline.DeserializeObject(xmlResponse);
+            var saleResponse = litleOnlineResponse.saleResponse;
 
             Assert.AreEqual(123, saleResponse.litleTxnId);
             Assert.AreEqual(12, saleResponse.recurringResponse.subscriptionId);
             Assert.AreEqual("345", saleResponse.recurringResponse.responseCode);
             Assert.AreEqual("Foo", saleResponse.recurringResponse.responseMessage);
-            Assert.AreEqual(0,saleResponse.recurringResponse.recurringTxnId);
+            Assert.AreEqual(0, saleResponse.recurringResponse.recurringTxnId);
         }
 
         [Test]
         public void TestRecurringRequest_Optional()
         {
-            sale sale = new sale();
+            var sale = new sale();
             sale.card = new cardType();
             sale.card.type = methodOfPaymentTypeEnum.VI;
             sale.card.number = "4100000000000001";
@@ -147,12 +172,18 @@ namespace Litle.Sdk.Test.Unit
             sale.orderSource = orderSourceType.ecommerce;
             sale.fraudFilterOverride = true;
 
-            var mock = new Mock<Communications>(_memoryStreams);;
-            
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<fraudFilterOverride>true</fraudFilterOverride>\r\n</sale>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");
+            var mock = new Mock<Communications>(_memoryStreams);
+            ;
 
-            Communications mockedCommunication = mock.Object;
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(".*<fraudFilterOverride>true</fraudFilterOverride>\r\n</sale>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");
+
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.Sale(sale);
         }
@@ -160,7 +191,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void Test_LitleInternalRecurringRequest()
         {
-            sale sale = new sale();
+            var sale = new sale();
             sale.card = new cardType();
             sale.card.type = methodOfPaymentTypeEnum.VI;
             sale.card.number = "4100000000000001";
@@ -173,19 +204,26 @@ namespace Litle.Sdk.Test.Unit
             sale.litleInternalRecurringRequest.subscriptionId = "123";
             sale.litleInternalRecurringRequest.recurringTxnId = "456";
 
-            var mock = new Mock<Communications>(_memoryStreams);;
-            
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex("<fraudFilterOverride>true</fraudFilterOverride>\r\n<litleInternalRecurringRequest>\r\n<subscriptionId>123</subscriptionId>\r\n<recurringTxnId>456</recurringTxnId>\r\n</litleInternalRecurringRequest>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");
+            var mock = new Mock<Communications>(_memoryStreams);
+            ;
 
-            Communications mockedCommunication = mock.Object;
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            "<fraudFilterOverride>true</fraudFilterOverride>\r\n<litleInternalRecurringRequest>\r\n<subscriptionId>123</subscriptionId>\r\n<recurringTxnId>456</recurringTxnId>\r\n</litleInternalRecurringRequest>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");
+
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.Sale(sale);
         }
 
         public void Test_LitleInternalRecurringRequest_Optional()
         {
-            sale sale = new sale();
+            var sale = new sale();
             sale.card = new cardType();
             sale.card.type = methodOfPaymentTypeEnum.VI;
             sale.card.number = "4100000000000001";
@@ -195,12 +233,18 @@ namespace Litle.Sdk.Test.Unit
             sale.orderSource = orderSourceType.ecommerce;
             sale.fraudFilterOverride = true;
 
-            var mock = new Mock<Communications>(_memoryStreams);;
-            
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<fraudFilterOverride>true</fraudFilterOverride>\r\n</sale>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");
+            var mock = new Mock<Communications>(_memoryStreams);
+            ;
 
-            Communications mockedCommunication = mock.Object;
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(".*<fraudFilterOverride>true</fraudFilterOverride>\r\n</sale>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");
+
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.Sale(sale);
         }
@@ -208,16 +252,23 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestDebtRepayment_True()
         {
-            sale sale = new sale();
+            var sale = new sale();
             sale.litleInternalRecurringRequest = new litleInternalRecurringRequest();
             sale.debtRepayment = true;
 
-            var mock = new Mock<Communications>(_memoryStreams);;
+            var mock = new Mock<Communications>(_memoryStreams);
+            ;
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*</litleInternalRecurringRequest>\r\n<debtRepayment>true</debtRepayment>\r\n</sale>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.19' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*</litleInternalRecurringRequest>\r\n<debtRepayment>true</debtRepayment>\r\n</sale>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.19' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.Sale(sale);
         }
@@ -225,16 +276,23 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestDebtRepayment_False()
         {
-            sale sale = new sale();
+            var sale = new sale();
             sale.litleInternalRecurringRequest = new litleInternalRecurringRequest();
             sale.debtRepayment = false;
 
-            var mock = new Mock<Communications>(_memoryStreams);;
+            var mock = new Mock<Communications>(_memoryStreams);
+            ;
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*</litleInternalRecurringRequest>\r\n<debtRepayment>false</debtRepayment>\r\n</sale>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.19' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*</litleInternalRecurringRequest>\r\n<debtRepayment>false</debtRepayment>\r\n</sale>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.19' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.Sale(sale);
         }
@@ -242,15 +300,21 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestDebtRepayment_Optional()
         {
-            sale sale = new sale();
+            var sale = new sale();
             sale.litleInternalRecurringRequest = new litleInternalRecurringRequest();
 
-            var mock = new Mock<Communications>(_memoryStreams);;
+            var mock = new Mock<Communications>(_memoryStreams);
+            ;
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*</litleInternalRecurringRequest>\r\n</sale>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.19' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(".*</litleInternalRecurringRequest>\r\n</sale>.*", RegexOptions.Singleline),
+                        It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.19' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.Sale(sale);
         }
@@ -258,18 +322,25 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestSecondaryAmount()
         {
-            sale sale = new sale();
+            var sale = new sale();
             sale.amount = 2;
             sale.secondaryAmount = 1;
             sale.orderSource = orderSourceType.ecommerce;
             sale.reportGroup = "Planets";
 
-            var mock = new Mock<Communications>(_memoryStreams);;
+            var mock = new Mock<Communications>(_memoryStreams);
+            ;
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<amount>2</amount>\r\n<secondaryAmount>1</secondaryAmount>\r\n<orderSource>ecommerce</orderSource>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*<amount>2</amount>\r\n<secondaryAmount>1</secondaryAmount>\r\n<orderSource>ecommerce</orderSource>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.Sale(sale);
         }
@@ -277,9 +348,9 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestApplepayAndWallet()
         {
-            sale sale = new sale();
+            var sale = new sale();
             sale.applepay = new applepayType();
-            applepayHeaderType applepayHeaderType = new applepayHeaderType();
+            var applepayHeaderType = new applepayHeaderType();
             applepayHeaderType.applicationData = "454657413164";
             applepayHeaderType.ephemeralPublicKey = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
             applepayHeaderType.publicKeyHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
@@ -291,16 +362,23 @@ namespace Litle.Sdk.Test.Unit
             sale.orderId = "12344";
             sale.amount = 2;
             sale.orderSource = orderSourceType.ecommerce;
-            wallet wallet = new Sdk.wallet();
+            var wallet = new wallet();
             wallet.walletSourceTypeId = "123";
             sale.wallet = wallet;
 
-            var mock = new Mock<Communications>(_memoryStreams);;
+            var mock = new Mock<Communications>(_memoryStreams);
+            ;
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*?<litleOnlineRequest.*?<sale.*?<applepay>.*?<data>user</data>.*?</applepay>.*?<walletSourceTypeId>123</walletSourceTypeId>.*?</wallet>.*?</sale>.*?", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*?<litleOnlineRequest.*?<sale.*?<applepay>.*?<data>user</data>.*?</applepay>.*?<walletSourceTypeId>123</walletSourceTypeId>.*?</wallet>.*?</sale>.*?",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><saleResponse><litleTxnId>123</litleTxnId></saleResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.Sale(sale);
         }

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestUnloadReversal.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestUnloadReversal.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -11,13 +12,15 @@ namespace Litle.Sdk.Test.Unit
 {
     [TestFixture]
     class TestUnloadReversal
-    {        
+    {
         private LitleOnline litle;
+        private IDictionary<string, StringBuilder> _memoryStreams;
 
         [TestFixtureSetUp]
         public void SetUpLitle()
         {
-            litle = new LitleOnline();
+            _memoryStreams = new Dictionary<string, StringBuilder>();
+            litle = new LitleOnline(_memoryStreams);
         }
 
         [Test]
@@ -28,7 +31,7 @@ namespace Litle.Sdk.Test.Unit
             unloadReversal.reportGroup = "b";
             unloadReversal.litleTxnId = "123";
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<litleTxnId>123</litleTxnId>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><unloadReversalResponse><litleTxnId>123</litleTxnId></unloadReversalResponse></litleOnlineResponse>");

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestUnloadReversal.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestUnloadReversal.cs
@@ -1,17 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Text;
-using NUnit.Framework;
-using Litle.Sdk;
-using Moq;
 using System.Text.RegularExpressions;
-
+using Moq;
+using NUnit.Framework;
 
 namespace Litle.Sdk.Test.Unit
 {
     [TestFixture]
-    class TestUnloadReversal
+    internal class TestUnloadReversal
     {
         private LitleOnline litle;
         private IDictionary<string, StringBuilder> _memoryStreams;
@@ -26,22 +22,24 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestSimple()
         {
-            unloadReversal unloadReversal = new unloadReversal();
+            var unloadReversal = new unloadReversal();
             unloadReversal.id = "a";
             unloadReversal.reportGroup = "b";
             unloadReversal.litleTxnId = "123";
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<litleTxnId>123</litleTxnId>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><unloadReversalResponse><litleTxnId>123</litleTxnId></unloadReversalResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(It.IsRegex(".*<litleTxnId>123</litleTxnId>.*", RegexOptions.Singleline),
+                        It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><unloadReversalResponse><litleTxnId>123</litleTxnId></unloadReversalResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            unloadReversalResponse response = litle.UnloadReversal(unloadReversal);
+            var response = litle.UnloadReversal(unloadReversal);
             Assert.AreEqual("123", response.litleTxnId);
         }
-
-
     }
 }

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestUpdateCardValidationNumOnToken.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestUpdateCardValidationNumOnToken.cs
@@ -1,17 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Text;
-using NUnit.Framework;
-using Litle.Sdk;
-using Moq;
 using System.Text.RegularExpressions;
-
+using Moq;
+using NUnit.Framework;
 
 namespace Litle.Sdk.Test.Unit
 {
     [TestFixture]
-    class TestUpdateCardValidationNumOnToken
+    internal class TestUpdateCardValidationNumOnToken
     {
         private LitleOnline litle;
         private IDictionary<string, StringBuilder> _memoryStreams;
@@ -26,19 +22,25 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestSimpleRequest()
         {
-            updateCardValidationNumOnToken update = new updateCardValidationNumOnToken();
+            var update = new updateCardValidationNumOnToken();
             update.orderId = "12344";
             update.litleToken = "1111222233334444";
             update.cardValidationNum = "321";
             update.id = "123";
             update.reportGroup = "Default Report Group";
-           
+
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<updateCardValidationNumOnToken id=\"123\" reportGroup=\"Default Report Group\".*<orderId>12344</orderId>.*<litleToken>1111222233334444</litleToken>.*<cardValidationNum>321</cardValidationNum>.*</updateCardValidationNumOnToken>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><updateCardValidationNumOnTokenResponse><litleTxnId>4</litleTxnId><orderId>12344</orderId><response>801</response><message>Token Successfully Registered</message><responseTime>2012-10-10T10:17:03</responseTime></updateCardValidationNumOnTokenResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*<updateCardValidationNumOnToken id=\"123\" reportGroup=\"Default Report Group\".*<orderId>12344</orderId>.*<litleToken>1111222233334444</litleToken>.*<cardValidationNum>321</cardValidationNum>.*</updateCardValidationNumOnToken>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><updateCardValidationNumOnTokenResponse><litleTxnId>4</litleTxnId><orderId>12344</orderId><response>801</response><message>Token Successfully Registered</message><responseTime>2012-10-10T10:17:03</responseTime></updateCardValidationNumOnTokenResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
             litle.UpdateCardValidationNumOnToken(update);
         }
@@ -46,7 +48,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestOrderIdIsOptional()
         {
-            updateCardValidationNumOnToken update = new updateCardValidationNumOnToken();
+            var update = new updateCardValidationNumOnToken();
             update.orderId = null;
             update.litleToken = "1111222233334444";
             update.cardValidationNum = "321";
@@ -55,17 +57,21 @@ namespace Litle.Sdk.Test.Unit
 
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<updateCardValidationNumOnToken id=\"123\" reportGroup=\"Default Report Group\".*<litleToken>1111222233334444</litleToken>.*<cardValidationNum>321</cardValidationNum>.*</updateCardValidationNumOnToken>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-            //mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><updateCardValidationNumOnTokenResponse><litleTxnId>4</litleTxnId><response>801</response><message>Token Successfully Registered</message><responseTime>2012-10-10T10:17:03</responseTime></updateCardValidationNumOnTokenResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*<updateCardValidationNumOnToken id=\"123\" reportGroup=\"Default Report Group\".*<litleToken>1111222233334444</litleToken>.*<cardValidationNum>321</cardValidationNum>.*</updateCardValidationNumOnToken>.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                //mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><updateCardValidationNumOnTokenResponse><litleTxnId>4</litleTxnId><response>801</response><message>Token Successfully Registered</message><responseTime>2012-10-10T10:17:03</responseTime></updateCardValidationNumOnTokenResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            updateCardValidationNumOnTokenResponse response = litle.UpdateCardValidationNumOnToken(update);
+            var response = litle.UpdateCardValidationNumOnToken(update);
             Assert.IsNotNull(response);
             Assert.IsNull(response.orderId);
-
         }
-
     }
 }

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestUpdateCardValidationNumOnToken.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestUpdateCardValidationNumOnToken.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -12,13 +13,14 @@ namespace Litle.Sdk.Test.Unit
     [TestFixture]
     class TestUpdateCardValidationNumOnToken
     {
-        
         private LitleOnline litle;
+        private IDictionary<string, StringBuilder> _memoryStreams;
 
         [TestFixtureSetUp]
         public void SetUpLitle()
         {
-            litle = new LitleOnline();
+            _memoryStreams = new Dictionary<string, StringBuilder>();
+            litle = new LitleOnline(_memoryStreams);
         }
 
         [Test]
@@ -31,7 +33,7 @@ namespace Litle.Sdk.Test.Unit
             update.id = "123";
             update.reportGroup = "Default Report Group";
            
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<updateCardValidationNumOnToken id=\"123\" reportGroup=\"Default Report Group\".*<orderId>12344</orderId>.*<litleToken>1111222233334444</litleToken>.*<cardValidationNum>321</cardValidationNum>.*</updateCardValidationNumOnToken>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.14' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><updateCardValidationNumOnTokenResponse><litleTxnId>4</litleTxnId><orderId>12344</orderId><response>801</response><message>Token Successfully Registered</message><responseTime>2012-10-10T10:17:03</responseTime></updateCardValidationNumOnTokenResponse></litleOnlineResponse>");
@@ -51,7 +53,7 @@ namespace Litle.Sdk.Test.Unit
             update.id = "123";
             update.reportGroup = "Default Report Group";
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<updateCardValidationNumOnToken id=\"123\" reportGroup=\"Default Report Group\".*<litleToken>1111222233334444</litleToken>.*<cardValidationNum>321</cardValidationNum>.*</updateCardValidationNumOnToken>.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
             //mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestUpdateSubscription.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestUpdateSubscription.cs
@@ -1,17 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Text;
-using NUnit.Framework;
-using Litle.Sdk;
-using Moq;
 using System.Text.RegularExpressions;
-
+using Moq;
+using NUnit.Framework;
 
 namespace Litle.Sdk.Test.Unit
 {
     [TestFixture]
-    class TestUpdateSubscription
+    internal class TestUpdateSubscription
     {
         private LitleOnline litle;
         private IDictionary<string, StringBuilder> _memoryStreams;
@@ -26,36 +23,40 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestSimple()
         {
-            updateSubscription update = new updateSubscription();
+            var update = new updateSubscription();
             update.billingDate = new DateTime(2002, 10, 9);
-            contact billToAddress = new contact();
+            var billToAddress = new contact();
             billToAddress.name = "Greg Dake";
             billToAddress.city = "Lowell";
             billToAddress.state = "MA";
             billToAddress.email = "sdksupport@litle.com";
             update.billToAddress = billToAddress;
-            cardType card = new cardType();
+            var card = new cardType();
             card.number = "4100000000000001";
             card.expDate = "1215";
             card.type = methodOfPaymentTypeEnum.VI;
             update.card = card;
             update.planCode = "abcdefg";
             update.subscriptionId = 12345;
-           
+
             var mock = new Mock<Communications>(_memoryStreams);
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<litleOnlineRequest.*?<updateSubscription>\r\n<subscriptionId>12345</subscriptionId>\r\n<planCode>abcdefg</planCode>\r\n<billToAddress>\r\n<name>Greg Dake</name>.*?</billToAddress>\r\n<card>\r\n<type>VI</type>.*?</card>\r\n<billingDate>2002-10-09</billingDate>\r\n</updateSubscription>\r\n</litleOnlineRequest>.*?.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.20' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><updateSubscriptionResponse ><litleTxnId>456</litleTxnId><response>000</response><message>Approved</message><responseTime>2013-09-04</responseTime><subscriptionId>12345</subscriptionId></updateSubscriptionResponse></litleOnlineResponse>");
-     
-            Communications mockedCommunication = mock.Object;
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(
+                        It.IsRegex(
+                            ".*<litleOnlineRequest.*?<updateSubscription>\r\n<subscriptionId>12345</subscriptionId>\r\n<planCode>abcdefg</planCode>\r\n<billToAddress>\r\n<name>Greg Dake</name>.*?</billToAddress>\r\n<card>\r\n<type>VI</type>.*?</card>\r\n<billingDate>2002-10-09</billingDate>\r\n</updateSubscription>\r\n</litleOnlineRequest>.*?.*",
+                            RegexOptions.Singleline), It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.20' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><updateSubscriptionResponse ><litleTxnId>456</litleTxnId><response>000</response><message>Approved</message><responseTime>2013-09-04</responseTime><subscriptionId>12345</subscriptionId></updateSubscriptionResponse></litleOnlineResponse>");
+
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            updateSubscriptionResponse response = litle.UpdateSubscription(update);
+            var response = litle.UpdateSubscription(update);
             Assert.AreEqual("12345", response.subscriptionId);
             Assert.AreEqual("456", response.litleTxnId);
             Assert.AreEqual("000", response.response);
             Assert.NotNull(response.responseTime);
         }
-
-
     }
 }

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestUpdateSubscription.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestUpdateSubscription.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -11,13 +12,15 @@ namespace Litle.Sdk.Test.Unit
 {
     [TestFixture]
     class TestUpdateSubscription
-    {        
+    {
         private LitleOnline litle;
+        private IDictionary<string, StringBuilder> _memoryStreams;
 
         [TestFixtureSetUp]
         public void SetUpLitle()
         {
-            litle = new LitleOnline();
+            _memoryStreams = new Dictionary<string, StringBuilder>();
+            litle = new LitleOnline(_memoryStreams);
         }
 
         [Test]
@@ -39,7 +42,7 @@ namespace Litle.Sdk.Test.Unit
             update.planCode = "abcdefg";
             update.subscriptionId = 12345;
            
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(_memoryStreams);
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*<litleOnlineRequest.*?<updateSubscription>\r\n<subscriptionId>12345</subscriptionId>\r\n<planCode>abcdefg</planCode>\r\n<billToAddress>\r\n<name>Greg Dake</name>.*?</billToAddress>\r\n<card>\r\n<type>VI</type>.*?</card>\r\n<billingDate>2002-10-09</billingDate>\r\n</updateSubscription>\r\n</litleOnlineRequest>.*?.*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.20' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><updateSubscriptionResponse ><litleTxnId>456</litleTxnId><response>000</response><message>Approved</message><responseTime>2013-09-04</responseTime><subscriptionId>12345</subscriptionId></updateSubscriptionResponse></litleOnlineResponse>");

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestVoid.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestVoid.cs
@@ -1,17 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Text;
-using NUnit.Framework;
-using Litle.Sdk;
-using Moq;
 using System.Text.RegularExpressions;
-
+using Moq;
+using NUnit.Framework;
 
 namespace Litle.Sdk.Test.Unit
 {
     [TestFixture]
-    class TestVoid
+    internal class TestVoid
     {
         private LitleOnline litle;
         private IDictionary<string, StringBuilder> _memoryStreams;
@@ -26,17 +22,21 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestRecyclingDataOnVoidResponse()
         {
-            voidTxn voidTxn = new voidTxn();
+            var voidTxn = new voidTxn();
             voidTxn.litleTxnId = 123;
-           
+
             var mock = new Mock<Communications>(new Dictionary<string, StringBuilder>());
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.16' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><voidResponse><litleTxnId>123</litleTxnId><response>000</response><responseTime>2013-01-31T15:48:09</responseTime><postDate>2013-01-31</postDate><message>Approved</message><recycling><creditLitleTxnId>456</creditLitleTxnId></recycling></voidResponse></litleOnlineResponse>");
-     
-            Communications mockedCommunication = mock.Object;
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(It.IsRegex(".*", RegexOptions.Singleline),
+                        It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.16' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><voidResponse><litleTxnId>123</litleTxnId><response>000</response><responseTime>2013-01-31T15:48:09</responseTime><postDate>2013-01-31</postDate><message>Approved</message><recycling><creditLitleTxnId>456</creditLitleTxnId></recycling></voidResponse></litleOnlineResponse>");
+
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            litleOnlineResponseTransactionResponseVoidResponse response = litle.DoVoid(voidTxn);
+            var response = litle.DoVoid(voidTxn);
             Assert.AreEqual(123, response.litleTxnId);
             Assert.AreEqual(456, response.recycling.creditLitleTxnId);
         }
@@ -44,20 +44,23 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestRecyclingDataOnVoidResponseIsOptional()
         {
-            voidTxn voidTxn = new voidTxn();
+            var voidTxn = new voidTxn();
             voidTxn.litleTxnId = 123;
 
             var mock = new Mock<Communications>(new Dictionary<string, StringBuilder>());
 
-            mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
-                .Returns("<litleOnlineResponse version='8.16' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><voidResponse><litleTxnId>123</litleTxnId><response>000</response><responseTime>2013-01-31T15:48:09</responseTime><postDate>2013-01-31</postDate><message>Approved</message></voidResponse></litleOnlineResponse>");
+            mock.Setup(
+                Communications =>
+                    Communications.HttpPost(It.IsRegex(".*", RegexOptions.Singleline),
+                        It.IsAny<Dictionary<string, string>>()))
+                .Returns(
+                    "<litleOnlineResponse version='8.16' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><voidResponse><litleTxnId>123</litleTxnId><response>000</response><responseTime>2013-01-31T15:48:09</responseTime><postDate>2013-01-31</postDate><message>Approved</message></voidResponse></litleOnlineResponse>");
 
-            Communications mockedCommunication = mock.Object;
+            var mockedCommunication = mock.Object;
             litle.setCommunication(mockedCommunication);
-            litleOnlineResponseTransactionResponseVoidResponse response = litle.DoVoid(voidTxn);
+            var response = litle.DoVoid(voidTxn);
             Assert.AreEqual(123, response.litleTxnId);
             Assert.IsNull(response.recycling);
         }
-
     }
 }

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestVoid.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestVoid.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 using Litle.Sdk;
@@ -12,13 +13,14 @@ namespace Litle.Sdk.Test.Unit
     [TestFixture]
     class TestVoid
     {
-        
         private LitleOnline litle;
+        private IDictionary<string, StringBuilder> _memoryStreams;
 
         [TestFixtureSetUp]
         public void SetUpLitle()
         {
-            litle = new LitleOnline();
+            _memoryStreams = new Dictionary<string, StringBuilder>();
+            litle = new LitleOnline(_memoryStreams);
         }
 
         [Test]
@@ -27,7 +29,7 @@ namespace Litle.Sdk.Test.Unit
             voidTxn voidTxn = new voidTxn();
             voidTxn.litleTxnId = 123;
            
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(new Dictionary<string, StringBuilder>());
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.16' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><voidResponse><litleTxnId>123</litleTxnId><response>000</response><responseTime>2013-01-31T15:48:09</responseTime><postDate>2013-01-31</postDate><message>Approved</message><recycling><creditLitleTxnId>456</creditLitleTxnId></recycling></voidResponse></litleOnlineResponse>");
@@ -45,7 +47,7 @@ namespace Litle.Sdk.Test.Unit
             voidTxn voidTxn = new voidTxn();
             voidTxn.litleTxnId = 123;
 
-            var mock = new Mock<Communications>();
+            var mock = new Mock<Communications>(new Dictionary<string, StringBuilder>());
 
             mock.Setup(Communications => Communications.HttpPost(It.IsRegex(".*", RegexOptions.Singleline), It.IsAny<Dictionary<String, String>>()))
                 .Returns("<litleOnlineResponse version='8.16' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'><voidResponse><litleTxnId>123</litleTxnId><response>000</response><responseTime>2013-01-31T15:48:09</responseTime><postDate>2013-01-31</postDate><message>Approved</message></voidResponse></litleOnlineResponse>");

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestXmlFieldsSerializer.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestXmlFieldsSerializer.cs
@@ -1,18 +1,12 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using NUnit.Framework;
-using Litle.Sdk;
-using Moq;
 using System.Text.RegularExpressions;
-
+using NUnit.Framework;
 
 namespace Litle.Sdk.Test.Unit
 {
     [TestFixture]
-    class TestXmlFieldsSerializer
+    internal class TestXmlFieldsSerializer
     {
-
         [TestFixtureSetUp]
         public void SetUpLitle()
         {
@@ -21,44 +15,45 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestRecurringRequest_Full()
         {
-            recurringRequest request = new recurringRequest();
+            var request = new recurringRequest();
             request.subscription = new subscription();
             request.subscription.planCode = "123abc";
             request.subscription.numberOfPayments = 10;
             request.subscription.startDate = new DateTime(2013, 7, 25);
             request.subscription.amount = 102;
 
-            String xml = request.Serialize();
-            System.Text.RegularExpressions.Match match = Regex.Match(xml,"<subscription>\r\n<planCode>123abc</planCode>\r\n<numberOfPayments>10</numberOfPayments>\r\n<startDate>2013-07-25</startDate>\r\n<amount>102</amount>\r\n</subscription>");
+            var xml = request.Serialize();
+            var match = Regex.Match(xml,
+                "<subscription>\r\n<planCode>123abc</planCode>\r\n<numberOfPayments>10</numberOfPayments>\r\n<startDate>2013-07-25</startDate>\r\n<amount>102</amount>\r\n</subscription>");
             Assert.IsTrue(match.Success, xml);
         }
 
         [Test]
         public void TestRecurringRequest_OnlyRequired()
         {
-            recurringRequest request = new recurringRequest();
+            var request = new recurringRequest();
             request.subscription = new subscription();
             request.subscription.planCode = "123abc";
 
-            String xml = request.Serialize();
-            System.Text.RegularExpressions.Match match = Regex.Match(xml, "<subscription>\r\n<planCode>123abc</planCode>\r\n</subscription>");
+            var xml = request.Serialize();
+            var match = Regex.Match(xml, "<subscription>\r\n<planCode>123abc</planCode>\r\n</subscription>");
             Assert.IsTrue(match.Success, xml);
         }
 
         [Test]
         public void TestSubscription_CanContainCreateDiscounts()
         {
-            subscription subscription = new subscription();
+            var subscription = new subscription();
             subscription.planCode = "123abc";
 
-            createDiscount cd1 = new createDiscount();
+            var cd1 = new createDiscount();
             cd1.discountCode = "1";
             cd1.name = "cheaper";
             cd1.amount = 200;
             cd1.startDate = new DateTime(2013, 9, 5);
             cd1.endDate = new DateTime(2013, 9, 6);
 
-            createDiscount cd2 = new createDiscount();
+            var cd2 = new createDiscount();
             cd2.discountCode = "2";
             cd2.name = "cheap";
             cd2.amount = 100;
@@ -68,8 +63,8 @@ namespace Litle.Sdk.Test.Unit
             subscription.createDiscounts.Add(cd1);
             subscription.createDiscounts.Add(cd2);
 
-            String actual = subscription.Serialize();
-            String expected = @"
+            var actual = subscription.Serialize();
+            var expected = @"
 <planCode>123abc</planCode>
 <createDiscount>
 <discountCode>1</discountCode>
@@ -91,17 +86,17 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestSubscription_CanContainCreateAddOns()
         {
-            subscription subscription = new subscription();
+            var subscription = new subscription();
             subscription.planCode = "123abc";
 
-            createAddOn cao1 = new createAddOn();
+            var cao1 = new createAddOn();
             cao1.addOnCode = "1";
             cao1.name = "addOn1";
             cao1.amount = 100;
             cao1.startDate = new DateTime(2013, 9, 5);
             cao1.endDate = new DateTime(2013, 9, 6);
 
-            createAddOn cao2 = new createAddOn();
+            var cao2 = new createAddOn();
             cao2.addOnCode = "2";
             cao2.name = "addOn2";
             cao2.amount = 200;
@@ -111,8 +106,8 @@ namespace Litle.Sdk.Test.Unit
             subscription.createAddOns.Add(cao1);
             subscription.createAddOns.Add(cao2);
 
-            String actual = subscription.Serialize();
-            String expected = @"
+            var actual = subscription.Serialize();
+            var expected = @"
 <planCode>123abc</planCode>
 <createAddOn>
 <addOnCode>1</addOnCode>
@@ -134,15 +129,15 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestUpdateSubscription_Full()
         {
-            updateSubscription update = new updateSubscription();
+            var update = new updateSubscription();
             update.billingDate = new DateTime(2002, 10, 9);
-            contact billToAddress = new contact();
+            var billToAddress = new contact();
             billToAddress.name = "Greg Dake";
             billToAddress.city = "Lowell";
             billToAddress.state = "MA";
             billToAddress.email = "sdksupport@litle.com";
             update.billToAddress = billToAddress;
-            cardType card = new cardType();
+            var card = new cardType();
             card.number = "4100000000000001";
             card.expDate = "1215";
             card.type = methodOfPaymentTypeEnum.VI;
@@ -150,46 +145,47 @@ namespace Litle.Sdk.Test.Unit
             update.planCode = "abcdefg";
             update.subscriptionId = 12345;
 
-            String actual = update.Serialize();
-            String expected = "\r\n<updateSubscription>\r\n<subscriptionId>12345</subscriptionId>\r\n<planCode>abcdefg</planCode>\r\n<billToAddress>\r\n<name>Greg Dake</name>\r\n<city>Lowell</city>\r\n<state>MA</state>\r\n<email>sdksupport@litle.com</email>\r\n</billToAddress>\r\n<card>\r\n<type>VI</type>\r\n<number>4100000000000001</number>\r\n<expDate>1215</expDate>\r\n</card>\r\n<billingDate>2002-10-09</billingDate>\r\n</updateSubscription>";
+            var actual = update.Serialize();
+            var expected =
+                "\r\n<updateSubscription>\r\n<subscriptionId>12345</subscriptionId>\r\n<planCode>abcdefg</planCode>\r\n<billToAddress>\r\n<name>Greg Dake</name>\r\n<city>Lowell</city>\r\n<state>MA</state>\r\n<email>sdksupport@litle.com</email>\r\n</billToAddress>\r\n<card>\r\n<type>VI</type>\r\n<number>4100000000000001</number>\r\n<expDate>1215</expDate>\r\n</card>\r\n<billingDate>2002-10-09</billingDate>\r\n</updateSubscription>";
             Assert.AreEqual(expected, actual);
         }
 
         [Test]
         public void testUpdateSubscription_OnlyRequired()
         {
-            updateSubscription update = new updateSubscription();
+            var update = new updateSubscription();
             update.subscriptionId = 12345;
 
-            String actual = update.Serialize();
-            String expected = "\r\n<updateSubscription>\r\n<subscriptionId>12345</subscriptionId>\r\n</updateSubscription>";
+            var actual = update.Serialize();
+            var expected = "\r\n<updateSubscription>\r\n<subscriptionId>12345</subscriptionId>\r\n</updateSubscription>";
             Assert.AreEqual(expected, actual);
         }
 
         [Test]
         public void testUpdateSubscription_CanContainCreateDiscounts()
         {
-            createDiscount cd1 = new createDiscount();
+            var cd1 = new createDiscount();
             cd1.discountCode = "1";
             cd1.name = "cheaper";
             cd1.amount = 200;
             cd1.startDate = new DateTime(2013, 9, 5);
             cd1.endDate = new DateTime(2013, 9, 6);
 
-            createDiscount cd2 = new createDiscount();
+            var cd2 = new createDiscount();
             cd2.discountCode = "2";
             cd2.name = "cheap";
             cd2.amount = 100;
             cd2.startDate = new DateTime(2013, 9, 3);
             cd2.endDate = new DateTime(2013, 9, 4);
 
-            updateSubscription update = new updateSubscription();
+            var update = new updateSubscription();
             update.subscriptionId = 1;
             update.createDiscounts.Add(cd1);
             update.createDiscounts.Add(cd2);
 
-            String actual = update.Serialize();
-            String expected = @"
+            var actual = update.Serialize();
+            var expected = @"
 <updateSubscription>
 <subscriptionId>1</subscriptionId>
 <createDiscount>
@@ -213,27 +209,27 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void testUpdateSubscription_CanContainUpdateDiscounts()
         {
-            updateDiscount ud1 = new updateDiscount();
+            var ud1 = new updateDiscount();
             ud1.discountCode = "1";
             ud1.name = "cheaper";
             ud1.amount = 200;
             ud1.startDate = new DateTime(2013, 9, 5);
             ud1.endDate = new DateTime(2013, 9, 6);
 
-            updateDiscount ud2 = new updateDiscount();
+            var ud2 = new updateDiscount();
             ud2.discountCode = "2";
             ud2.name = "cheap";
             ud2.amount = 100;
             ud2.startDate = new DateTime(2013, 9, 3);
             ud2.endDate = new DateTime(2013, 9, 4);
 
-            updateSubscription update = new updateSubscription();
+            var update = new updateSubscription();
             update.subscriptionId = 1;
             update.updateDiscounts.Add(ud1);
             update.updateDiscounts.Add(ud2);
 
-            String actual = update.Serialize();
-            String expected = @"
+            var actual = update.Serialize();
+            var expected = @"
 <updateSubscription>
 <subscriptionId>1</subscriptionId>
 <updateDiscount>
@@ -257,19 +253,19 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void testUpdateSubscription_CanContainDeleteDiscounts()
         {
-            deleteDiscount dd1 = new deleteDiscount();
+            var dd1 = new deleteDiscount();
             dd1.discountCode = "1";
 
-            deleteDiscount dd2 = new deleteDiscount();
+            var dd2 = new deleteDiscount();
             dd2.discountCode = "2";
 
-            updateSubscription update = new updateSubscription();
+            var update = new updateSubscription();
             update.subscriptionId = 1;
             update.deleteDiscounts.Add(dd1);
             update.deleteDiscounts.Add(dd2);
 
-            String actual = update.Serialize();
-            String expected = @"
+            var actual = update.Serialize();
+            var expected = @"
 <updateSubscription>
 <subscriptionId>1</subscriptionId>
 <deleteDiscount>
@@ -285,27 +281,27 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void testUpdateSubscription_CanContainCreateAddOns()
         {
-            createAddOn cao1 = new createAddOn();
+            var cao1 = new createAddOn();
             cao1.addOnCode = "1";
             cao1.name = "addOn1";
             cao1.amount = 100;
             cao1.startDate = new DateTime(2013, 9, 5);
             cao1.endDate = new DateTime(2013, 9, 6);
 
-            createAddOn cao2 = new createAddOn();
+            var cao2 = new createAddOn();
             cao2.addOnCode = "2";
             cao2.name = "addOn2";
             cao2.amount = 200;
             cao2.startDate = new DateTime(2013, 9, 4);
             cao2.endDate = new DateTime(2013, 9, 5);
 
-            updateSubscription update = new updateSubscription();
+            var update = new updateSubscription();
             update.subscriptionId = 1;
             update.createAddOns.Add(cao1);
             update.createAddOns.Add(cao2);
 
-            String actual = update.Serialize();
-            String expected = @"
+            var actual = update.Serialize();
+            var expected = @"
 <updateSubscription>
 <subscriptionId>1</subscriptionId>
 <createAddOn>
@@ -329,27 +325,27 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void testUpdateSubscription_CanContainUpdateAddOns()
         {
-            updateAddOn uao1 = new updateAddOn();
+            var uao1 = new updateAddOn();
             uao1.addOnCode = "1";
             uao1.name = "addOn1";
             uao1.amount = 100;
             uao1.startDate = new DateTime(2013, 9, 5);
             uao1.endDate = new DateTime(2013, 9, 6);
 
-            updateAddOn uao2 = new updateAddOn();
+            var uao2 = new updateAddOn();
             uao2.addOnCode = "2";
             uao2.name = "addOn2";
             uao2.amount = 200;
             uao2.startDate = new DateTime(2013, 9, 4);
             uao2.endDate = new DateTime(2013, 9, 5);
 
-            updateSubscription update = new updateSubscription();
+            var update = new updateSubscription();
             update.subscriptionId = 1;
             update.updateAddOns.Add(uao1);
             update.updateAddOns.Add(uao2);
 
-            String actual = update.Serialize();
-            String expected = @"
+            var actual = update.Serialize();
+            var expected = @"
 <updateSubscription>
 <subscriptionId>1</subscriptionId>
 <updateAddOn>
@@ -373,19 +369,19 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void testUpdateSubscription_CanContainDeleteAddOns()
         {
-            deleteAddOn dao1 = new deleteAddOn();
+            var dao1 = new deleteAddOn();
             dao1.addOnCode = "1";
 
-            deleteAddOn dao2 = new deleteAddOn();
+            var dao2 = new deleteAddOn();
             dao2.addOnCode = "2";
 
-            updateSubscription update = new updateSubscription();
+            var update = new updateSubscription();
             update.subscriptionId = 1;
             update.deleteAddOns.Add(dao1);
             update.deleteAddOns.Add(dao2);
 
-            String actual = update.Serialize();
-            String expected = @"
+            var actual = update.Serialize();
+            var expected = @"
 <updateSubscription>
 <subscriptionId>1</subscriptionId>
 <deleteAddOn>
@@ -401,13 +397,13 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void testUpdateSubscription_CanContainToken()
         {
-            updateSubscription update = new updateSubscription();
+            var update = new updateSubscription();
             update.subscriptionId = 1;
             update.token = new cardTokenType();
             update.token.litleToken = "123456";
 
-            String actual = update.Serialize();
-            String expected = @"
+            var actual = update.Serialize();
+            var expected = @"
 <updateSubscription>
 <subscriptionId>1</subscriptionId>
 <token>
@@ -420,13 +416,13 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void testUpdateSubscription_CanContainPaypage()
         {
-            updateSubscription update = new updateSubscription();
+            var update = new updateSubscription();
             update.subscriptionId = 1;
             update.paypage = new cardPaypageType();
             update.paypage.paypageRegistrationId = "abc123";
 
-            String actual = update.Serialize();
-            String expected = @"
+            var actual = update.Serialize();
+            var expected = @"
 <updateSubscription>
 <subscriptionId>1</subscriptionId>
 <paypage>
@@ -440,11 +436,11 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestCancelSubscription_Full()
         {
-            cancelSubscription cancel = new cancelSubscription();
+            var cancel = new cancelSubscription();
             cancel.subscriptionId = 12345;
 
-            String actual = cancel.Serialize();
-            String expected = @"
+            var actual = cancel.Serialize();
+            var expected = @"
 <cancelSubscription>
 <subscriptionId>12345</subscriptionId>
 </cancelSubscription>";
@@ -454,11 +450,11 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void testCancelSubscription_OnlyRequired()
         {
-            cancelSubscription update = new cancelSubscription();
+            var update = new cancelSubscription();
             update.subscriptionId = 12345;
 
-            String actual = update.Serialize();
-            String expected = @"
+            var actual = update.Serialize();
+            var expected = @"
 <cancelSubscription>
 <subscriptionId>12345</subscriptionId>
 </cancelSubscription>";
@@ -468,7 +464,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void testActivate_Full()
         {
-            activate activate = new activate();
+            var activate = new activate();
             activate.orderId = "12345";
             activate.amount = 200;
             activate.orderSource = orderSourceType.ecommerce;
@@ -476,8 +472,8 @@ namespace Litle.Sdk.Test.Unit
             activate.reportGroup = "theReportGroup";
             activate.card = new cardType();
 
-            String actual = activate.Serialize();
-            String expected = @"
+            var actual = activate.Serialize();
+            var expected = @"
 <activate id=""theId"" reportGroup=""theReportGroup"">
 <orderId>12345</orderId>
 <amount>200</amount>
@@ -492,7 +488,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void testActivate_VirtualGiftCard()
         {
-            activate activate = new activate();
+            var activate = new activate();
             activate.orderId = "12345";
             activate.amount = 200;
             activate.orderSource = orderSourceType.ecommerce;
@@ -500,8 +496,8 @@ namespace Litle.Sdk.Test.Unit
             activate.reportGroup = "theReportGroup";
             activate.virtualGiftCard = new virtualGiftCardType();
 
-            String actual = activate.Serialize();
-            String expected = @"
+            var actual = activate.Serialize();
+            var expected = @"
 <activate id=""theId"" reportGroup=""theReportGroup"">
 <orderId>12345</orderId>
 <amount>200</amount>
@@ -515,12 +511,12 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void testVirtualGiftCard_Full()
         {
-            virtualGiftCardType virtualGiftCard = new virtualGiftCardType();
+            var virtualGiftCard = new virtualGiftCardType();
             virtualGiftCard.accountNumberLength = 16;
             virtualGiftCard.giftCardBin = "123456";
 
-            String actual = virtualGiftCard.Serialize();
-            String expected = @"
+            var actual = virtualGiftCard.Serialize();
+            var expected = @"
 <accountNumberLength>16</accountNumberLength>
 <giftCardBin>123456</giftCardBin>";
             Assert.AreEqual(expected, actual);
@@ -529,15 +525,15 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void testDeactivate_Full()
         {
-            deactivate deactivate = new deactivate();
+            var deactivate = new deactivate();
             deactivate.orderId = "12345";
             deactivate.orderSource = orderSourceType.ecommerce;
             deactivate.card = new cardType();
             deactivate.id = "theId";
             deactivate.reportGroup = "theReportGroup";
 
-            String actual = deactivate.Serialize();
-            String expected = @"
+            var actual = deactivate.Serialize();
+            var expected = @"
 <deactivate id=""theId"" reportGroup=""theReportGroup"">
 <orderId>12345</orderId>
 <orderSource>ecommerce</orderSource>
@@ -551,15 +547,15 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void testDeactivate_OnlyRequired()
         {
-            deactivate deactivate = new deactivate();
+            var deactivate = new deactivate();
             deactivate.orderId = "12345";
             deactivate.orderSource = orderSourceType.ecommerce;
             deactivate.card = new cardType();
             deactivate.id = "theId";
             deactivate.reportGroup = "theReportGroup";
 
-            String actual = deactivate.Serialize();
-            String expected = @"
+            var actual = deactivate.Serialize();
+            var expected = @"
 <deactivate id=""theId"" reportGroup=""theReportGroup"">
 <orderId>12345</orderId>
 <orderSource>ecommerce</orderSource>
@@ -573,7 +569,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void testLoad_Full()
         {
-            load load = new load();
+            var load = new load();
             load.orderId = "12345";
             load.amount = 200;
             load.orderSource = orderSourceType.ecommerce;
@@ -581,8 +577,8 @@ namespace Litle.Sdk.Test.Unit
             load.id = "theId";
             load.reportGroup = "theReportGroup";
 
-            String actual = load.Serialize();
-            String expected = @"
+            var actual = load.Serialize();
+            var expected = @"
 <load id=""theId"" reportGroup=""theReportGroup"">
 <orderId>12345</orderId>
 <amount>200</amount>
@@ -597,7 +593,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void testLoad_OnlyRequired()
         {
-            load load = new load();
+            var load = new load();
             load.orderId = "12345";
             load.amount = 200;
             load.orderSource = orderSourceType.ecommerce;
@@ -605,8 +601,8 @@ namespace Litle.Sdk.Test.Unit
             load.id = "theId";
             load.reportGroup = "theReportGroup";
 
-            String actual = load.Serialize();
-            String expected = @"
+            var actual = load.Serialize();
+            var expected = @"
 <load id=""theId"" reportGroup=""theReportGroup"">
 <orderId>12345</orderId>
 <amount>200</amount>
@@ -621,7 +617,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void testUnload_Full()
         {
-            unload unload = new unload();
+            var unload = new unload();
             unload.orderId = "12345";
             unload.amount = 200;
             unload.orderSource = orderSourceType.ecommerce;
@@ -629,8 +625,8 @@ namespace Litle.Sdk.Test.Unit
             unload.id = "theId";
             unload.reportGroup = "theReportGroup";
 
-            String actual = unload.Serialize();
-            String expected = @"
+            var actual = unload.Serialize();
+            var expected = @"
 <unload id=""theId"" reportGroup=""theReportGroup"">
 <orderId>12345</orderId>
 <amount>200</amount>
@@ -645,7 +641,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void testUnload_OnlyRequired()
         {
-            unload unload = new unload();
+            var unload = new unload();
             unload.orderId = "12345";
             unload.amount = 200;
             unload.orderSource = orderSourceType.ecommerce;
@@ -653,8 +649,8 @@ namespace Litle.Sdk.Test.Unit
             unload.id = "theId";
             unload.reportGroup = "theReportGroup";
 
-            String actual = unload.Serialize();
-            String expected = @"
+            var actual = unload.Serialize();
+            var expected = @"
 <unload id=""theId"" reportGroup=""theReportGroup"">
 <orderId>12345</orderId>
 <amount>200</amount>
@@ -669,15 +665,15 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void testBalanceInquiry_Full()
         {
-            balanceInquiry balanceInquiry = new balanceInquiry();
+            var balanceInquiry = new balanceInquiry();
             balanceInquiry.orderId = "12345";
             balanceInquiry.orderSource = orderSourceType.ecommerce;
             balanceInquiry.card = new cardType();
             balanceInquiry.id = "theId";
             balanceInquiry.reportGroup = "theReportGroup";
 
-            String actual = balanceInquiry.Serialize();
-            String expected = @"
+            var actual = balanceInquiry.Serialize();
+            var expected = @"
 <balanceInquiry id=""theId"" reportGroup=""theReportGroup"">
 <orderId>12345</orderId>
 <orderSource>ecommerce</orderSource>
@@ -691,15 +687,15 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void testBalanceInquiry_OnlyRequired()
         {
-            balanceInquiry balanceInquiry = new balanceInquiry();
+            var balanceInquiry = new balanceInquiry();
             balanceInquiry.orderId = "12345";
             balanceInquiry.orderSource = orderSourceType.ecommerce;
             balanceInquiry.card = new cardType();
             balanceInquiry.id = "theId";
             balanceInquiry.reportGroup = "theReportGroup";
 
-            String actual = balanceInquiry.Serialize();
-            String expected = @"
+            var actual = balanceInquiry.Serialize();
+            var expected = @"
 <balanceInquiry id=""theId"" reportGroup=""theReportGroup"">
 <orderId>12345</orderId>
 <orderSource>ecommerce</orderSource>
@@ -713,7 +709,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestCreatePlan_Full()
         {
-            createPlan create = new createPlan();
+            var create = new createPlan();
             create.planCode = "abc";
             create.name = "thePlan";
             create.description = "theDescription";
@@ -724,8 +720,8 @@ namespace Litle.Sdk.Test.Unit
             create.trialIntervalType = trialIntervalType.MONTH;
             create.active = true;
 
-            String actual = create.Serialize();
-            String expected = @"
+            var actual = create.Serialize();
+            var expected = @"
 <createPlan>
 <planCode>abc</planCode>
 <name>thePlan</name>
@@ -744,14 +740,14 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestCreatePlan_OnlyRequired()
         {
-            createPlan create = new createPlan();
+            var create = new createPlan();
             create.planCode = "abc";
             create.name = "thePlan";
             create.intervalType = intervalType.ANNUAL;
             create.amount = 100;
 
-            String actual = create.Serialize();
-            String expected = @"
+            var actual = create.Serialize();
+            var expected = @"
 <createPlan>
 <planCode>abc</planCode>
 <name>thePlan</name>
@@ -764,12 +760,12 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestUpdatePlan_Full()
         {
-            updatePlan update = new updatePlan();
+            var update = new updatePlan();
             update.planCode = "abc";
             update.active = true;
 
-            String actual = update.Serialize();
-            String expected = @"
+            var actual = update.Serialize();
+            var expected = @"
 <updatePlan>
 <planCode>abc</planCode>
 <active>true</active>
@@ -780,13 +776,13 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TesLitleInternalRecurringRequestMustContainFinalPayment()
         {
-            litleInternalRecurringRequest litleInternalRecurringRequest = new litleInternalRecurringRequest();
+            var litleInternalRecurringRequest = new litleInternalRecurringRequest();
             litleInternalRecurringRequest.subscriptionId = "123";
             litleInternalRecurringRequest.recurringTxnId = "456";
             litleInternalRecurringRequest.finalPayment = true;
 
-            String actual = litleInternalRecurringRequest.Serialize();
-            String expected = @"
+            var actual = litleInternalRecurringRequest.Serialize();
+            var expected = @"
 <subscriptionId>123</subscriptionId>
 <recurringTxnId>456</recurringTxnId>
 <finalPayment>true</finalPayment>";
@@ -796,15 +792,15 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestCreateDiscount_Full()
         {
-            createDiscount cd = new createDiscount();
+            var cd = new createDiscount();
             cd.discountCode = "1";
             cd.name = "cheaper";
             cd.amount = 200;
             cd.startDate = new DateTime(2013, 9, 5);
             cd.endDate = new DateTime(2013, 9, 6);
 
-            String actual = cd.Serialize();
-            String expected = @"
+            var actual = cd.Serialize();
+            var expected = @"
 <discountCode>1</discountCode>
 <name>cheaper</name>
 <amount>200</amount>
@@ -816,15 +812,15 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestUpdateDiscount_Full()
         {
-            updateDiscount ud = new updateDiscount();
+            var ud = new updateDiscount();
             ud.discountCode = "1";
             ud.name = "cheaper";
             ud.amount = 200;
             ud.startDate = new DateTime(2013, 9, 5);
             ud.endDate = new DateTime(2013, 9, 6);
 
-            String actual = ud.Serialize();
-            String expected = @"
+            var actual = ud.Serialize();
+            var expected = @"
 <discountCode>1</discountCode>
 <name>cheaper</name>
 <amount>200</amount>
@@ -836,11 +832,11 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestUpdateDiscount_OnlyRequired()
         {
-            updateDiscount ud = new updateDiscount();
+            var ud = new updateDiscount();
             ud.discountCode = "1";
 
-            String actual = ud.Serialize();
-            String expected = @"
+            var actual = ud.Serialize();
+            var expected = @"
 <discountCode>1</discountCode>";
             Assert.AreEqual(expected, actual);
         }
@@ -848,11 +844,11 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestDeleteDiscount()
         {
-            deleteDiscount ud = new deleteDiscount();
+            var ud = new deleteDiscount();
             ud.discountCode = "1";
 
-            String actual = ud.Serialize();
-            String expected = @"
+            var actual = ud.Serialize();
+            var expected = @"
 <discountCode>1</discountCode>";
             Assert.AreEqual(expected, actual);
         }
@@ -860,15 +856,15 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestCreateAddOn()
         {
-            createAddOn cao = new createAddOn();
+            var cao = new createAddOn();
             cao.addOnCode = "1";
             cao.name = "addOn1";
             cao.amount = 100;
             cao.startDate = new DateTime(2013, 9, 5);
             cao.endDate = new DateTime(2013, 9, 6);
 
-            String actual = cao.Serialize();
-            String expected = @"
+            var actual = cao.Serialize();
+            var expected = @"
 <addOnCode>1</addOnCode>
 <name>addOn1</name>
 <amount>100</amount>
@@ -880,15 +876,15 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestUpdateAddOn_Full()
         {
-            updateAddOn uao = new updateAddOn();
+            var uao = new updateAddOn();
             uao.addOnCode = "1";
             uao.name = "addOn1";
             uao.amount = 100;
             uao.startDate = new DateTime(2013, 9, 5);
             uao.endDate = new DateTime(2013, 9, 6);
 
-            String actual = uao.Serialize();
-            String expected = @"
+            var actual = uao.Serialize();
+            var expected = @"
 <addOnCode>1</addOnCode>
 <name>addOn1</name>
 <amount>100</amount>
@@ -900,11 +896,11 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestUpdateAddOn_OnlyRequired()
         {
-            updateAddOn uao = new updateAddOn();
+            var uao = new updateAddOn();
             uao.addOnCode = "1";
 
-            String actual = uao.Serialize();
-            String expected = @"
+            var actual = uao.Serialize();
+            var expected = @"
 <addOnCode>1</addOnCode>";
             Assert.AreEqual(expected, actual);
         }
@@ -912,11 +908,11 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestDeleteAddOn()
         {
-            deleteAddOn dao = new deleteAddOn();
+            var dao = new deleteAddOn();
             dao.addOnCode = "1";
 
-            String actual = dao.Serialize();
-            String expected = @"
+            var actual = dao.Serialize();
+            var expected = @"
 <addOnCode>1</addOnCode>";
             Assert.AreEqual(expected, actual);
         }
@@ -924,14 +920,14 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void testDepositReversal_Full()
         {
-            depositReversal depositReversal = new depositReversal();
+            var depositReversal = new depositReversal();
             depositReversal.id = "theId";
             depositReversal.reportGroup = "theReportGroup";
             depositReversal.customerId = "theCustomerId";
             depositReversal.litleTxnId = "123";
 
-            String actual = depositReversal.Serialize();
-            String expected = @"
+            var actual = depositReversal.Serialize();
+            var expected = @"
 <depositReversal id=""theId"" customerId=""theCustomerId"" reportGroup=""theReportGroup"">
 <litleTxnId>123</litleTxnId>
 </depositReversal>";
@@ -941,14 +937,14 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void testRefundReversal_Full()
         {
-            refundReversal refundReversal = new refundReversal();
+            var refundReversal = new refundReversal();
             refundReversal.id = "theId";
             refundReversal.reportGroup = "theReportGroup";
             refundReversal.customerId = "theCustomerId";
             refundReversal.litleTxnId = "123";
 
-            String actual = refundReversal.Serialize();
-            String expected = @"
+            var actual = refundReversal.Serialize();
+            var expected = @"
 <refundReversal id=""theId"" customerId=""theCustomerId"" reportGroup=""theReportGroup"">
 <litleTxnId>123</litleTxnId>
 </refundReversal>";
@@ -958,14 +954,14 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void testActivateReversal_Full()
         {
-            activateReversal activateReversal = new activateReversal();
+            var activateReversal = new activateReversal();
             activateReversal.id = "theId";
             activateReversal.reportGroup = "theReportGroup";
             activateReversal.customerId = "theCustomerId";
             activateReversal.litleTxnId = "123";
 
-            String actual = activateReversal.Serialize();
-            String expected = @"
+            var actual = activateReversal.Serialize();
+            var expected = @"
 <activateReversal id=""theId"" customerId=""theCustomerId"" reportGroup=""theReportGroup"">
 <litleTxnId>123</litleTxnId>
 </activateReversal>";
@@ -975,14 +971,14 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void testDeactivateReversal_Full()
         {
-            deactivateReversal deactivateReversal = new deactivateReversal();
+            var deactivateReversal = new deactivateReversal();
             deactivateReversal.id = "theId";
             deactivateReversal.reportGroup = "theReportGroup";
             deactivateReversal.customerId = "theCustomerId";
             deactivateReversal.litleTxnId = "123";
 
-            String actual = deactivateReversal.Serialize();
-            String expected = @"
+            var actual = deactivateReversal.Serialize();
+            var expected = @"
 <deactivateReversal id=""theId"" customerId=""theCustomerId"" reportGroup=""theReportGroup"">
 <litleTxnId>123</litleTxnId>
 </deactivateReversal>";
@@ -992,14 +988,14 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void testLoadReversal_Full()
         {
-            loadReversal loadReversal = new loadReversal();
+            var loadReversal = new loadReversal();
             loadReversal.id = "theId";
             loadReversal.reportGroup = "theReportGroup";
             loadReversal.customerId = "theCustomerId";
             loadReversal.litleTxnId = "123";
 
-            String actual = loadReversal.Serialize();
-            String expected = @"
+            var actual = loadReversal.Serialize();
+            var expected = @"
 <loadReversal id=""theId"" customerId=""theCustomerId"" reportGroup=""theReportGroup"">
 <litleTxnId>123</litleTxnId>
 </loadReversal>";
@@ -1009,14 +1005,14 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void testUnloadReversal_Full()
         {
-            unloadReversal unloadReversal = new unloadReversal();
+            var unloadReversal = new unloadReversal();
             unloadReversal.id = "theId";
             unloadReversal.reportGroup = "theReportGroup";
             unloadReversal.customerId = "theCustomerId";
             unloadReversal.litleTxnId = "123";
 
-            String actual = unloadReversal.Serialize();
-            String expected = @"
+            var actual = unloadReversal.Serialize();
+            var expected = @"
 <unloadReversal id=""theId"" customerId=""theCustomerId"" reportGroup=""theReportGroup"">
 <litleTxnId>123</litleTxnId>
 </unloadReversal>";
@@ -1026,14 +1022,14 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void testSpecialCharacters_RefundReversal()
         {
-            refundReversal refundReversal = new refundReversal();
+            var refundReversal = new refundReversal();
             refundReversal.id = "theId";
             refundReversal.reportGroup = "<'&\">";
             refundReversal.customerId = "theCustomerId";
             refundReversal.litleTxnId = "123";
 
-            String actual = refundReversal.Serialize();
-            String expected = @"
+            var actual = refundReversal.Serialize();
+            var expected = @"
 <refundReversal id=""theId"" customerId=""theCustomerId"" reportGroup=""&lt;&apos;&amp;&quot;&gt;"">
 <litleTxnId>123</litleTxnId>
 </refundReversal>";
@@ -1043,13 +1039,13 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestEmptyMethodOfPayment()
         {
-            cardType card = new cardType();
+            var card = new cardType();
             card.type = methodOfPaymentTypeEnum.Item;
             card.number = "4100000000000001";
             card.expDate = "1250";
 
-            String actual = card.Serialize();
-            String expected = @"
+            var actual = card.Serialize();
+            var expected = @"
 <type></type>
 <number>4100000000000001</number>
 <expDate>1250</expDate>";

--- a/LitleSdkForNet/LitleSdkForNetTest/Unit/TestXmlFieldsUnserializer.cs
+++ b/LitleSdkForNet/LitleSdkForNetTest/Unit/TestXmlFieldsUnserializer.cs
@@ -1,20 +1,13 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using NUnit.Framework;
-using Litle.Sdk;
-using Moq;
-using System.Text.RegularExpressions;
-using System.Xml.Serialization;
 using System.IO;
-
+using System.Xml.Serialization;
+using NUnit.Framework;
 
 namespace Litle.Sdk.Test.Unit
 {
     [TestFixture]
-    class TestXmlFieldsUnserializer
+    internal class TestXmlFieldsUnserializer
     {
-
         [TestFixtureSetUp]
         public void SetUpLitle()
         {
@@ -23,10 +16,11 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestAuthorizationResponseContainsGiftCardResponse()
         {
-            String xml = "<authorizationResponse xmlns=\"http://www.litle.com/schema\"><giftCardResponse></giftCardResponse></authorizationResponse>";
-            XmlSerializer serializer = new XmlSerializer(typeof(authorizationResponse));
-            StringReader reader = new StringReader(xml);
-            authorizationResponse authorizationResponse = (authorizationResponse)serializer.Deserialize(reader);
+            var xml =
+                "<authorizationResponse xmlns=\"http://www.litle.com/schema\"><giftCardResponse></giftCardResponse></authorizationResponse>";
+            var serializer = new XmlSerializer(typeof (authorizationResponse));
+            var reader = new StringReader(xml);
+            var authorizationResponse = (authorizationResponse) serializer.Deserialize(reader);
 
             Assert.NotNull(authorizationResponse.giftCardResponse);
         }
@@ -34,10 +28,11 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestAuthReversalResponseContainsGiftCardResponse()
         {
-            String xml = "<authReversalResponse xmlns=\"http://www.litle.com/schema\"><giftCardResponse></giftCardResponse></authReversalResponse>";
-            XmlSerializer serializer = new XmlSerializer(typeof(authReversalResponse));
-            StringReader reader = new StringReader(xml);
-            authReversalResponse authReversalResponse = (authReversalResponse)serializer.Deserialize(reader);
+            var xml =
+                "<authReversalResponse xmlns=\"http://www.litle.com/schema\"><giftCardResponse></giftCardResponse></authReversalResponse>";
+            var serializer = new XmlSerializer(typeof (authReversalResponse));
+            var reader = new StringReader(xml);
+            var authReversalResponse = (authReversalResponse) serializer.Deserialize(reader);
 
             Assert.NotNull(authReversalResponse.giftCardResponse);
         }
@@ -45,10 +40,11 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestCaptureResponseContainsGiftCardResponse()
         {
-            String xml = "<captureResponse xmlns=\"http://www.litle.com/schema\"><giftCardResponse></giftCardResponse></captureResponse>";
-            XmlSerializer serializer = new XmlSerializer(typeof(captureResponse));
-            StringReader reader = new StringReader(xml);
-            captureResponse captureResponse = (captureResponse)serializer.Deserialize(reader);
+            var xml =
+                "<captureResponse xmlns=\"http://www.litle.com/schema\"><giftCardResponse></giftCardResponse></captureResponse>";
+            var serializer = new XmlSerializer(typeof (captureResponse));
+            var reader = new StringReader(xml);
+            var captureResponse = (captureResponse) serializer.Deserialize(reader);
 
             Assert.NotNull(captureResponse.giftCardResponse);
         }
@@ -56,10 +52,11 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestCaptureResponseContainsFraudResult()
         {
-            String xml = "<captureResponse xmlns=\"http://www.litle.com/schema\"><fraudResult></fraudResult></captureResponse>";
-            XmlSerializer serializer = new XmlSerializer(typeof(captureResponse));
-            StringReader reader = new StringReader(xml);
-            captureResponse captureResponse = (captureResponse)serializer.Deserialize(reader);
+            var xml =
+                "<captureResponse xmlns=\"http://www.litle.com/schema\"><fraudResult></fraudResult></captureResponse>";
+            var serializer = new XmlSerializer(typeof (captureResponse));
+            var reader = new StringReader(xml);
+            var captureResponse = (captureResponse) serializer.Deserialize(reader);
 
             Assert.NotNull(captureResponse.fraudResult);
         }
@@ -67,10 +64,11 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestForceCaptureResponseContainsGiftCardResponse()
         {
-            String xml = "<forceCaptureResponse xmlns=\"http://www.litle.com/schema\"><giftCardResponse></giftCardResponse></forceCaptureResponse>";
-            XmlSerializer serializer = new XmlSerializer(typeof(forceCaptureResponse));
-            StringReader reader = new StringReader(xml);
-            forceCaptureResponse forceCaptureResponse = (forceCaptureResponse)serializer.Deserialize(reader);
+            var xml =
+                "<forceCaptureResponse xmlns=\"http://www.litle.com/schema\"><giftCardResponse></giftCardResponse></forceCaptureResponse>";
+            var serializer = new XmlSerializer(typeof (forceCaptureResponse));
+            var reader = new StringReader(xml);
+            var forceCaptureResponse = (forceCaptureResponse) serializer.Deserialize(reader);
 
             Assert.NotNull(forceCaptureResponse.giftCardResponse);
         }
@@ -78,10 +76,11 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestForceCaptureResponseContainsFraudResult()
         {
-            String xml = "<forceCaptureResponse xmlns=\"http://www.litle.com/schema\"><fraudResult></fraudResult></forceCaptureResponse>";
-            XmlSerializer serializer = new XmlSerializer(typeof(forceCaptureResponse));
-            StringReader reader = new StringReader(xml);
-            forceCaptureResponse forceCaptureResponse = (forceCaptureResponse)serializer.Deserialize(reader);
+            var xml =
+                "<forceCaptureResponse xmlns=\"http://www.litle.com/schema\"><fraudResult></fraudResult></forceCaptureResponse>";
+            var serializer = new XmlSerializer(typeof (forceCaptureResponse));
+            var reader = new StringReader(xml);
+            var forceCaptureResponse = (forceCaptureResponse) serializer.Deserialize(reader);
 
             Assert.NotNull(forceCaptureResponse.fraudResult);
         }
@@ -89,10 +88,11 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestCaptureGivenAuthResponseContainsGiftCardResponse()
         {
-            String xml = "<captureGivenAuthResponse xmlns=\"http://www.litle.com/schema\"><giftCardResponse></giftCardResponse></captureGivenAuthResponse>";
-            XmlSerializer serializer = new XmlSerializer(typeof(captureGivenAuthResponse));
-            StringReader reader = new StringReader(xml);
-            captureGivenAuthResponse captureGivenAuthResponse = (captureGivenAuthResponse)serializer.Deserialize(reader);
+            var xml =
+                "<captureGivenAuthResponse xmlns=\"http://www.litle.com/schema\"><giftCardResponse></giftCardResponse></captureGivenAuthResponse>";
+            var serializer = new XmlSerializer(typeof (captureGivenAuthResponse));
+            var reader = new StringReader(xml);
+            var captureGivenAuthResponse = (captureGivenAuthResponse) serializer.Deserialize(reader);
 
             Assert.NotNull(captureGivenAuthResponse.giftCardResponse);
         }
@@ -100,10 +100,11 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestCaptureGivenAuthResponseContainsFraudResult()
         {
-            String xml = "<captureGivenAuthResponse xmlns=\"http://www.litle.com/schema\"><fraudResult></fraudResult></captureGivenAuthResponse>";
-            XmlSerializer serializer = new XmlSerializer(typeof(captureGivenAuthResponse));
-            StringReader reader = new StringReader(xml);
-            captureGivenAuthResponse captureGivenAuthResponse = (captureGivenAuthResponse)serializer.Deserialize(reader);
+            var xml =
+                "<captureGivenAuthResponse xmlns=\"http://www.litle.com/schema\"><fraudResult></fraudResult></captureGivenAuthResponse>";
+            var serializer = new XmlSerializer(typeof (captureGivenAuthResponse));
+            var reader = new StringReader(xml);
+            var captureGivenAuthResponse = (captureGivenAuthResponse) serializer.Deserialize(reader);
 
             Assert.NotNull(captureGivenAuthResponse.fraudResult);
         }
@@ -111,10 +112,11 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestSaleResponseContainsGiftCardResponse()
         {
-            String xml = "<saleResponse xmlns=\"http://www.litle.com/schema\"><giftCardResponse></giftCardResponse></saleResponse>";
-            XmlSerializer serializer = new XmlSerializer(typeof(saleResponse));
-            StringReader reader = new StringReader(xml);
-            saleResponse saleResponse = (saleResponse)serializer.Deserialize(reader);
+            var xml =
+                "<saleResponse xmlns=\"http://www.litle.com/schema\"><giftCardResponse></giftCardResponse></saleResponse>";
+            var serializer = new XmlSerializer(typeof (saleResponse));
+            var reader = new StringReader(xml);
+            var saleResponse = (saleResponse) serializer.Deserialize(reader);
 
             Assert.NotNull(saleResponse.giftCardResponse);
         }
@@ -122,10 +124,11 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestCreditResponseContainsGiftCardResponse()
         {
-            String xml = "<creditResponse xmlns=\"http://www.litle.com/schema\"><giftCardResponse></giftCardResponse></creditResponse>";
-            XmlSerializer serializer = new XmlSerializer(typeof(creditResponse));
-            StringReader reader = new StringReader(xml);
-            creditResponse creditResponse = (creditResponse)serializer.Deserialize(reader);
+            var xml =
+                "<creditResponse xmlns=\"http://www.litle.com/schema\"><giftCardResponse></giftCardResponse></creditResponse>";
+            var serializer = new XmlSerializer(typeof (creditResponse));
+            var reader = new StringReader(xml);
+            var creditResponse = (creditResponse) serializer.Deserialize(reader);
 
             Assert.NotNull(creditResponse.giftCardResponse);
         }
@@ -133,10 +136,11 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestCreditResponseContainsFraudResult()
         {
-            String xml = "<creditResponse xmlns=\"http://www.litle.com/schema\"><fraudResult></fraudResult></creditResponse>";
-            XmlSerializer serializer = new XmlSerializer(typeof(creditResponse));
-            StringReader reader = new StringReader(xml);
-            creditResponse creditResponse = (creditResponse)serializer.Deserialize(reader);
+            var xml =
+                "<creditResponse xmlns=\"http://www.litle.com/schema\"><fraudResult></fraudResult></creditResponse>";
+            var serializer = new XmlSerializer(typeof (creditResponse));
+            var reader = new StringReader(xml);
+            var creditResponse = (creditResponse) serializer.Deserialize(reader);
 
             Assert.NotNull(creditResponse.fraudResult);
         }
@@ -144,10 +148,11 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestActivateResponse()
         {
-            String xml = "<activateResponse reportGroup=\"A\" id=\"3\" customerId=\"4\" duplicate=\"true\" xmlns=\"http://www.litle.com/schema\"><litleTxnId>1</litleTxnId><orderId>2</orderId><response>000</response><responseTime>2013-09-05T14:23:45</responseTime><postDate>2013-09-05</postDate><message>Approved</message><fraudResult></fraudResult><giftCardResponse></giftCardResponse></activateResponse>";
-            XmlSerializer serializer = new XmlSerializer(typeof(activateResponse));
-            StringReader reader = new StringReader(xml);
-            activateResponse activateResponse = (activateResponse)serializer.Deserialize(reader);
+            var xml =
+                "<activateResponse reportGroup=\"A\" id=\"3\" customerId=\"4\" duplicate=\"true\" xmlns=\"http://www.litle.com/schema\"><litleTxnId>1</litleTxnId><orderId>2</orderId><response>000</response><responseTime>2013-09-05T14:23:45</responseTime><postDate>2013-09-05</postDate><message>Approved</message><fraudResult></fraudResult><giftCardResponse></giftCardResponse></activateResponse>";
+            var serializer = new XmlSerializer(typeof (activateResponse));
+            var reader = new StringReader(xml);
+            var activateResponse = (activateResponse) serializer.Deserialize(reader);
 
             Assert.AreEqual("A", activateResponse.reportGroup);
             Assert.AreEqual("3", activateResponse.id);
@@ -156,8 +161,8 @@ namespace Litle.Sdk.Test.Unit
             Assert.AreEqual("1", activateResponse.litleTxnId);
             Assert.AreEqual("2", activateResponse.orderId);
             Assert.AreEqual("000", activateResponse.response);
-            Assert.AreEqual(new DateTime(2013,9,5,14,23,45), activateResponse.responseTime);
-            Assert.AreEqual(new DateTime(2013,9,5), activateResponse.postDate);
+            Assert.AreEqual(new DateTime(2013, 9, 5, 14, 23, 45), activateResponse.responseTime);
+            Assert.AreEqual(new DateTime(2013, 9, 5), activateResponse.postDate);
             Assert.AreEqual("Approved", activateResponse.message);
             Assert.NotNull(activateResponse.fraudResult);
             Assert.NotNull(activateResponse.giftCardResponse);
@@ -166,10 +171,11 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestLoadResponse()
         {
-            String xml = "<loadResponse reportGroup=\"A\" id=\"3\" customerId=\"4\" duplicate=\"true\" xmlns=\"http://www.litle.com/schema\"><litleTxnId>1</litleTxnId><orderId>2</orderId><response>000</response><responseTime>2013-09-05T14:23:45</responseTime><postDate>2013-09-05</postDate><message>Approved</message><fraudResult></fraudResult><giftCardResponse></giftCardResponse></loadResponse>";
-            XmlSerializer serializer = new XmlSerializer(typeof(loadResponse));
-            StringReader reader = new StringReader(xml);
-            loadResponse loadResponse = (loadResponse)serializer.Deserialize(reader);
+            var xml =
+                "<loadResponse reportGroup=\"A\" id=\"3\" customerId=\"4\" duplicate=\"true\" xmlns=\"http://www.litle.com/schema\"><litleTxnId>1</litleTxnId><orderId>2</orderId><response>000</response><responseTime>2013-09-05T14:23:45</responseTime><postDate>2013-09-05</postDate><message>Approved</message><fraudResult></fraudResult><giftCardResponse></giftCardResponse></loadResponse>";
+            var serializer = new XmlSerializer(typeof (loadResponse));
+            var reader = new StringReader(xml);
+            var loadResponse = (loadResponse) serializer.Deserialize(reader);
 
             Assert.AreEqual("A", loadResponse.reportGroup);
             Assert.AreEqual("3", loadResponse.id);
@@ -188,10 +194,11 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestUnloadResponse()
         {
-            String xml = "<unloadResponse reportGroup=\"A\" id=\"3\" customerId=\"4\" duplicate=\"true\" xmlns=\"http://www.litle.com/schema\"><litleTxnId>1</litleTxnId><orderId>2</orderId><response>000</response><responseTime>2013-09-05T14:23:45</responseTime><postDate>2013-09-05</postDate><message>Approved</message><fraudResult></fraudResult><giftCardResponse></giftCardResponse></unloadResponse>";
-            XmlSerializer serializer = new XmlSerializer(typeof(unloadResponse));
-            StringReader reader = new StringReader(xml);
-            unloadResponse unloadResponse = (unloadResponse)serializer.Deserialize(reader);
+            var xml =
+                "<unloadResponse reportGroup=\"A\" id=\"3\" customerId=\"4\" duplicate=\"true\" xmlns=\"http://www.litle.com/schema\"><litleTxnId>1</litleTxnId><orderId>2</orderId><response>000</response><responseTime>2013-09-05T14:23:45</responseTime><postDate>2013-09-05</postDate><message>Approved</message><fraudResult></fraudResult><giftCardResponse></giftCardResponse></unloadResponse>";
+            var serializer = new XmlSerializer(typeof (unloadResponse));
+            var reader = new StringReader(xml);
+            var unloadResponse = (unloadResponse) serializer.Deserialize(reader);
 
             Assert.AreEqual("A", unloadResponse.reportGroup);
             Assert.AreEqual("3", unloadResponse.id);
@@ -210,11 +217,12 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestGiftCardResponse()
         {
-            String xml = "<balanceInquiryResponse reportGroup=\"A\" id=\"3\" customerId=\"4\" xmlns=\"http://www.litle.com/schema\"><giftCardResponse><availableBalance>1</availableBalance><beginningBalance>2</beginningBalance><endingBalance>3</endingBalance><cashBackAmount>4</cashBackAmount></giftCardResponse></balanceInquiryResponse>";
-            XmlSerializer serializer = new XmlSerializer(typeof(balanceInquiryResponse));
-            StringReader reader = new StringReader(xml);
-            balanceInquiryResponse balanceInquiryResponse = (balanceInquiryResponse)serializer.Deserialize(reader);
-            giftCardResponse giftCardResponse = balanceInquiryResponse.giftCardResponse;
+            var xml =
+                "<balanceInquiryResponse reportGroup=\"A\" id=\"3\" customerId=\"4\" xmlns=\"http://www.litle.com/schema\"><giftCardResponse><availableBalance>1</availableBalance><beginningBalance>2</beginningBalance><endingBalance>3</endingBalance><cashBackAmount>4</cashBackAmount></giftCardResponse></balanceInquiryResponse>";
+            var serializer = new XmlSerializer(typeof (balanceInquiryResponse));
+            var reader = new StringReader(xml);
+            var balanceInquiryResponse = (balanceInquiryResponse) serializer.Deserialize(reader);
+            var giftCardResponse = balanceInquiryResponse.giftCardResponse;
 
             Assert.AreEqual("1", giftCardResponse.availableBalance);
             Assert.AreEqual("2", giftCardResponse.beginningBalance);
@@ -225,10 +233,11 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestBalanceInquiryResponse()
         {
-            String xml = "<balanceInquiryResponse reportGroup=\"A\" id=\"3\" customerId=\"4\" xmlns=\"http://www.litle.com/schema\"><litleTxnId>1</litleTxnId><orderId>2</orderId><response>000</response><responseTime>2013-09-05T14:23:45</responseTime><postDate>2013-09-05</postDate><message>Approved</message><fraudResult></fraudResult><giftCardResponse></giftCardResponse></balanceInquiryResponse>";
-            XmlSerializer serializer = new XmlSerializer(typeof(balanceInquiryResponse));
-            StringReader reader = new StringReader(xml);
-            balanceInquiryResponse balanceInquiryResponse = (balanceInquiryResponse)serializer.Deserialize(reader);
+            var xml =
+                "<balanceInquiryResponse reportGroup=\"A\" id=\"3\" customerId=\"4\" xmlns=\"http://www.litle.com/schema\"><litleTxnId>1</litleTxnId><orderId>2</orderId><response>000</response><responseTime>2013-09-05T14:23:45</responseTime><postDate>2013-09-05</postDate><message>Approved</message><fraudResult></fraudResult><giftCardResponse></giftCardResponse></balanceInquiryResponse>";
+            var serializer = new XmlSerializer(typeof (balanceInquiryResponse));
+            var reader = new StringReader(xml);
+            var balanceInquiryResponse = (balanceInquiryResponse) serializer.Deserialize(reader);
 
             Assert.AreEqual("A", balanceInquiryResponse.reportGroup);
             Assert.AreEqual("3", balanceInquiryResponse.id);
@@ -246,10 +255,11 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestDeactivateResponse()
         {
-            String xml = "<deactivateResponse reportGroup=\"A\" id=\"3\" customerId=\"4\" xmlns=\"http://www.litle.com/schema\"><litleTxnId>1</litleTxnId><orderId>2</orderId><response>000</response><responseTime>2013-09-05T14:23:45</responseTime><postDate>2013-09-05</postDate><message>Approved</message><fraudResult></fraudResult><giftCardResponse></giftCardResponse></deactivateResponse>";
-            XmlSerializer serializer = new XmlSerializer(typeof(deactivateResponse));
-            StringReader reader = new StringReader(xml);
-            deactivateResponse deactivateResponse = (deactivateResponse)serializer.Deserialize(reader);
+            var xml =
+                "<deactivateResponse reportGroup=\"A\" id=\"3\" customerId=\"4\" xmlns=\"http://www.litle.com/schema\"><litleTxnId>1</litleTxnId><orderId>2</orderId><response>000</response><responseTime>2013-09-05T14:23:45</responseTime><postDate>2013-09-05</postDate><message>Approved</message><fraudResult></fraudResult><giftCardResponse></giftCardResponse></deactivateResponse>";
+            var serializer = new XmlSerializer(typeof (deactivateResponse));
+            var reader = new StringReader(xml);
+            var deactivateResponse = (deactivateResponse) serializer.Deserialize(reader);
 
             Assert.AreEqual("A", deactivateResponse.reportGroup);
             Assert.AreEqual("3", deactivateResponse.id);
@@ -267,7 +277,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestCreatePlanResponse()
         {
-            String xml = @"
+            var xml = @"
 <createPlanResponse xmlns=""http://www.litle.com/schema"">
 <litleTxnId>1</litleTxnId>
 <response>000</response>
@@ -275,9 +285,9 @@ namespace Litle.Sdk.Test.Unit
 <responseTime>2013-09-05T14:23:45</responseTime>
 <planCode>thePlan</planCode>
 </createPlanResponse>";
-            XmlSerializer serializer = new XmlSerializer(typeof(createPlanResponse));
-            StringReader reader = new StringReader(xml);
-            createPlanResponse createPlanResponse = (createPlanResponse)serializer.Deserialize(reader);
+            var serializer = new XmlSerializer(typeof (createPlanResponse));
+            var reader = new StringReader(xml);
+            var createPlanResponse = (createPlanResponse) serializer.Deserialize(reader);
 
             Assert.AreEqual("1", createPlanResponse.litleTxnId);
             Assert.AreEqual("000", createPlanResponse.response);
@@ -289,7 +299,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestUpdatePlanResponse()
         {
-            String xml = @"
+            var xml = @"
 <updatePlanResponse xmlns=""http://www.litle.com/schema"">
 <litleTxnId>1</litleTxnId>
 <response>000</response>
@@ -297,9 +307,9 @@ namespace Litle.Sdk.Test.Unit
 <responseTime>2013-09-05T14:23:45</responseTime>
 <planCode>thePlan</planCode>
 </updatePlanResponse>";
-            XmlSerializer serializer = new XmlSerializer(typeof(updatePlanResponse));
-            StringReader reader = new StringReader(xml);
-            updatePlanResponse updatePlanResponse = (updatePlanResponse)serializer.Deserialize(reader);
+            var serializer = new XmlSerializer(typeof (updatePlanResponse));
+            var reader = new StringReader(xml);
+            var updatePlanResponse = (updatePlanResponse) serializer.Deserialize(reader);
 
             Assert.AreEqual("1", updatePlanResponse.litleTxnId);
             Assert.AreEqual("000", updatePlanResponse.response);
@@ -311,7 +321,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestUpdateSubscriptionResponseCanContainTokenResponse()
         {
-            String xml = @"
+            var xml = @"
 <updateSubscriptionResponse xmlns=""http://www.litle.com/schema"">
 <litleTxnId>1</litleTxnId>
 <response>000</response>
@@ -322,9 +332,9 @@ namespace Litle.Sdk.Test.Unit
 <litleToken>123456</litleToken>
 </tokenResponse>
 </updateSubscriptionResponse>";
-            XmlSerializer serializer = new XmlSerializer(typeof(updateSubscriptionResponse));
-            StringReader reader = new StringReader(xml);
-            updateSubscriptionResponse updateSubscriptionResponse = (updateSubscriptionResponse)serializer.Deserialize(reader);
+            var serializer = new XmlSerializer(typeof (updateSubscriptionResponse));
+            var reader = new StringReader(xml);
+            var updateSubscriptionResponse = (updateSubscriptionResponse) serializer.Deserialize(reader);
             Assert.AreEqual("123", updateSubscriptionResponse.subscriptionId);
             Assert.AreEqual("123456", updateSubscriptionResponse.tokenResponse.litleToken);
         }
@@ -332,27 +342,27 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestEnhancedAuthResponseCanContainVirtualAccountNumber()
         {
-            String xml = @"
+            var xml = @"
 <enhancedAuthResponse xmlns=""http://www.litle.com/schema"">
 <virtualAccountNumber>true</virtualAccountNumber>
 </enhancedAuthResponse>";
-            XmlSerializer serializer = new XmlSerializer(typeof(enhancedAuthResponse));
-            StringReader reader = new StringReader(xml);
-            enhancedAuthResponse enhancedAuthResponse = (enhancedAuthResponse)serializer.Deserialize(reader);
+            var serializer = new XmlSerializer(typeof (enhancedAuthResponse));
+            var reader = new StringReader(xml);
+            var enhancedAuthResponse = (enhancedAuthResponse) serializer.Deserialize(reader);
             Assert.IsTrue(enhancedAuthResponse.virtualAccountNumber);
         }
 
         [Test]
         public void TestEnhancedAuthResponseWithCardProductType()
         {
-            String xml = @"
+            var xml = @"
 <enhancedAuthResponse xmlns=""http://www.litle.com/schema"">
 <virtualAccountNumber>true</virtualAccountNumber>
 <cardProductType>COMMERCIAL</cardProductType>
 </enhancedAuthResponse>";
-            XmlSerializer serializer = new XmlSerializer(typeof(enhancedAuthResponse));
-            StringReader reader = new StringReader(xml);
-            enhancedAuthResponse enhancedAuthResponse = (enhancedAuthResponse)serializer.Deserialize(reader);
+            var serializer = new XmlSerializer(typeof (enhancedAuthResponse));
+            var reader = new StringReader(xml);
+            var enhancedAuthResponse = (enhancedAuthResponse) serializer.Deserialize(reader);
             Assert.IsTrue(enhancedAuthResponse.virtualAccountNumber);
             Assert.AreEqual(cardProductTypeEnum.COMMERCIAL, enhancedAuthResponse.cardProductType);
         }
@@ -360,13 +370,13 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestEnhancedAuthResponseWithNullableEnumFields()
         {
-            String xml = @"
+            var xml = @"
 <enhancedAuthResponse xmlns=""http://www.litle.com/schema"">
 <virtualAccountNumber>1</virtualAccountNumber>
 </enhancedAuthResponse>";
-            XmlSerializer serializer = new XmlSerializer(typeof(enhancedAuthResponse));
-            StringReader reader = new StringReader(xml);
-            enhancedAuthResponse enhancedAuthResponse = (enhancedAuthResponse)serializer.Deserialize(reader);
+            var serializer = new XmlSerializer(typeof (enhancedAuthResponse));
+            var reader = new StringReader(xml);
+            var enhancedAuthResponse = (enhancedAuthResponse) serializer.Deserialize(reader);
             Assert.IsTrue(enhancedAuthResponse.virtualAccountNumber);
             Assert.IsNull(enhancedAuthResponse.cardProductType);
             Assert.IsNull(enhancedAuthResponse.affluence);
@@ -375,7 +385,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestAuthReversalResponseCanContainGiftCardResponse()
         {
-            String xml = @"
+            var xml = @"
 <authReversalResponse xmlns=""http://www.litle.com/schema"" id=""theId"" customerId=""theCustomerId"" reportGroup=""theReportGroup"">
 <litleTxnId>1</litleTxnId>
 <orderId>2</orderId>
@@ -387,9 +397,9 @@ namespace Litle.Sdk.Test.Unit
 <availableBalance>5</availableBalance>
 </giftCardResponse>
 </authReversalResponse>";
-            XmlSerializer serializer = new XmlSerializer(typeof(authReversalResponse));
-            StringReader reader = new StringReader(xml);
-            authReversalResponse authReversalResponse = (authReversalResponse)serializer.Deserialize(reader);
+            var serializer = new XmlSerializer(typeof (authReversalResponse));
+            var reader = new StringReader(xml);
+            var authReversalResponse = (authReversalResponse) serializer.Deserialize(reader);
             Assert.AreEqual("theId", authReversalResponse.id);
             Assert.AreEqual("theCustomerId", authReversalResponse.customerId);
             Assert.AreEqual("theReportGroup", authReversalResponse.reportGroup);
@@ -405,7 +415,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestDepositReversalResponseCanContainGiftCardResponse()
         {
-            String xml = @"
+            var xml = @"
 <depositReversalResponse xmlns=""http://www.litle.com/schema"" id=""theId"" customerId=""theCustomerId"" reportGroup=""theReportGroup"">
 <litleTxnId>1</litleTxnId>
 <orderId>2</orderId>
@@ -417,9 +427,9 @@ namespace Litle.Sdk.Test.Unit
 <availableBalance>5</availableBalance>
 </giftCardResponse>
 </depositReversalResponse>";
-            XmlSerializer serializer = new XmlSerializer(typeof(depositReversalResponse));
-            StringReader reader = new StringReader(xml);
-            depositReversalResponse depositReversalResponse = (depositReversalResponse)serializer.Deserialize(reader);
+            var serializer = new XmlSerializer(typeof (depositReversalResponse));
+            var reader = new StringReader(xml);
+            var depositReversalResponse = (depositReversalResponse) serializer.Deserialize(reader);
             Assert.AreEqual("theId", depositReversalResponse.id);
             Assert.AreEqual("theCustomerId", depositReversalResponse.customerId);
             Assert.AreEqual("theReportGroup", depositReversalResponse.reportGroup);
@@ -435,7 +445,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestActivateReversalResponseCanContainGiftCardResponse()
         {
-            String xml = @"
+            var xml = @"
 <activateReversalResponse xmlns=""http://www.litle.com/schema"" id=""theId"" customerId=""theCustomerId"" reportGroup=""theReportGroup"">
 <litleTxnId>1</litleTxnId>
 <orderId>2</orderId>
@@ -447,9 +457,9 @@ namespace Litle.Sdk.Test.Unit
 <availableBalance>5</availableBalance>
 </giftCardResponse>
 </activateReversalResponse>";
-            XmlSerializer serializer = new XmlSerializer(typeof(activateReversalResponse));
-            StringReader reader = new StringReader(xml);
-            activateReversalResponse activateReversalResponse = (activateReversalResponse)serializer.Deserialize(reader);
+            var serializer = new XmlSerializer(typeof (activateReversalResponse));
+            var reader = new StringReader(xml);
+            var activateReversalResponse = (activateReversalResponse) serializer.Deserialize(reader);
             Assert.AreEqual("theId", activateReversalResponse.id);
             Assert.AreEqual("theCustomerId", activateReversalResponse.customerId);
             Assert.AreEqual("theReportGroup", activateReversalResponse.reportGroup);
@@ -465,7 +475,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestDeactivateReversalResponseCanContainGiftCardResponse()
         {
-            String xml = @"
+            var xml = @"
 <deactivateReversalResponse xmlns=""http://www.litle.com/schema"" id=""theId"" customerId=""theCustomerId"" reportGroup=""theReportGroup"">
 <litleTxnId>1</litleTxnId>
 <orderId>2</orderId>
@@ -477,9 +487,9 @@ namespace Litle.Sdk.Test.Unit
 <availableBalance>5</availableBalance>
 </giftCardResponse>
 </deactivateReversalResponse>";
-            XmlSerializer serializer = new XmlSerializer(typeof(deactivateReversalResponse));
-            StringReader reader = new StringReader(xml);
-            deactivateReversalResponse deactivateReversalResponse = (deactivateReversalResponse)serializer.Deserialize(reader);
+            var serializer = new XmlSerializer(typeof (deactivateReversalResponse));
+            var reader = new StringReader(xml);
+            var deactivateReversalResponse = (deactivateReversalResponse) serializer.Deserialize(reader);
             Assert.AreEqual("theId", deactivateReversalResponse.id);
             Assert.AreEqual("theCustomerId", deactivateReversalResponse.customerId);
             Assert.AreEqual("theReportGroup", deactivateReversalResponse.reportGroup);
@@ -495,7 +505,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestLoadReversalResponseCanContainGiftCardResponse()
         {
-            String xml = @"
+            var xml = @"
 <loadReversalResponse xmlns=""http://www.litle.com/schema"" id=""theId"" customerId=""theCustomerId"" reportGroup=""theReportGroup"">
 <litleTxnId>1</litleTxnId>
 <orderId>2</orderId>
@@ -507,9 +517,9 @@ namespace Litle.Sdk.Test.Unit
 <availableBalance>5</availableBalance>
 </giftCardResponse>
 </loadReversalResponse>";
-            XmlSerializer serializer = new XmlSerializer(typeof(loadReversalResponse));
-            StringReader reader = new StringReader(xml);
-            loadReversalResponse loadReversalResponse = (loadReversalResponse)serializer.Deserialize(reader);
+            var serializer = new XmlSerializer(typeof (loadReversalResponse));
+            var reader = new StringReader(xml);
+            var loadReversalResponse = (loadReversalResponse) serializer.Deserialize(reader);
             Assert.AreEqual("theId", loadReversalResponse.id);
             Assert.AreEqual("theCustomerId", loadReversalResponse.customerId);
             Assert.AreEqual("theReportGroup", loadReversalResponse.reportGroup);
@@ -525,7 +535,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestUnloadReversalResponseCanContainGiftCardResponse()
         {
-            String xml = @"
+            var xml = @"
 <unloadReversalResponse xmlns=""http://www.litle.com/schema"" id=""theId"" customerId=""theCustomerId"" reportGroup=""theReportGroup"">
 <litleTxnId>1</litleTxnId>
 <orderId>2</orderId>
@@ -537,9 +547,9 @@ namespace Litle.Sdk.Test.Unit
 <availableBalance>5</availableBalance>
 </giftCardResponse>
 </unloadReversalResponse>";
-            XmlSerializer serializer = new XmlSerializer(typeof(unloadReversalResponse));
-            StringReader reader = new StringReader(xml);
-            unloadReversalResponse unloadReversalResponse = (unloadReversalResponse)serializer.Deserialize(reader);
+            var serializer = new XmlSerializer(typeof (unloadReversalResponse));
+            var reader = new StringReader(xml);
+            var unloadReversalResponse = (unloadReversalResponse) serializer.Deserialize(reader);
             Assert.AreEqual("theId", unloadReversalResponse.id);
             Assert.AreEqual("theCustomerId", unloadReversalResponse.customerId);
             Assert.AreEqual("theReportGroup", unloadReversalResponse.reportGroup);
@@ -555,7 +565,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestActivateResponseCanContainVirtualGiftCardResponse()
         {
-            String xml = @"
+            var xml = @"
 <activateResponse reportGroup=""A"" id=""3"" customerId=""4"" duplicate=""true"" xmlns=""http://www.litle.com/schema"">
 <litleTxnId>1</litleTxnId>
 <orderId>2</orderId>
@@ -566,17 +576,17 @@ namespace Litle.Sdk.Test.Unit
 <accountNumber>123</accountNumber>
 </virtualGiftCardResponse>
 </activateResponse>";
-            XmlSerializer serializer = new XmlSerializer(typeof(activateResponse));
-            StringReader reader = new StringReader(xml);
-            activateResponse activateResponse = (activateResponse)serializer.Deserialize(reader);
+            var serializer = new XmlSerializer(typeof (activateResponse));
+            var reader = new StringReader(xml);
+            var activateResponse = (activateResponse) serializer.Deserialize(reader);
 
-            Assert.AreEqual("123",activateResponse.virtualGiftCardResponse.accountNumber);
+            Assert.AreEqual("123", activateResponse.virtualGiftCardResponse.accountNumber);
         }
 
         [Test]
         public void TestVirtualGiftCardResponse()
         {
-            String xml = @"
+            var xml = @"
 <activateResponse reportGroup=""A"" id=""3"" customerId=""4"" duplicate=""true"" xmlns=""http://www.litle.com/schema"">
 <litleTxnId>1</litleTxnId>
 <orderId>2</orderId>
@@ -588,9 +598,9 @@ namespace Litle.Sdk.Test.Unit
 <cardValidationNum>abc</cardValidationNum>
 </virtualGiftCardResponse>
 </activateResponse>";
-            XmlSerializer serializer = new XmlSerializer(typeof(activateResponse));
-            StringReader reader = new StringReader(xml);
-            activateResponse activateResponse = (activateResponse)serializer.Deserialize(reader);
+            var serializer = new XmlSerializer(typeof (activateResponse));
+            var reader = new StringReader(xml);
+            var activateResponse = (activateResponse) serializer.Deserialize(reader);
 
             Assert.AreEqual("123", activateResponse.virtualGiftCardResponse.accountNumber);
             Assert.AreEqual("abc", activateResponse.virtualGiftCardResponse.cardValidationNum);
@@ -599,7 +609,7 @@ namespace Litle.Sdk.Test.Unit
         [Test]
         public void TestAccountUpdaterResponse()
         {
-            String xml = @"
+            var xml = @"
 <authorizationResponse xmlns=""http://www.litle.com/schema"">
 <accountUpdater>
 <extendedCardResponse>
@@ -618,9 +628,9 @@ namespace Litle.Sdk.Test.Unit
 </originalCardInfo>
 </accountUpdater>
 </authorizationResponse>";
-            XmlSerializer serializer = new XmlSerializer(typeof(authorizationResponse));
-            StringReader reader = new StringReader(xml);
-            authorizationResponse authorizationResponse = (authorizationResponse)serializer.Deserialize(reader);
+            var serializer = new XmlSerializer(typeof (authorizationResponse));
+            var reader = new StringReader(xml);
+            var authorizationResponse = (authorizationResponse) serializer.Deserialize(reader);
             Assert.AreEqual("TheMessage", authorizationResponse.accountUpdater.extendedCardResponse.message);
             Assert.AreEqual("TheCode", authorizationResponse.accountUpdater.extendedCardResponse.code);
             Assert.AreEqual(methodOfPaymentTypeEnum.VI, authorizationResponse.accountUpdater.newCardInfo.type);


### PR DESCRIPTION
We can't use the existing SDK if it is writing un-encrypted data to disk; Coverdell have addressed this so pulling in their changes rather than reinventing the wheel. SDK code needs to be reviewed in its entirety before production use, this will include these changes.
